### PR TITLE
feat(products): add endpoint for updating product data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Created by https://www.toptal.com/developers/gitignore/api/osx,node,linux,windows,sam
 # Edit at https://www.toptal.com/developers/gitignore?templates=osx,node,linux,windows,sam
 
@@ -208,4 +207,5 @@ $RECYCLE.BIN/
 # Environment variables
 .env
 env.json
-# End of https://www.toptal.com/developers/gitignore/api/osx,node,linux,windows,sam
+
+.kilocode/rules/*

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ $RECYCLE.BIN/
 env.json
 
 .kilocode/rules/*
+mongodb-data-local

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.formatOnSave": false,
+  "files.autoSave": "onFocusChange",
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+}

--- a/src/controllers/products/productData/product-info.ts
+++ b/src/controllers/products/productData/product-info.ts
@@ -1,0 +1,228 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { addFieldsToUpdate, validateTab, validateAllObjectIds } from '../../../utils/validationUtils';
+import { ResponseWrapper } from '../../../utils/responseWrapper';
+import { ObjectId } from 'mongodb';
+import {
+    UpdateProductInformationData,
+    AddCustomFieldData,
+    UpdateCustomFieldInput,
+    DeleteCustomFieldInput,
+    UpdateProductInformationCompletionData,
+} from '../../../types/products/product-info';
+
+/**
+ * Handles the update of product information fields.
+ * @param {UpdateProductInformationData} inputData - The data object containing product information fields.
+ * @param {string} tab - The current tab being updated.
+ * @param {string} action - The action being performed.
+ * @returns {{ updateQuery: Record<string, unknown>, updatedData: UpdateProductInformationData, actionLog: string, error: APIGatewayProxyResult | null }} An object containing the update query, updated data, and any validation error.
+ */
+export function updateProductInformation(
+    inputData: UpdateProductInformationData,
+    tab: string,
+    action: string,
+): {
+    updateQuery: Record<string, unknown>;
+    updatedData: UpdateProductInformationData;
+    actionLog: string;
+    error: APIGatewayProxyResult | null;
+} {
+    const isValidTabUpdateProductInfo = validateTab(tab, 'product-information', action);
+    if (isValidTabUpdateProductInfo)
+        return {
+            updateQuery: {},
+            updatedData: {} as UpdateProductInformationData,
+            actionLog: '',
+            error: isValidTabUpdateProductInfo,
+        };
+
+    const requiredFields = [
+        'market_geography',
+        'country_of_origin',
+        'oem_contract_manufacturer',
+        'commercial_clinical',
+    ];
+
+    const productInfoData: Partial<UpdateProductInformationData> = {};
+
+    addFieldsToUpdate(productInfoData, inputData, requiredFields);
+
+    const updateQuery = { $set: { 'product_information.data': productInfoData } };
+    const updatedData = inputData;
+    const actionLog = 'UPDATE';
+
+    return { updateQuery, updatedData, actionLog, error: null };
+}
+
+/**
+ * Handles the addition of custom fields to product information.
+ * @param {AddCustomFieldData[]} inputData - An array of custom field data objects.
+ * @param {string} tab - The current tab being updated.
+ * @param {string} action - The action being performed.
+ * @returns {{ updateQuery: Record<string, unknown>, updatedData: { customFields: AddCustomFieldData[] }, actionLog: string, error: APIGatewayProxyResult | null }} An object containing the update query, updated data, and any validation error.
+ */
+export function addCustomField(
+    inputData: AddCustomFieldData[],
+    tab: string,
+    action: string,
+): {
+    updateQuery: Record<string, unknown>;
+    updatedData: { customFields: AddCustomFieldData[] };
+    actionLog: string;
+    error: APIGatewayProxyResult | null;
+} {
+    const isValidTabAddCustomField = validateTab(tab, 'product-information', action);
+    if (isValidTabAddCustomField)
+        return { updateQuery: {}, updatedData: { customFields: [] }, actionLog: '', error: isValidTabAddCustomField };
+
+    if (!Array.isArray(inputData) || inputData.length === 0)
+        return {
+            updateQuery: {},
+            updatedData: { customFields: [] },
+            actionLog: '',
+            error: ResponseWrapper.badRequest('Data must be an array of custom fields'),
+        };
+
+    for (const item of inputData) {
+        if (!item.label || !item.value) {
+            return {
+                updateQuery: {},
+                updatedData: { customFields: [] },
+                actionLog: '',
+                error: ResponseWrapper.badRequest('Each custom field must have label and value'),
+            };
+        }
+    }
+
+    const newCustomFields = inputData.map((item) => ({
+        _id: new ObjectId(),
+        label: item.label,
+        value: item.value,
+    }));
+
+    const updateQuery = { $push: { 'product_information.custom_fields': { $each: newCustomFields } } };
+    const updatedData = { customFields: newCustomFields };
+    const actionLog = 'CREATE';
+
+    return { updateQuery, updatedData, actionLog, error: null };
+}
+
+/**
+ * Handles the update of existing custom fields in product information.
+ * @param {UpdateCustomFieldInput[]} inputData - An array of custom field data objects to update.
+ * @param {string} tab - The current tab being updated.
+ * @param {string} action - The action being performed.
+ * @returns {{ updateQuery: Record<string, unknown>, updatedData: { customFields: UpdateCustomFieldInput[] }, actionLog: string, error: APIGatewayProxyResult | null }} An object containing the update query, updated data, and any validation error.
+ */
+export function updateCustomField(
+    inputData: UpdateCustomFieldInput[],
+    tab: string,
+    action: string,
+): {
+    updateQuery: Record<string, unknown>;
+    updatedData: { customFields: UpdateCustomFieldInput[] };
+    actionLog: string;
+    error: APIGatewayProxyResult | null;
+} {
+    const isValidTabUpdateCustomField = validateTab(tab, 'product-information', action);
+    if (isValidTabUpdateCustomField)
+        return {
+            updateQuery: {},
+            updatedData: { customFields: [] },
+            actionLog: '',
+            error: isValidTabUpdateCustomField,
+        };
+
+    if (!Array.isArray(inputData)) {
+        return {
+            updateQuery: {},
+            updatedData: { customFields: [] },
+            actionLog: '',
+            error: ResponseWrapper.badRequest('Data for updating custom fields must be an array.'),
+        };
+    }
+
+    const validatedCustomFields = inputData.map((field) => ({
+        ...field,
+        _id: field.id ? new ObjectId(field.id) : new ObjectId(),
+    }));
+
+    const updateQuery = { $set: { 'product_information.custom_fields': validatedCustomFields } };
+    const updatedData = { customFields: inputData };
+    const actionLog = 'UPDATE';
+
+    return { updateQuery, updatedData, actionLog, error: null };
+}
+
+/**
+ * Handles the deletion of a custom field from product information.
+ * @param {DeleteCustomFieldInput} inputData - The data object containing the ID of the custom field to delete.
+ * @param {string} tab - The current tab being updated.
+ * @param {string} action - The action being performed.
+ * @returns {{ updateQuery: Record<string, unknown>, updatedData: { id: string }, actionLog: string, error: APIGatewayProxyResult | null }} An object containing the update query, updated data, and any validation error.
+ */
+export function deleteCustomField(
+    inputData: DeleteCustomFieldInput,
+    tab: string,
+    action: string,
+): {
+    updateQuery: Record<string, unknown>;
+    updatedData: { id: string };
+    actionLog: string;
+    error: APIGatewayProxyResult | null;
+} {
+    const isValidTabDeleteCustomField = validateTab(tab, 'product-information', action);
+    if (isValidTabDeleteCustomField)
+        return { updateQuery: {}, updatedData: { id: '' }, actionLog: '', error: isValidTabDeleteCustomField };
+
+    const validatedFieldId = validateAllObjectIds({ id: inputData.id });
+    if (validatedFieldId) return { updateQuery: {}, updatedData: { id: '' }, actionLog: '', error: validatedFieldId };
+
+    const updateQuery = { $pull: { 'product_information.custom_fields': { _id: new ObjectId(inputData.id) } } };
+    const updatedData = { id: inputData.id };
+    const actionLog = 'DELETE';
+
+    return { updateQuery, updatedData, actionLog, error: null };
+}
+
+/**
+ * Handles the update of product information tab completion status.
+ * @param {UpdateProductInformationCompletionData} inputData - The data object containing the tab completion status.
+ * @param {string} tab - The current tab being updated.
+ * @param {string} action - The action being performed.
+ * @returns {{ updateQuery: Record<string, unknown>, updatedData: { tab_completed: boolean }, actionLog: string, error: APIGatewayProxyResult | null }} An object containing the update query, updated data, and any validation error.
+ */
+export function updateProductInfoTabCompletion(
+    inputData: UpdateProductInformationCompletionData,
+    tab: string,
+    action: string,
+): {
+    updateQuery: Record<string, unknown>;
+    updatedData: { tab_completed: boolean };
+    actionLog: string;
+    error: APIGatewayProxyResult | null;
+} {
+    const isValidTabProductInfoCompletion = validateTab(tab, 'product-information', action);
+    if (isValidTabProductInfoCompletion)
+        return {
+            updateQuery: {},
+            updatedData: { tab_completed: inputData.tab_completed },
+            actionLog: '',
+            error: isValidTabProductInfoCompletion,
+        };
+
+    if (typeof inputData.tab_completed !== 'boolean') {
+        return {
+            updateQuery: {},
+            updatedData: { tab_completed: inputData.tab_completed },
+            actionLog: '',
+            error: ResponseWrapper.badRequest('tab_completed must be a boolean value'),
+        };
+    }
+
+    const updateQuery = { $set: { 'product_information.tab_completed': inputData.tab_completed } };
+    const updatedData = { tab_completed: inputData.tab_completed };
+    const actionLog = 'UPDATE';
+
+    return { updateQuery, updatedData, actionLog, error: null };
+}

