### PR TITLE
Add Departments CRUD API

### DIFF
--- a/src/controllers/departments/createDepartment.ts
+++ b/src/controllers/departments/createDepartment.ts
@@ -1,0 +1,145 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { getDb } from '../../utils/db';
+import { Department } from '../../models/department';
+import { AuditLog, AuditLogAction } from '../../models/auditLog';
+import { updateAuditLog } from '../../utils/auditLog';
+import { ObjectId } from 'mongodb';
+
+/**
+ * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+ * @param {Object} event - API Gateway Lambda Proxy Input Format
+ *
+ * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+ * @returns {Object} object - API Gateway Lambda Proxy Output Format
+ *
+ */
+
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		if (!event.body) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Request body is required',
+				}),
+			};
+		}
+
+		type DepartmentInput = {
+			department_name: string;
+			department_description: string;
+			image?: string;
+			manager?: string;
+			admin_id: string;
+			workspace_id: string;
+			users?: string[];
+		};
+
+		const input: DepartmentInput = JSON.parse(event.body);
+
+		if (!input.department_name || !input.department_description || !input.admin_id || !input.workspace_id) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Missing required fields: department_name, department_description, admin_id, and workspace_id are required',
+				}),
+			};
+		}
+
+		// Validate ObjectId formats
+		if (!ObjectId.isValid(input.admin_id)) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Invalid admin_id format. Must be a valid MongoDB ObjectId.',
+				}),
+			};
+		}
+
+		if (!ObjectId.isValid(input.workspace_id)) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Invalid workspace_id format. Must be a valid MongoDB ObjectId.',
+				}),
+			};
+		}
+
+		// Validate user IDs if provided
+		if (input.users && input.users.length > 0) {
+			const invalidUserIds = input.users.filter(userId => !ObjectId.isValid(userId));
+			if (invalidUserIds.length > 0) {
+				return {
+					statusCode: 400,
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						message: `Invalid user IDs format: ${invalidUserIds.join(', ')}. Must be valid MongoDB ObjectIds.`,
+					}),
+				};
+			}
+		}
+
+		const db = await getDb();
+		
+		const adminObjectId = new ObjectId(input.admin_id);
+		const workspaceObjectId = new ObjectId(input.workspace_id);
+		const userObjectIds = input.users ? input.users.map(userId => new ObjectId(userId)) : [];
+
+		const department = await db.collection<Department>('departments').insertOne({
+			department_name: input.department_name,
+			department_description: input.department_description,
+			image: input.image,
+			manager: input.manager,
+			admin_id: adminObjectId,
+			workspace_id: workspaceObjectId,
+			users: userObjectIds,
+		});
+
+		await updateAuditLog({
+			entity: 'department',
+			entityId: department.insertedId.toString(),
+			action: AuditLogAction.CREATE,
+			actionBy: input.workspace_id,
+			actionAt: new Date(),
+			active: true,
+		});
+
+		return {
+			statusCode: 201,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				message: 'Department created successfully',
+				department: department,
+			}),
+		};
+	} catch (err) {
+		console.error('Error in Lambda handler:', err);
+		return {
+			statusCode: 500,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				message: 'Internal server error',
+				error: err instanceof Error ? err.message : 'Unknown error',
+				timestamp: new Date().toISOString(),
+			}),
+		};
+	}
+}; 

