### PR TITLE
feat(products): add update product endpoint and fix ObjectId type of Product model

### DIFF
--- a/src/controllers/products/createProduct.ts
+++ b/src/controllers/products/createProduct.ts
@@ -119,14 +119,14 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
             symbols_graphics: { data: [], tab_completed: false },
             product_data: {
                 data: {
-                    _id: new ObjectId().toString(),
+                    _id: new ObjectId(),
                     workbook_data: {},
                 },
                 tab_completed: false,
             },
             operational_parameters: {
                 data: {
-                    _id: new ObjectId().toString(),
+                    _id: new ObjectId(),
                     workbook_data: {},
                 },
                 tab_completed: false,

--- a/src/controllers/products/getAllProducts.ts
+++ b/src/controllers/products/getAllProducts.ts
@@ -61,7 +61,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
         const skip = (page - 1) * limit;
 
-        // CHECK - what these filter things are doing and are they correct or not
         // Build filter object
         let filter: any = {};
 
@@ -90,8 +89,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
             ];
         }
 
-        // CHECK - ALl the below code and pipeline is needed or what. Because it is not there in getAllDepartments.
-        // OH got it, so below one is for actionAt but it is in Audit log and we are joining it with our product data to sort things
         // If sorting by actionAt, use aggregation to join with audit_logs
         if (sort === 'actionAt') {
             // Aggregation pipeline

--- a/src/controllers/products/updateProduct.ts
+++ b/src/controllers/products/updateProduct.ts
@@ -1,0 +1,162 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { getDb } from '../../utils/db';
+import type { Product } from '../../models/product';
+import { AuditLogAction } from '../../models/auditLog';
+import { updateAuditLog } from '../../utils/auditLog';
+import { ObjectId } from 'mongodb';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { verifyJWT } from '../../utils/authUtils';
+
+/**
+ * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+ * @param {Object} event - API Gateway Lambda Proxy Input Format
+ *
+ * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+ * @returns {Object} object - API Gateway Lambda Proxy Output Format
+ *
+ */
+
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    try {
+        if (!event.body) {
+            return ResponseWrapper.badRequest('Request body is required');
+        }
+
+        // Extract product ID from path parameters
+        const productId = event.pathParameters?.id;
+
+        if (!productId) {
+            return ResponseWrapper.badRequest('Product ID is required in path parameters');
+        }
+
+        // Validate ObjectId format
+        if (!ObjectId.isValid(productId)) {
+            return ResponseWrapper.badRequest('Invalid product ID format. Must be a valid MongoDB ObjectId.');
+        }
+
+        const authHeader = event.headers?.Authorization || event.headers?.authorization;
+        if (!authHeader) {
+            return ResponseWrapper.unauthorized('Unauthorized');
+        }
+
+        const token = authHeader.split(' ')[1];
+
+        // Check if the user is valid - both users and admins can update products
+        const { isValid, payload } = await verifyJWT(token);
+        if (!isValid) {
+            return ResponseWrapper.unauthorized('Unauthorized');
+        }
+
+        let input: any;
+        try {
+            input = JSON.parse(event.body);
+        } catch (error) {
+            return ResponseWrapper.badRequest('Invalid JSON in request body');
+        }
+
+        // Validate required fields for action-based approach
+        if (!input.action) {
+            return ResponseWrapper.badRequest('action field is required');
+        }
+
+        const validActions = ['update-product', 'update-status'];
+        if (!validActions.includes(input.action)) {
+            return ResponseWrapper.badRequest(`Invalid action. Must be one of: ${validActions.join(', ')}`);
+        }
+
+        if (!input.data) {
+            return ResponseWrapper.badRequest('data field is required');
+        }
+
+        const db = await getDb();
+        const productObjectId = new ObjectId(productId);
+
+        // Find existing product
+        const existingProduct = await db.collection<Product>('products').findOne({
+            _id: productObjectId,
+        });
+
+        if (!existingProduct) {
+            return ResponseWrapper.notFound('Product not found');
+        }
+
+        // Prepare update data based on action
+        const updateData: Partial<Product> = {};
+
+        switch (input.action) {
+            case 'update-product':
+                // Update product information fields - check if at least one field is provided
+                const productFields = ['product_name', 'product_description', 'target_date', 'actual_completion_date'];
+                const hasProductFields = productFields.some((field) => input.data[field] !== undefined);
+
+                if (!hasProductFields) {
+                    return ResponseWrapper.badRequest(
+                        'At least one product field is required: product_name, product_description, target_date, or actual_completion_date',
+                    );
+                }
+
+                // Apply all provided fields directly
+                for (const field of productFields) {
+                    if (input.data[field] !== undefined) {
+                        updateData[field as keyof Product] = input.data[field];
+                    }
+                }
+                break;
+
+            case 'update-status':
+                // Handle status updates with business rules
+                const newStatus = input.data.status;
+
+                // Validate status value
+                if (!['draft', 'submitted', 'archived'].includes(newStatus)) {
+                    return ResponseWrapper.badRequest('Invalid status. Must be one of: draft, submitted, archived');
+                }
+
+                // Business rules for status transitions
+                if (newStatus === 'submitted' && existingProduct.complete_count !== 100) {
+                    return ResponseWrapper.badRequest(
+                        'Cannot change status to "submitted" unless complete_count is 100',
+                    );
+                }
+
+                updateData.status = newStatus;
+                break;
+
+            default:
+                return ResponseWrapper.badRequest(`Unknown action: ${input.action}`);
+        }
+
+        // Update the product
+        const result = await db
+            .collection<Product>('products')
+            .updateOne({ _id: productObjectId }, { $set: updateData });
+
+        if (result.matchedCount === 0) {
+            return ResponseWrapper.notFound('Product not found');
+        }
+
+        // Log the update action
+        await updateAuditLog({
+            entity: 'product',
+            entityId: productId,
+            action: AuditLogAction.UPDATE,
+            actionBy: payload?.name?.toString() || 'Unknown',
+            actionAt: new Date(),
+            active: true,
+        });
+
+        // Fetch updated product for response
+        const updatedProduct = await db.collection<Product>('products').findOne({
+            _id: productObjectId,
+        });
+
+        return ResponseWrapper.success({
+            message: 'Product updated successfully',
+            action: input.action,
+            product: updatedProduct,
+        });
+    } catch (err) {
+        console.error('Error in Lambda handler:', err);
+        return ResponseWrapper.internalServerError(err instanceof Error ? err : String(err));
+    }
+};