--- a/src/controllers/products/productData/product-info.ts
+++ b/src/controllers/products/productData/product-info.ts
@@ -3,11 +3,10 @@ import { addFieldsToUpdate, validateTab, validateAllObjectIds } from '../../../u
 import { ResponseWrapper } from '../../../utils/responseWrapper';
 import { ObjectId } from 'mongodb';
 import {
-    UpdateProductInformationData,
-    AddCustomFieldData,
-    UpdateCustomFieldInput,
-    DeleteCustomFieldInput,
-    UpdateProductInformationCompletionData,
+	UpdateProductInformationData,
+	CustomFieldInput,
+	DeleteCustomFieldInput,
+	UpdateProductInformationCompletionData,
 } from '../../../types/products/product-info';
 
 /**
@@ -15,143 +14,129 @@ import {
  * @param {UpdateProductInformationData} inputData - The data object containing product information fields.
  * @param {string} tab - The current tab being updated.
  * @param {string} action - The action being performed.
- * @returns {{ updateQuery: Record<string, unknown>, updatedData: UpdateProductInformationData, actionLog: string, error: APIGatewayProxyResult | null }} An object containing the update query, updated data, and any validation error.
+ * @return {Object} An object containing the update query, updated data, and any validation error.
  */
 export function updateProductInformation(
-    inputData: UpdateProductInformationData,
-    tab: string,
-    action: string,
+	inputData: UpdateProductInformationData,
+	tab: string,
+	action: string,
 ): {
     updateQuery: Record<string, unknown>;
     updatedData: UpdateProductInformationData;
     actionLog: string;
     error: APIGatewayProxyResult | null;
 } {
-    const isValidTabUpdateProductInfo = validateTab(tab, 'product-information', action);
-    if (isValidTabUpdateProductInfo)
-        return {
-            updateQuery: {},
-            updatedData: {} as UpdateProductInformationData,
-            actionLog: '',
-            error: isValidTabUpdateProductInfo,
-        };
-
-    const requiredFields = [
-        'market_geography',
-        'country_of_origin',
-        'oem_contract_manufacturer',
-        'commercial_clinical',
-    ];
-
-    const productInfoData: Partial<UpdateProductInformationData> = {};
-
-    addFieldsToUpdate(productInfoData, inputData, requiredFields);
-
-    const updateQuery = { $set: { 'product_information.data': productInfoData } };
-    const updatedData = inputData;
-    const actionLog = 'UPDATE';
-
-    return { updateQuery, updatedData, actionLog, error: null };
+	try {
+		const isValidTabUpdateProductInfo = validateTab(tab, 'product-information', action);
+		if (isValidTabUpdateProductInfo)
+			throw new Error(isValidTabUpdateProductInfo.body);
+	
+		const requiredFields = [
+			'market_geography',
+			'country_of_origin',
+			'oem_contract_manufacturer',
+			'commercial_clinical',
+		];
+	
+		const productInfoData: Partial<UpdateProductInformationData> = {};
+	
+		addFieldsToUpdate(productInfoData, inputData, requiredFields);
+	
+		const updateQuery = { $set: { 'product_information.data': productInfoData } };
+		const updatedData = inputData;
+		const actionLog = 'UPDATE';
+	
+		return { updateQuery, updatedData, actionLog, error: null };
+	} catch (error) {
+		if (error instanceof Error) return { updateQuery: {}, updatedData: {} as UpdateProductInformationData, actionLog: '', error: ResponseWrapper.badRequest(error.message) };
+		return { updateQuery: {}, updatedData: {} as UpdateProductInformationData, actionLog: '', error: ResponseWrapper.internalServerError('Failed to update product information') };
+	}
 }
 
 /**
  * Handles the addition of custom fields to product information.
- * @param {AddCustomFieldData[]} inputData - An array of custom field data objects.
+ * @param {CustomFieldInput[]} inputData - An array of custom field data objects.
  * @param {string} tab - The current tab being updated.
  * @param {string} action - The action being performed.
- * @returns {{ updateQuery: Record<string, unknown>, updatedData: { customFields: AddCustomFieldData[] }, actionLog: string, error: APIGatewayProxyResult | null }} An object containing the update query, updated data, and any validation error.
+ * @return {Object} An object containing the update query, updated data, and any validation error.
  */
 export function addCustomField(
-    inputData: AddCustomFieldData[],
-    tab: string,
-    action: string,
+	inputData: CustomFieldInput[],
+	tab: string,
+	action: string,
 ): {
     updateQuery: Record<string, unknown>;
-    updatedData: { customFields: AddCustomFieldData[] };
+    updatedData: { customFields: CustomFieldInput[] };
     actionLog: string;
     error: APIGatewayProxyResult | null;
 } {
-    const isValidTabAddCustomField = validateTab(tab, 'product-information', action);
-    if (isValidTabAddCustomField)
-        return { updateQuery: {}, updatedData: { customFields: [] }, actionLog: '', error: isValidTabAddCustomField };
+	try {
+		const isValidTabAddCustomField = validateTab(tab, 'product-information', action);
+		if (isValidTabAddCustomField) throw new Error(isValidTabAddCustomField.body);
+			
+		if (!Array.isArray(inputData) || inputData.length === 0) throw new Error('Data for adding custom fields must be a non-empty array.');
+	
+		for (const item of inputData) {
+			if (!item.label || !item.value) throw new Error('Each custom field must have both label and value.');
+			
+		}
+	
+		const newCustomFields = inputData.map((item) => ({
+			_id: new ObjectId(),
+			label: item.label,
+			value: item.value,
+		}));
+	
+		const updateQuery = { $push: { 'product_information.custom_fields': { $each: newCustomFields } } };
+		const updatedData = { customFields: newCustomFields };
+		const actionLog = 'CREATE';
+	
+		return { updateQuery, updatedData, actionLog, error: null };
+	} catch (error) {
+		if (error instanceof Error) return { updateQuery: {}, updatedData: { customFields: [] }, actionLog: '', error: ResponseWrapper.badRequest(error.message) };
 
-    if (!Array.isArray(inputData) || inputData.length === 0)
-        return {
-            updateQuery: {},
-            updatedData: { customFields: [] },
-            actionLog: '',
-            error: ResponseWrapper.badRequest('Data must be an array of custom fields'),
-        };
-
-    for (const item of inputData) {
-        if (!item.label || !item.value) {
-            return {
-                updateQuery: {},
-                updatedData: { customFields: [] },
-                actionLog: '',
-                error: ResponseWrapper.badRequest('Each custom field must have label and value'),
-            };
-        }
-    }
-
-    const newCustomFields = inputData.map((item) => ({
-        _id: new ObjectId(),
-        label: item.label,
-        value: item.value,
-    }));
-
-    const updateQuery = { $push: { 'product_information.custom_fields': { $each: newCustomFields } } };
-    const updatedData = { customFields: newCustomFields };
-    const actionLog = 'CREATE';
-
-    return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery: {}, updatedData: { customFields: [] }, actionLog: '', error: ResponseWrapper.internalServerError('Failed to add custom field') };
+	}
 }
 
 /**
  * Handles the update of existing custom fields in product information.
- * @param {UpdateCustomFieldInput[]} inputData - An array of custom field data objects to update.
+ * @param {CustomFieldInput[]} inputData - An array of custom field data objects to update.
  * @param {string} tab - The current tab being updated.
  * @param {string} action - The action being performed.
- * @returns {{ updateQuery: Record<string, unknown>, updatedData: { customFields: UpdateCustomFieldInput[] }, actionLog: string, error: APIGatewayProxyResult | null }} An object containing the update query, updated data, and any validation error.
+ * @return {Object} An object containing the update query, updated data, and any validation error.
  */
 export function updateCustomField(
-    inputData: UpdateCustomFieldInput[],
-    tab: string,
-    action: string,
+	inputData: CustomFieldInput[],
+	tab: string,
+	action: string,
 ): {
     updateQuery: Record<string, unknown>;
-    updatedData: { customFields: UpdateCustomFieldInput[] };
+    updatedData: { customFields: CustomFieldInput[] };
     actionLog: string;
     error: APIGatewayProxyResult | null;
 } {
-    const isValidTabUpdateCustomField = validateTab(tab, 'product-information', action);
-    if (isValidTabUpdateCustomField)
-        return {
-            updateQuery: {},
-            updatedData: { customFields: [] },
-            actionLog: '',
-            error: isValidTabUpdateCustomField,
-        };
+	try {
+		const isValidTabUpdateCustomField = validateTab(tab, 'product-information', action);
+		if (isValidTabUpdateCustomField) throw new Error(isValidTabUpdateCustomField.body);
+	
+		if (!Array.isArray(inputData)) throw new Error('Data for updating custom fields must be an array.');
+	
+		const validatedCustomFields = inputData.map((field) => ({
+			...field,
+			_id: field.id ? new ObjectId(field.id) : new ObjectId(),
+		}));
+	
+		const updateQuery = { $set: { 'product_information.custom_fields': validatedCustomFields } };
+		const updatedData = { customFields: inputData };
+		const actionLog = 'UPDATE';
+	
+		return { updateQuery, updatedData, actionLog, error: null };
+	} catch (error) {
+		if (error instanceof Error) return { updateQuery: {}, updatedData: { customFields: [] }, actionLog: '', error: ResponseWrapper.badRequest(error.message) };
 
-    if (!Array.isArray(inputData)) {
-        return {
-            updateQuery: {},
-            updatedData: { customFields: [] },
-            actionLog: '',
-            error: ResponseWrapper.badRequest('Data for updating custom fields must be an array.'),
-        };
-    }
-
-    const validatedCustomFields = inputData.map((field) => ({
-        ...field,
-        _id: field.id ? new ObjectId(field.id) : new ObjectId(),
-    }));
-
-    const updateQuery = { $set: { 'product_information.custom_fields': validatedCustomFields } };
-    const updatedData = { customFields: inputData };
-    const actionLog = 'UPDATE';
-
-    return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery: {}, updatedData: { customFields: [] }, actionLog: '', error: ResponseWrapper.internalServerError('Failed to update custom field') };
+	}
 }
 
 /**
@@ -159,30 +144,35 @@ export function updateCustomField(
  * @param {DeleteCustomFieldInput} inputData - The data object containing the ID of the custom field to delete.
  * @param {string} tab - The current tab being updated.
  * @param {string} action - The action being performed.
- * @returns {{ updateQuery: Record<string, unknown>, updatedData: { id: string }, actionLog: string, error: APIGatewayProxyResult | null }} An object containing the update query, updated data, and any validation error.
+ * @return {Object} An object containing the update query, updated data, and any validation error.
  */
 export function deleteCustomField(
-    inputData: DeleteCustomFieldInput,
-    tab: string,
-    action: string,
+	inputData: DeleteCustomFieldInput,
+	tab: string,
+	action: string,
 ): {
     updateQuery: Record<string, unknown>;
     updatedData: { id: string };
     actionLog: string;
     error: APIGatewayProxyResult | null;
 } {
-    const isValidTabDeleteCustomField = validateTab(tab, 'product-information', action);
-    if (isValidTabDeleteCustomField)
-        return { updateQuery: {}, updatedData: { id: '' }, actionLog: '', error: isValidTabDeleteCustomField };
+	try {
+		const isValidTabDeleteCustomField = validateTab(tab, 'product-information', action);
+		if (isValidTabDeleteCustomField) throw new Error(isValidTabDeleteCustomField.body);
+	
+		const validatedFieldId = validateAllObjectIds({ id: inputData.id });
+		if (validatedFieldId) return { updateQuery: {}, updatedData: { id: '' }, actionLog: '', error: validatedFieldId };
+	
+		const updateQuery = { $pull: { 'product_information.custom_fields': { _id: new ObjectId(inputData.id) } } };
+		const updatedData = { id: inputData.id };
+		const actionLog = 'DELETE';
+	
+		return { updateQuery, updatedData, actionLog, error: null };
+	} catch (error) {
+		if (error instanceof Error) return { updateQuery: {}, updatedData: { id: '' }, actionLog: '', error: ResponseWrapper.badRequest(error.message) };
 
-    const validatedFieldId = validateAllObjectIds({ id: inputData.id });
-    if (validatedFieldId) return { updateQuery: {}, updatedData: { id: '' }, actionLog: '', error: validatedFieldId };
-
-    const updateQuery = { $pull: { 'product_information.custom_fields': { _id: new ObjectId(inputData.id) } } };
-    const updatedData = { id: inputData.id };
-    const actionLog = 'DELETE';
-
-    return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery: {}, updatedData: { id: '' }, actionLog: '', error: ResponseWrapper.internalServerError('Failed to delete custom field') };
+	}
 }
 
 /**
@@ -190,39 +180,32 @@ export function deleteCustomField(
  * @param {UpdateProductInformationCompletionData} inputData - The data object containing the tab completion status.
  * @param {string} tab - The current tab being updated.
  * @param {string} action - The action being performed.
- * @returns {{ updateQuery: Record<string, unknown>, updatedData: { tab_completed: boolean }, actionLog: string, error: APIGatewayProxyResult | null }} An object containing the update query, updated data, and any validation error.
+ * @return {Object} An object containing the update query, updated data, and any validation error.
  */
 export function updateProductInfoTabCompletion(
-    inputData: UpdateProductInformationCompletionData,
-    tab: string,
-    action: string,
+	inputData: UpdateProductInformationCompletionData,
+	tab: string,
+	action: string,
 ): {
     updateQuery: Record<string, unknown>;
     updatedData: { tab_completed: boolean };
     actionLog: string;
     error: APIGatewayProxyResult | null;
 } {
-    const isValidTabProductInfoCompletion = validateTab(tab, 'product-information', action);
-    if (isValidTabProductInfoCompletion)
-        return {
-            updateQuery: {},
-            updatedData: { tab_completed: inputData.tab_completed },
-            actionLog: '',
-            error: isValidTabProductInfoCompletion,
-        };
-
-    if (typeof inputData.tab_completed !== 'boolean') {
-        return {
-            updateQuery: {},
-            updatedData: { tab_completed: inputData.tab_completed },
-            actionLog: '',
-            error: ResponseWrapper.badRequest('tab_completed must be a boolean value'),
-        };
-    }
-
-    const updateQuery = { $set: { 'product_information.tab_completed': inputData.tab_completed } };
-    const updatedData = { tab_completed: inputData.tab_completed };
-    const actionLog = 'UPDATE';
-
-    return { updateQuery, updatedData, actionLog, error: null };
+	try {
+		const isValidTabProductInfoCompletion = validateTab(tab, 'product-information', action);
+		if (isValidTabProductInfoCompletion) throw new Error(isValidTabProductInfoCompletion.body);
+	
+		if (typeof inputData.tab_completed !== 'boolean') throw new Error('tab_completed must be a boolean value.');
+	
+		const updateQuery = { $set: { 'product_information.tab_completed': inputData.tab_completed } };
+		const updatedData = { tab_completed: inputData.tab_completed };
+		const actionLog = 'UPDATE';
+	
+		return { updateQuery, updatedData, actionLog, error: null };
+	} catch (error) {
+		if (error instanceof Error) return { updateQuery: {}, updatedData: { tab_completed: false }, actionLog: '', error: ResponseWrapper.badRequest(error.message) };
+		
+		return { updateQuery: {}, updatedData: { tab_completed: false }, actionLog: '', error: ResponseWrapper.internalServerError('Failed to update product information tab completion') };
+	}
 }