--- a/src/controllers/departments/deleteDepartment.ts
+++ b/src/controllers/departments/deleteDepartment.ts
@@ -1,0 +1,88 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { getDb } from '../../utils/db';
+import { Department } from '../../models/department';
+import { AuditLog, AuditLogAction } from '../../models/auditLog';
+import { updateAuditLog } from '../../utils/auditLog';
+import { ObjectId } from 'mongodb';
+
+/**
+ * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+ * @param {Object} event - API Gateway Lambda Proxy Input Format
+ *
+ * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+ * @returns {Object} object - API Gateway Lambda Proxy Output Format
+ *
+ */
+
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		if (!event.pathParameters?.id) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Missing required fields: id is required',
+				}),
+			};
+		}
+
+		const db = await getDb();
+		
+		const departmentRecord: Department | null = await db.collection<Department>('departments').findOne({
+			_id: new ObjectId(event.pathParameters.id)
+		});
+
+		if (!departmentRecord) {
+			return {
+				statusCode: 404,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Department not found',
+				}),
+			};
+		}
+
+		const department = await db.collection<Department>('departments').deleteOne({
+			_id: new ObjectId(event.pathParameters?.id)
+		});
+
+		const auditRecord : AuditLog = {
+			entity: 'department',
+			entityId: (event.pathParameters?.id).toString(),
+			action: AuditLogAction.DELETE,
+			actionBy: (departmentRecord.admin_id as ObjectId).toString(),
+			actionAt: new Date(),
+			active: true,
+		};
+
+		await updateAuditLog(auditRecord);
+
+		return {
+			statusCode: 200,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				message: 'Department deleted successfully',
+				department: department,
+			}),
+		};
+	} catch (err) {
+		console.error('Error in Lambda handler:', err);
+		return {
+			statusCode: 500,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				message: 'Internal server error',
+				error: err instanceof Error ? err.message : 'Unknown error',
+				timestamp: new Date().toISOString(),
+			}),
+		};
+	}
+}; 

--- a/src/controllers/departments/getDepartment.ts
+++ b/src/controllers/departments/getDepartment.ts
@@ -1,0 +1,69 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { getDb } from '../../utils/db';
+import { Department } from '../../models/department';
+import { ObjectId } from 'mongodb';
+
+/**
+ * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+ * @param {Object} event - API Gateway Lambda Proxy Input Format
+ *
+ * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+ * @returns {Object} object - API Gateway Lambda Proxy Output Format
+ *
+ */
+
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		if (!event.pathParameters?.id) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Missing required fields: id is required',
+				}),
+			};
+		}
+
+		const db = await getDb();
+		
+		const department: Department | null = await db.collection<Department>('departments').findOne({ _id: new ObjectId(event.pathParameters.id) });
+
+		if (!department) {
+			return {
+				statusCode: 404,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Department not found',
+				}),
+			};
+		}
+
+		return {
+			statusCode: 200,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				message: 'Department fetched successfully',
+				result: department,
+			}),
+		};
+	} catch (err) {
+		console.error('Error in Lambda handler:', err);
+		return {
+			statusCode: 500,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				message: 'Internal server error',
+				error: err instanceof Error ? err.message : 'Unknown error',
+				timestamp: new Date().toISOString(),
+			}),
+		};
+	}
+}; 