--- a/src/controllers/projects/getProject.ts
+++ b/src/controllers/projects/getProject.ts
@@ -1,0 +1,55 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { getDb } from '../../utils/db';
+import type { Project } from '../../models/project';
+import { ObjectId } from 'mongodb';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { verifyJWT } from '../../utils/authUtils';
+
+/**
+ * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+ * @param {Object} event - API Gateway Lambda Proxy Input Format
+ *
+ * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+ * @returns {Object} object - API Gateway Lambda Proxy Output Format
+ *
+ */
+
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    try {
+        if (!event.pathParameters?.id) {
+            return ResponseWrapper.badRequest('Missing required fields: id is required');
+        }
+
+        const authHeader = event.headers?.Authorization || event.headers?.authorization;
+        if (!authHeader) {
+            return ResponseWrapper.unauthorized('Unauthorized');
+        }
+
+        const token = authHeader.split(' ')[1];
+
+        const { isValid, payload } = await verifyJWT(token);
+
+        if (!isValid) {
+            return ResponseWrapper.unauthorized('Unauthorized');
+        }
+
+        const db = await getDb();
+
+        const project: Project | null = await db.collection<Project>('projects').findOne({
+            _id: new ObjectId(event.pathParameters.id),
+            isArchived: { $ne: true },
+        });
+
+        if (!project) {
+            return ResponseWrapper.badRequest('Project not found');
+        }
+
+        return ResponseWrapper.success({
+            message: 'Project retrieved successfully',
+            project: project,
+        });
+    } catch (err) {
+        console.error('Error in Lambda handler:', err);
+        return ResponseWrapper.internalServerError(err instanceof Error ? err : String(err));
+    }
+};

--- a/src/models/product.ts
+++ b/src/models/product.ts
@@ -59,14 +59,14 @@ export type Product = {
     };
     product_data: {
         data: {
-            _id: string;
+            _id: ObjectId;
             workbook_data: {};
         };
         tab_completed: boolean;
     };
     operational_parameters: {
         data: {
-            _id: string;
+            _id: ObjectId;
             workbook_data: {};
         };
         tab_completed: boolean;

--- a/template.yaml
+++ b/template.yaml
@@ -341,6 +341,23 @@ Resources:
         <<: *EsbuildProps
         EntryPoints: [controllers/projects/getAllProjects.ts]
 
+  GetProjectFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: src/
+      Handler: controllers/projects/getProject.lambdaHandler
+      Events:
+        GetProject:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Path: /projects/{id}
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/projects/getProject.ts]
+
   ArchiveProjectFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
@@ -395,6 +412,23 @@ Resources:
       BuildProperties:
         <<: *EsbuildProps
         EntryPoints: [controllers/products/getAllProducts.ts]
+
+  UpdateProductFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: src/
+      Handler: controllers/products/updateProduct.lambdaHandler
+      Events:
+        UpdateProduct:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Path: /products/{id}
+            Method: patch
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/products/updateProduct.ts]
 
   ApplicationResourceGroup:
     Type: AWS::ResourceGroups::Group


### PR DESCRIPTION
Add updateProduct endpoint and fix the ObjectId type of the Product model

- add UpdateProductFunction lambda with PATCH /products/{id} endpoint
- add getProject to get a project by its ID
- change _id fields from string to ObjectId in product data model


**More context on why we're using a switch case statement in updateProduct @Sumitjh26997 -** 
Initially, we considered creating three endpoints: one to update the product, one to archive the product, and one to submit the product. Then, I thought about merging the archive product and submit product endpoints because they basically perform the same action, which is updating the status. 
Here, I actually merged that into the main updateProduct endpoint, as both involve updating some aspect of the product, with the only difference being the data involved.

Let me know if we can improve it further (more readable, more efficient, DRY, etc.)