--- a/src/controllers/products/updateProductData.ts
+++ b/src/controllers/products/updateProductData.ts
@@ -1,0 +1,149 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { validateAllObjectIds, validateMissingFields, validateTab } from '../../utils/validationUtils';
+import { getDb } from '../../utils/db';
+import { Product } from '../../models/product';
+import { ObjectId } from 'mongodb';
+import { AuditLog } from '../../models/auditLog';
+import { authenticateRequest } from '../../utils/authUtils';
+import { updateAuditLog } from '../../utils/auditLog';
+import {
+    addCustomField,
+    deleteCustomField,
+    updateCustomField,
+    updateProductInformation,
+    updateProductInfoTabCompletion,
+} from './productData/product-info';
+import { UpdateProductDataRequest } from '../../types/products/product-info';
+
+const validTabs = [
+    'product-information',
+    'compliance-information',
+    'label-components',
+    'symbols-graphics',
+    'product-data',
+    'operational-parameters',
+    'label-tags',
+];
+
+/**
+ * Update product data (generic PATCH endpoint)
+ * @param {APIGatewayProxyEvent} event - API Gateway Lambda Proxy Input Format
+ * @return {Promise<APIGatewayProxyResult>} API Gateway Lambda Proxy Output Format
+ */
+
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const auth = await authenticateRequest(event);
+
+    if (!auth.isValid) return auth.error;
+
+    try {
+        if (!event.body) return ResponseWrapper.badRequest('Request body is required to update product data');
+
+        const input: UpdateProductDataRequest = JSON.parse(event.body);
+
+        const missingFields = validateMissingFields({
+            id: input.id,
+            tab: input.tab,
+            action: input.action,
+        });
+
+        if (missingFields) return missingFields;
+
+        const objectIdValidation = validateAllObjectIds({
+            _id: input.id!,
+        });
+
+        if (objectIdValidation) return objectIdValidation;
+
+        if (!validTabs.includes(input.tab))
+            return ResponseWrapper.badRequest(`Invalid tab parameter. Must be one of: ${validTabs.join(', ')}`);
+
+        const db = await getDb();
+
+        const product = await db.collection<Product>('products').findOne({ _id: new ObjectId(input.id) });
+
+        if (!product) return ResponseWrapper.notFound('Product not found, please check the provided product id.');
+
+        let updateQuery = {};
+        let updatedData = {};
+        let actionLog = '';
+
+        switch (input.action) {
+            case 'update_product_information':
+                const result = updateProductInformation(input.data, input.tab, input.action);
+                if (result.error) return result.error;
+
+                ({ updateQuery, updatedData, actionLog } = result);
+
+                break;
+
+            case 'add_custom_field':
+                const addCustomFieldResult = addCustomField(input.data, input.tab, input.action);
+                if (addCustomFieldResult.error) return addCustomFieldResult.error;
+
+                ({ updateQuery, updatedData, actionLog } = addCustomFieldResult);
+
+                break;
+
+            case 'update_custom_field':
+                const updateCustomFieldResult = updateCustomField(input.data, input.tab, input.action);
+                if (updateCustomFieldResult.error) return updateCustomFieldResult.error;
+
+                ({ updateQuery, updatedData, actionLog } = updateCustomFieldResult);
+
+                break;
+
+            case 'delete_custom_field':
+                const deleteCustomFieldResult = deleteCustomField(input.data, input.tab, input.action);
+                if (deleteCustomFieldResult.error) return deleteCustomFieldResult.error;
+
+                ({ updateQuery, updatedData, actionLog } = deleteCustomFieldResult);
+
+                break;
+
+            case 'update_product_information_completion':
+                const updateTabCompletionResult = updateProductInfoTabCompletion(input.data, input.tab, input.action);
+                if (updateTabCompletionResult.error) return updateTabCompletionResult.error;
+
+                ({ updateQuery, updatedData, actionLog } = updateTabCompletionResult);
+
+                break;
+
+            default:
+                return ResponseWrapper.badRequest('Invalid action');
+        }
+
+        const auditLog: AuditLog = {
+            entity: 'Product',
+            entityId: input.id,
+            action: actionLog as AuditLog['action'],
+            actionBy: auth.payload?.name?.toString()!,
+            actionAt: new Date(),
+            active: true,
+        };
+
+        const updateResult = await db
+            .collection<Product>('products')
+            .updateOne({ _id: new ObjectId(input.id) }, updateQuery);
+
+        if (updateResult.modifiedCount === 0) {
+            return ResponseWrapper.notFound(
+                'Custom field not found or already deleted, please check the provided custom field id.',
+            );
+        }
+
+        await updateAuditLog(auditLog);
+
+        return ResponseWrapper.success({
+            message: 'Product updated successfully',
+            action: input.action,
+            tab: input.tab,
+            data: updatedData,
+        });
+    } catch (error: unknown) {
+        return ResponseWrapper.internalServerError(
+            `Internal server error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+};

--- a/src/controllers/products/updateProductData.ts
+++ b/src/controllers/products/updateProductData.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { ResponseWrapper } from '../../utils/responseWrapper';
-import { validateAllObjectIds, validateMissingFields, validateTab } from '../../utils/validationUtils';
+import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
 import { getDb } from '../../utils/db';
 import { Product } from '../../models/product';
 import { ObjectId } from 'mongodb';
@@ -8,22 +8,22 @@ import { AuditLog } from '../../models/auditLog';
 import { authenticateRequest } from '../../utils/authUtils';
 import { updateAuditLog } from '../../utils/auditLog';
 import {
-    addCustomField,
-    deleteCustomField,
-    updateCustomField,
-    updateProductInformation,
-    updateProductInfoTabCompletion,
+	addCustomField,
+	deleteCustomField,
+	updateCustomField,
+	updateProductInformation,
+	updateProductInfoTabCompletion,
 } from './productData/product-info';
 import { UpdateProductDataRequest } from '../../types/products/product-info';
 
 const validTabs = [
-    'product-information',
-    'compliance-information',
-    'label-components',
-    'symbols-graphics',
-    'product-data',
-    'operational-parameters',
-    'label-tags',
+	'product-information',
+	'compliance-information',
+	'label-components',
+	'symbols-graphics',
+	'product-data',
+	'operational-parameters',
+	'label-tags',
 ];
 
 /**
@@ -33,117 +33,117 @@ const validTabs = [
  */
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    const auth = await authenticateRequest(event);
+	const auth = await authenticateRequest(event);
 
-    if (!auth.isValid) return auth.error;
+	if (!auth.isValid) return auth.error;
 
-    try {
-        if (!event.body) return ResponseWrapper.badRequest('Request body is required to update product data');
+	try {
+		if (!event.body) return ResponseWrapper.badRequest('Request body is required to update product data');
 
-        const input: UpdateProductDataRequest = JSON.parse(event.body);
+		const input: UpdateProductDataRequest = JSON.parse(event.body);
 
-        const missingFields = validateMissingFields({
-            id: input.id,
-            tab: input.tab,
-            action: input.action,
-        });
+		const missingFields = validateMissingFields({
+			id: input.id,
+			tab: input.tab,
+			action: input.action,
+		});
 
-        if (missingFields) return missingFields;
+		if (missingFields) return missingFields;
 
-        const objectIdValidation = validateAllObjectIds({
-            _id: input.id!,
-        });
+		const objectIdValidation = validateAllObjectIds({
+			_id: input.id!,
+		});
 
-        if (objectIdValidation) return objectIdValidation;
+		if (objectIdValidation) return objectIdValidation;
 
-        if (!validTabs.includes(input.tab))
-            return ResponseWrapper.badRequest(`Invalid tab parameter. Must be one of: ${validTabs.join(', ')}`);
+		if (!validTabs.includes(input.tab))
+			return ResponseWrapper.badRequest(`Invalid tab parameter. Must be one of: ${validTabs.join(', ')}`);
 
-        const db = await getDb();
+		const db = await getDb();
 
-        const product = await db.collection<Product>('products').findOne({ _id: new ObjectId(input.id) });
+		const product = await db.collection<Product>('products').findOne({ _id: new ObjectId(input.id) });
 
-        if (!product) return ResponseWrapper.notFound('Product not found, please check the provided product id.');
+		if (!product) return ResponseWrapper.notFound('Product not found, please check the provided product id.');
 
-        let updateQuery = {};
-        let updatedData = {};
-        let actionLog = '';
+		let updateQuery = {};
+		let updatedData = {};
+		let actionLog = '';
 
-        switch (input.action) {
-            case 'update_product_information':
-                const result = updateProductInformation(input.data, input.tab, input.action);
-                if (result.error) return result.error;
+		switch (input.action) {
+		case 'update_product_information':
+			const result = updateProductInformation(input.data, input.tab, input.action);
+			if (result.error) return result.error;
 
-                ({ updateQuery, updatedData, actionLog } = result);
+			({ updateQuery, updatedData, actionLog } = result);
 
-                break;
+			break;
 
-            case 'add_custom_field':
-                const addCustomFieldResult = addCustomField(input.data, input.tab, input.action);
-                if (addCustomFieldResult.error) return addCustomFieldResult.error;
+		case 'add_custom_field':
+			const addCustomFieldResult = addCustomField(input.data, input.tab, input.action);
+			if (addCustomFieldResult.error) return addCustomFieldResult.error;
 
-                ({ updateQuery, updatedData, actionLog } = addCustomFieldResult);
+			({ updateQuery, updatedData, actionLog } = addCustomFieldResult);
 
-                break;
+			break;
 
-            case 'update_custom_field':
-                const updateCustomFieldResult = updateCustomField(input.data, input.tab, input.action);
-                if (updateCustomFieldResult.error) return updateCustomFieldResult.error;
+		case 'update_custom_field':
+			const updateCustomFieldResult = updateCustomField(input.data, input.tab, input.action);
+			if (updateCustomFieldResult.error) return updateCustomFieldResult.error;
 
-                ({ updateQuery, updatedData, actionLog } = updateCustomFieldResult);
+			({ updateQuery, updatedData, actionLog } = updateCustomFieldResult);
 
-                break;
+			break;
 
-            case 'delete_custom_field':
-                const deleteCustomFieldResult = deleteCustomField(input.data, input.tab, input.action);
-                if (deleteCustomFieldResult.error) return deleteCustomFieldResult.error;
+		case 'delete_custom_field':
+			const deleteCustomFieldResult = deleteCustomField(input.data, input.tab, input.action);
+			if (deleteCustomFieldResult.error) return deleteCustomFieldResult.error;
 
-                ({ updateQuery, updatedData, actionLog } = deleteCustomFieldResult);
+			({ updateQuery, updatedData, actionLog } = deleteCustomFieldResult);
 
-                break;
+			break;
 
-            case 'update_product_information_completion':
-                const updateTabCompletionResult = updateProductInfoTabCompletion(input.data, input.tab, input.action);
-                if (updateTabCompletionResult.error) return updateTabCompletionResult.error;
+		case 'update_product_information_completion':
+			const updateTabCompletionResult = updateProductInfoTabCompletion(input.data, input.tab, input.action);
+			if (updateTabCompletionResult.error) return updateTabCompletionResult.error;
 
-                ({ updateQuery, updatedData, actionLog } = updateTabCompletionResult);
+			({ updateQuery, updatedData, actionLog } = updateTabCompletionResult);
 
-                break;
+			break;
 
-            default:
-                return ResponseWrapper.badRequest('Invalid action');
-        }
+		default:
+			return ResponseWrapper.badRequest('Invalid action');
+		}
 
-        const auditLog: AuditLog = {
-            entity: 'Product',
-            entityId: input.id,
-            action: actionLog as AuditLog['action'],
-            actionBy: auth.payload?.name?.toString()!,
-            actionAt: new Date(),
-            active: true,
-        };
+		const auditLog: AuditLog = {
+			entity: 'Product',
+			entityId: input.id,
+			action: actionLog as AuditLog['action'],
+			actionBy: auth.payload?.name?.toString()!,
+			actionAt: new Date(),
+			active: true,
+		};
 
-        const updateResult = await db
-            .collection<Product>('products')
-            .updateOne({ _id: new ObjectId(input.id) }, updateQuery);
+		const updateResult = await db
+			.collection<Product>('products')
+			.updateOne({ _id: new ObjectId(input.id) }, updateQuery);
 
-        if (updateResult.modifiedCount === 0) {
-            return ResponseWrapper.notFound(
-                'Custom field not found or already deleted, please check the provided custom field id.',
-            );
-        }
+		if (updateResult.modifiedCount === 0) {
+			return ResponseWrapper.notFound(
+				'Custom field not found or already deleted, please check the provided custom field id.',
+			);
+		}
 
-        await updateAuditLog(auditLog);
+		await updateAuditLog(auditLog);
 
-        return ResponseWrapper.success({
-            message: 'Product updated successfully',
-            action: input.action,
-            tab: input.tab,
-            data: updatedData,
-        });
-    } catch (error: unknown) {
-        return ResponseWrapper.internalServerError(
-            `Internal server error: ${error instanceof Error ? error.message : String(error)}`,
-        );
-    }
+		return ResponseWrapper.success({
+			message: 'Product updated successfully',
+			action: input.action,
+			tab: input.tab,
+			data: updatedData,
+		});
+	} catch (error: unknown) {
+		return ResponseWrapper.internalServerError(
+			`Internal server error: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
 };

--- a/src/types/products/product-info.ts
+++ b/src/types/products/product-info.ts
@@ -1,3 +1,4 @@
+// Base data interfaces
 export interface UpdateProductInformationData {
     market_geography: string;
     country_of_origin: string;
@@ -5,13 +6,8 @@ export interface UpdateProductInformationData {
     commercial_clinical: string;
 }
 
-export interface AddCustomFieldData {
-    label: string;
-    value: string;
-}
-
-export interface UpdateCustomFieldInput {
-    id: string;
+export interface CustomFieldInput {
+    id?: string;
     label?: string;
     value?: string;
 }
@@ -24,44 +20,26 @@ export interface UpdateProductInformationCompletionData {
     tab_completed: boolean;
 }
 
-export type UpdateProductInfo = {
+// Base request type with common properties
+type BaseProductRequest<TAction extends string, TData> = {
     id: string;
     tab: 'product-information';
-    action: 'update_product_information';
-    data: UpdateProductInformationData;
+    action: TAction;
+    data: TData;
 };
 
-export type AddCustomField = {
-    id: string;
-    tab: 'product-information';
-    action: 'add_custom_field';
-    data: AddCustomFieldData[];
-};
+// Specific request types using the base type
+export type UpdateProductInfo = BaseProductRequest<'update_product_information', UpdateProductInformationData>;
 
-export type UpdateCustomField = {
-    id: string;
-    tab: 'product-information';
-    action: 'update_custom_field';
-    data: UpdateCustomFieldInput[];
-};
+export type AddUpdateCustomField = BaseProductRequest<'add_custom_field' | 'update_custom_field', CustomFieldInput[]>;
 
-export type DeleteCustomField = {
-    id: string;
-    tab: 'product-information';
-    action: 'delete_custom_field';
-    data: DeleteCustomFieldInput;
-};
+export type DeleteCustomField = BaseProductRequest<'delete_custom_field', DeleteCustomFieldInput>;
 
-export type UpdateProductInfoTabCompletion = {
-    id: string;
-    tab: 'product-information';
-    action: 'update_product_information_completion';
-    data: UpdateProductInformationCompletionData;
-};
+export type UpdateProductInfoTabCompletion = BaseProductRequest<'update_product_information_completion', UpdateProductInformationCompletionData>;
 
+// Union type for all product information requests
 export type UpdateProductDataRequest =
     | UpdateProductInfo
-    | AddCustomField
-    | UpdateCustomField
+    | AddUpdateCustomField
     | DeleteCustomField
     | UpdateProductInfoTabCompletion;

--- a/src/types/products/product-info.ts
+++ b/src/types/products/product-info.ts
@@ -1,0 +1,67 @@
+export interface UpdateProductInformationData {
+    market_geography: string;
+    country_of_origin: string;
+    oem_contract_manufacturer: string;
+    commercial_clinical: string;
+}
+
+export interface AddCustomFieldData {
+    label: string;
+    value: string;
+}
+
+export interface UpdateCustomFieldInput {
+    id: string;
+    label?: string;
+    value?: string;
+}
+
+export interface DeleteCustomFieldInput {
+    id: string;
+}
+
+export interface UpdateProductInformationCompletionData {
+    tab_completed: boolean;
+}
+
+export type UpdateProductInfo = {
+    id: string;
+    tab: 'product-information';
+    action: 'update_product_information';
+    data: UpdateProductInformationData;
+};
+
+export type AddCustomField = {
+    id: string;
+    tab: 'product-information';
+    action: 'add_custom_field';
+    data: AddCustomFieldData[];
+};
+
+export type UpdateCustomField = {
+    id: string;
+    tab: 'product-information';
+    action: 'update_custom_field';
+    data: UpdateCustomFieldInput[];
+};
+
+export type DeleteCustomField = {
+    id: string;
+    tab: 'product-information';
+    action: 'delete_custom_field';
+    data: DeleteCustomFieldInput;
+};
+
+export type UpdateProductInfoTabCompletion = {
+    id: string;
+    tab: 'product-information';
+    action: 'update_product_information_completion';
+    data: UpdateProductInformationCompletionData;
+};
+
+export type UpdateProductDataRequest =
+    | UpdateProductInfo
+    | AddCustomField
+    | UpdateCustomField
+    | DeleteCustomField
+    | UpdateProductInfoTabCompletion;

--- a/src/utils/validationUtils.ts
+++ b/src/utils/validationUtils.ts
@@ -1,4 +1,3 @@
-
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from './responseWrapper';
 import type { APIGatewayProxyResult } from 'aws-lambda';
@@ -9,12 +8,12 @@ import type { APIGatewayProxyResult } from 'aws-lambda';
  * @return {APIGatewayProxyResult | null} ResponseWrapper error if invalid, null if all valid
  */
 export function validateObjectIds(fields: Record<string, ObjectId | string>): APIGatewayProxyResult | null {
-	for (const [fieldName, value] of Object.entries(fields)) {
-		if (!ObjectId.isValid(value)) {
-	  return ResponseWrapper.badRequest(`Invalid ${fieldName} format. Must be a valid MongoDB ObjectId.`);
-		}
-	}
-	return null;
+    for (const [fieldName, value] of Object.entries(fields)) {
+        if (!ObjectId.isValid(value)) {
+            return ResponseWrapper.badRequest(`Invalid ${fieldName} format. Must be a valid MongoDB ObjectId.`);
+        }
+    }
+    return null;
 }
 
 /**
@@ -23,17 +22,17 @@ export function validateObjectIds(fields: Record<string, ObjectId | string>): AP
  * @return {APIGatewayProxyResult | null} ResponseWrapper error if invalid, null if all valid
  */
 export function validateObjectIdArrays(arrays: Record<string, ObjectId[] | string[]>): APIGatewayProxyResult | null {
-	for (const [fieldName, ids] of Object.entries(arrays)) {
-		if (ids && ids.length > 0) {
-	  const invalidIds = ids.filter(id => !ObjectId.isValid(id));
-	  if (invalidIds.length > 0) {
-	    return ResponseWrapper.badRequest(
-	      `Invalid ${fieldName} format: ${invalidIds.join(', ')}. Must be valid MongoDB ObjectIds.`
-	    );
-	  }
-		}
-	}
-	return null;
+    for (const [fieldName, ids] of Object.entries(arrays)) {
+        if (ids && ids.length > 0) {
+            const invalidIds = ids.filter((id) => !ObjectId.isValid(id));
+            if (invalidIds.length > 0) {
+                return ResponseWrapper.badRequest(
+                    `Invalid ${fieldName} format: ${invalidIds.join(', ')}. Must be valid MongoDB ObjectIds.`,
+                );
+            }
+        }
+    }
+    return null;
 }
 
 /**
@@ -43,18 +42,18 @@ export function validateObjectIdArrays(arrays: Record<string, ObjectId[] | strin
  * @return {APIGatewayProxyResult | null} ResponseWrapper error if invalid, null if all valid
  */
 export function validateAllObjectIds(
-	singleIds: Record<string, ObjectId | string> = {},
-	arrayIds: Record<string, ObjectId[] | string[]> = {}
+    singleIds: Record<string, ObjectId | string> = {},
+    arrayIds: Record<string, ObjectId[] | string[]> = {},
 ): APIGatewayProxyResult | null {
-	// Validate single ObjectIds
-	const singleValidation = validateObjectIds(singleIds);
-	if (singleValidation) return singleValidation;
-  
-	// Validate ObjectId arrays
-	const arrayValidation = validateObjectIdArrays(arrayIds);
-	if (arrayValidation) return arrayValidation;
-  
-	return null;
+    // Validate single ObjectIds
+    const singleValidation = validateObjectIds(singleIds);
+    if (singleValidation) return singleValidation;
+
+    // Validate ObjectId arrays
+    const arrayValidation = validateObjectIdArrays(arrayIds);
+    if (arrayValidation) return arrayValidation;
+
+    return null;
 }
 
 /**
@@ -63,13 +62,13 @@ export function validateAllObjectIds(
  * @return {APIGatewayProxyResult | null} ResponseWrapper error if invalid, null if all valid
  */
 export function validateMissingFields(fields: Record<string, string>): APIGatewayProxyResult | null {
-	for (const [fieldName, value] of Object.entries(fields)) {
-		if (!value) {
-	  return ResponseWrapper.badRequest(`Missing required field(s): ${fieldName}`);
-		}
-	}
-	
-	return null;
+    for (const [fieldName, value] of Object.entries(fields)) {
+        if (!value) {
+            return ResponseWrapper.badRequest(`Missing required field(s): ${fieldName}`);
+        }
+    }
+
+    return null;
 }
 
 /**
@@ -79,8 +78,61 @@ export function validateMissingFields(fields: Record<string, string>): APIGatewa
  * @return {APIGatewayProxyResult | null} ResponseWrapper error if invalid, null if all valid
  */
 export function validateEnum(enumValues: string[], value: string): APIGatewayProxyResult | null {
-	if (!enumValues.includes(value)) {
-		return ResponseWrapper.badRequest(`Invalid value. Must be one of: ${enumValues.join(', ')}`);
-	}
-	return null;
+    if (!enumValues.includes(value)) {
+        return ResponseWrapper.badRequest(`Invalid value. Must be one of: ${enumValues.join(', ')}`);
+    }
+    return null;
+}
+
+/**
+ * Adds fields to an update object if they are present in the source data
+ * @param {Record<string, any>} updateObject - The object to add fields to
+ * @param {Record<string, any>} sourceData - The data to read from
+ * @param {string[]} fields - A list of field names to process
+ * @param {string} prefix - A prefix to add to the field names in the update object
+ */
+export function addFieldsToUpdate(
+    updateObject: Record<string, any>,
+    sourceData: Record<string, any>,
+    fields: string[],
+) {
+    for (const field of fields) {
+        if (sourceData[field] !== undefined) {
+            updateObject[`${field}`] = sourceData[field];
+        }
+    }
+}
+
+/**
+ * Validates the tab for a given action
+ * @param {string} tab - The tab to validate
+ * @param {string} expectedTab - The expected tab
+ * @param {string} action - The action being performed
+ * @return {APIGatewayProxyResult | null} ResponseWrapper error if invalid, null if all valid
+ */
+export function validateTab(tab: string, expectedTab: string, action: string): APIGatewayProxyResult | null {
+    if (tab !== expectedTab) {
+        return ResponseWrapper.badRequest(`Action ${action} must be used with tab ${expectedTab}`);
+    }
+    return null;
+}
+
+/**
+ * Adds fields to an update object if they are present in the source data, with a dynamic prefix.
+ * @param {Record<string, any>} updateObject - The object to add fields to
+ * @param {Record<string, any>} sourceData - The data to read from
+ * @param {string[]} fields - A list of field names to process
+ * @param {string} prefix - A prefix to add to the field names in the update object
+ */
+export function addFieldsToUpdateWithPrefix(
+    updateObject: Record<string, any>,
+    sourceData: Record<string, any>,
+    fields: string[],
+    prefix: string,
+) {
+    for (const field of fields) {
+        if (sourceData[field] !== undefined) {
+            updateObject[`${prefix}.${field}`] = sourceData[field];
+        }
+    }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -430,6 +430,23 @@ Resources:
         <<: *EsbuildProps
         EntryPoints: [controllers/products/updateProduct.ts]
 
+  UpdateProductDataFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: src/
+      Handler: controllers/products/updateProductData.lambdaHandler
+      Events:
+        UpdateProductData:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Path: /products/productData
+            Method: patch
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/products/updateProductData.ts]
+
   GetProductDataFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:


### PR DESCRIPTION
Added an endpoint for updating product data

- Introduces PATCH /products/productData to support various actions for updating product details, compliance info, label components, symbols, and product workbook data. 
- Right now, only added cases for tab 'product_information'
- Separate function files for each tab for each action to make the main endpoint function more readable and clean
- Adds helper functions (addFieldsToUpdate, validateTab, addFieldsToUpdateWithPrefix)