--- a/src/controllers/departments/updateDepartment.ts
+++ b/src/controllers/departments/updateDepartment.ts
@@ -1,0 +1,180 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { getDb } from '../../utils/db';
+import { Department } from '../../models/department';
+import { AuditLog, AuditLogAction } from '../../models/auditLog';
+import { updateAuditLog } from '../../utils/auditLog';
+import { ObjectId } from 'mongodb';
+
+/**
+ * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+ * @param {Object} event - API Gateway Lambda Proxy Input Format
+ *
+ * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+ * @returns {Object} object - API Gateway Lambda Proxy Output Format
+ *
+ */
+
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		if (!event.body) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Request body is required',
+				}),
+			};
+		}
+
+		type DepartmentUpdateInput = {
+			_id: string;
+			department_name: string;
+			department_description: string;
+			image?: string;
+			manager?: string;
+			admin_id: string;
+			workspace_id: string;
+			users?: string[];
+		};
+
+		const input: DepartmentUpdateInput = JSON.parse(event.body);
+
+		if (!input.department_name || !input.department_description || !input.admin_id || !input.workspace_id || !input._id) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Missing required fields: _id, department_name, department_description, admin_id, and workspace_id are required',
+				}),
+			};
+		}
+
+		// Validate ObjectId formats
+		if (!ObjectId.isValid(input._id)) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Invalid _id format. Must be a valid MongoDB ObjectId.',
+				}),
+			};
+		}
+
+		if (!ObjectId.isValid(input.admin_id)) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Invalid admin_id format. Must be a valid MongoDB ObjectId.',
+				}),
+			};
+		}
+
+		if (!ObjectId.isValid(input.workspace_id)) {
+			return {
+				statusCode: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Invalid workspace_id format. Must be a valid MongoDB ObjectId.',
+				}),
+			};
+		}
+
+		// Validate user IDs if provided
+		if (input.users && input.users.length > 0) {
+			const invalidUserIds = input.users.filter(userId => !ObjectId.isValid(userId));
+			if (invalidUserIds.length > 0) {
+				return {
+					statusCode: 400,
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						message: `Invalid user IDs format: ${invalidUserIds.join(', ')}. Must be valid MongoDB ObjectIds.`,
+					}),
+				};
+			}
+		}
+
+		const db = await getDb();
+
+		const departmentRecord: Department | null = await db.collection<Department>('departments').findOne({
+			_id: new ObjectId(input._id),
+		});
+		
+		if (!departmentRecord) {
+			return {
+				statusCode: 404,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					message: 'Department not found',
+				}),
+			};
+		}
+		
+		const adminObjectId = new ObjectId(input.admin_id);
+		const workspaceObjectId = new ObjectId(input.workspace_id);
+		const userObjectIds = input.users ? input.users.map(userId => new ObjectId(userId)) : [];
+
+		const department = await db.collection<Department>('departments').updateOne({
+			_id: new ObjectId((departmentRecord._id as ObjectId)),
+		}, {
+			$set: {
+				department_name: input.department_name,
+				department_description: input.department_description,
+				image: input.image,
+				manager: input.manager,
+				admin_id: adminObjectId,
+				workspace_id: workspaceObjectId,
+				users: userObjectIds,
+			}
+		});
+
+		const auditRecord : AuditLog = {
+			entity: 'department',
+			entityId: (departmentRecord._id as ObjectId).toString(),
+			action: AuditLogAction.UPDATE,
+			actionBy: input.admin_id,
+			actionAt: new Date(),
+			active: true,
+		};
+
+		await updateAuditLog(auditRecord);
+
+		return {
+			statusCode: 200,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				message: 'Department updated successfully',
+				department: department,
+			}),
+		};
+	} catch (err) {
+		console.error('Error in Lambda handler:', err);
+		return {
+			statusCode: 500,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				message: 'Internal server error',
+				error: err instanceof Error ? err.message : 'Unknown error',
+				timestamp: new Date().toISOString(),
+			}),
+		};
+	}
+}; 

--- a/src/models/department.ts
+++ b/src/models/department.ts
@@ -1,0 +1,12 @@
+import { ObjectId } from 'mongodb';
+
+export type Department = {
+	_id?: ObjectId;
+	workspace_id: ObjectId;
+	department_name: string;
+	department_description: string;
+	image?: string;
+	manager?: string;
+	admin_id: ObjectId;
+	users: ObjectId[];
+}; 

--- a/template.yaml
+++ b/template.yaml
@@ -146,6 +146,76 @@ Resources:
         <<: *EsbuildProps
         EntryPoints: [controllers/workspaces/createWorkspace.ts]
 
+  # ──────────────────────────────────────────────────────────────────────────
+  # DEPARTMENTS
+  # ──────────────────────────────────────────────────────────────────────────
+  CreateDepartmentFunction:
+    Type: AWS::Serverless::Function 
+    Properties:
+      CodeUri: src/
+      Handler: controllers/departments/createDepartment.lambdaHandler
+      Events:
+        CreateDepartment:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Path: /departments
+            Method: post
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/departments/createDepartment.ts]
+        
+  GetDepartmentFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: src/
+      Handler: controllers/departments/getDepartment.lambdaHandler
+      Events:
+        GetDepartment:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Path: /departments/{id}
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/departments/getDepartment.ts]
+
+  UpdateDepartmentFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: src/
+      Handler: controllers/departments/updateDepartment.lambdaHandler
+      Events:
+        UpdateDepartment:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Path: /departments
+            Method: put
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/departments/updateDepartment.ts]
+
+  DeleteDepartmentFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: src/
+      Handler: controllers/departments/deleteDepartment.lambdaHandler
+      Events:
+        DeleteDepartment:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Path: /departments/{id}
+            Method: delete
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/departments/deleteDepartment.ts]
 
   ApplicationResourceGroup:
     Type: AWS::ResourceGroups::Group


### PR DESCRIPTION
  - Implement complete Departments CRUD API with MongoDB integration
  - Add department model with required fields: _id, workspace_id, department_name, department_description, admin_id
  - Optional fields: image, manager, users array
  - Create Lambda functions for all CRUD operations (Create, Read, Update, Delete)
  - Add comprehensive ObjectId validation to prevent BSON errors
  - Include audit logging for department operations
