### PR TITLE
Chore/update schemas, update data handling, updates to controllers per client, minor fixes

### DIFF
--- a/src/controllers/bookmarks/getProductsFromBookmark.ts
+++ b/src/controllers/bookmarks/getProductsFromBookmark.ts
@@ -59,6 +59,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 								product_description: "$$product.product_description",
 								status: "$$product.status",
 								master_version: "$$product.master_version",
+								folder_name: "$product_folders.folder_name",
 							},
 						},
 					},

--- a/src/controllers/dashboard/getDashboardStats.ts
+++ b/src/controllers/dashboard/getDashboardStats.ts
@@ -20,41 +20,41 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 	        return ResponseWrapper.badRequest('Missing required fields: id (workspaceId) is required');
 	    }
 
-			const validationResult = validateAllObjectIds({
-				'_id': workspaceId,
-			});
+		const validationResult = validateAllObjectIds({
+			'_id': workspaceId,
+		});
 			
-			if (validationResult) {
-				return validationResult;
-			}
+		if (validationResult) {
+			return validationResult;
+		}
 
-			const auth = await authenticateRequest(event);
+		const auth = await authenticateRequest(event);
 
-			if (!auth.isValid) {
-				return auth.error;
-			}
+		if (!auth.isValid) {
+			return auth.error;
+		}
 
-			const db = await getDb();
-			const workspaceObjectId = new ObjectId(workspaceId);
+		const db = await getDb();
+		const workspaceObjectId = new ObjectId(workspaceId);
 
-			// Count departments for the workspace
-			const departments = db.collection('departments').countDocuments({
-					workspace_id: workspaceObjectId,
-					isArchived: false,
-			});
+		// Count departments for the workspace
+		const departments = db.collection('departments').countDocuments({
+			workspace_id: workspaceObjectId,
+			isArchived: false,
+		});
 
-			// Get projects for the workspace - get both count and IDs
-			const projectsQuery = db
-				.collection('projects')
-				.find({ 
-						workspace_id: workspaceObjectId,
-						isArchived: false 
-				}, { projection: { _id: 1 } })
-				.toArray();
+		// Get projects for the workspace - get both count and IDs
+		const projectsQuery = db
+			.collection('projects')
+			.find({ 
+				workspace_id: workspaceObjectId,
+				isArchived: false 
+			}, { projection: { _id: 1 } })
+			.toArray();
 			
-			const [totalDepartments, projectsData] = await Promise.all([departments, projectsQuery]);
+		const [totalDepartments, projectsData] = await Promise.all([departments, projectsQuery]);
 
-			const totalProjects = projectsData.length;
+		const totalProjects = projectsData.length;
 	    const projectObjectIds = projectsData.map((project) => project._id);
 
 	    const totalProducts = await db.collection('products').countDocuments({
@@ -66,13 +66,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 	    // TODO: Later on when we implement source files we will need to add the count for source files here
 
 	    return ResponseWrapper.success({
-				message: 'Dashboard statistics retrieved successfully',
-				data: {
-						total_departments: totalDepartments,
-						total_projects: totalProjects,
-						total_products: totalProducts,
-						total_source_files: 50, // TODO: Hardcoding for now, will need to implement later
-				},
+			message: 'Dashboard statistics retrieved successfully',
+			data: {
+				total_departments: totalDepartments,
+				total_projects: totalProjects,
+				total_products: totalProducts,
+				total_source_files: 50, // TODO: Hardcoding for now, will need to implement later
+			},
 	    });
 	} catch (err) {
 	    console.error('Error in Lambda handler:', err);

--- a/src/controllers/products/createProduct.ts
+++ b/src/controllers/products/createProduct.ts
@@ -76,7 +76,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.conflict('Product plan number already exists');
 		}
 
-		// Set default values
+		// Set default values - use client data if provided, otherwise use defaults
 		const productData = {
 			project_id: projectObjectId,
 			department_id: departmentObjectId,
@@ -88,7 +88,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actual_completion_date: input.actual_completion_date || null,
 			status: input.status,
 			complete_count: input.complete_count || 0,
-			product_information: {
+			product_information: input.product_information || {
 				data: {
 					_id: new ObjectId(),
 					market_geography: '',
@@ -99,30 +99,30 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				},
 				tab_completed: false,
 			},
-			compliance_information: {
+			compliance_information: input.compliance_information || {
 				data: [],
 				tab_completed: false,
 			},
-			label_components: {
+			label_components: input.label_components || {
 				data: [],
 				tab_completed: false,
 			},
-			symbols_graphics: { data: [], tab_completed: false },
-			product_data: {
+			symbols_graphics: input.symbols_graphics || { data: [], tab_completed: false },
+			product_data: input.product_data || {
 				data: {
 					_id: new ObjectId(),
 					workbook_data: {},
 				},
 				tab_completed: false,
 			},
-			operational_parameters: {
+			operational_parameters: input.operational_parameters || {
 				data: {
 					_id: new ObjectId(),
 					workbook_data: {},
 				},
 				tab_completed: false,
 			},
-			label_tags: {
+			label_tags: input.label_tags || {
 				data: [],
 				tab_completed: false,
 			},

--- a/src/controllers/products/getProductData.ts
+++ b/src/controllers/products/getProductData.ts
@@ -49,6 +49,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			'product-data',
 			'operational-parameters',
 			'label-tags',
+			'all-tabs',
 		], tab);
 				
 		if(enumValidation) {
@@ -67,13 +68,61 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.notFound('Product not found');
 		}
 
-		// Extract data based on tab
+		// Handle all-tabs case separately to maintain type safety
+		if (tab === 'all-tabs') {
+			const allTabsData = {
+				product_information: {
+					data: { ...product.product_information.data },
+					tab_completed: product.product_information.tab_completed,
+				},
+				compliance_information: {
+					data: product.compliance_information.data,
+					tab_completed: product.compliance_information.tab_completed,
+				},
+				label_components: {
+					data: product.label_components.data,
+					tab_completed: product.label_components.tab_completed,
+				},
+				symbols_graphics: {
+					data: product.symbols_graphics.data,
+					tab_completed: product.symbols_graphics.tab_completed,
+				},
+				product_data: {
+					data: {
+						_id: product.product_data.data._id,
+						workbook_data: product.product_data.data.workbook_data,
+					},
+					tab_completed: product.product_data.tab_completed,
+				},
+				operational_parameters: {
+					data: {
+						_id: product.operational_parameters.data._id,
+						workbook_data: product.operational_parameters.data.workbook_data,
+					},
+					tab_completed: product.operational_parameters.tab_completed,
+				},
+				label_tags: {
+					data: product.label_tags.data,
+					tab_completed: product.label_tags.tab_completed,
+				},
+			};
+
+			return ResponseWrapper.success({
+				message: 'Product data fetched successfully',
+				result: {
+					tab: tab,
+					data: allTabsData,
+				},
+			});
+		}
+
+		// Extract data for individual tabs
 		let tabData: ProductInformation | ComplianceInformation | LabelComponents | SymbolsGraphics | ExcelData | LabelTags;
 
 		switch (tab) {
 		case 'product-information':
 			tabData = {
-				data: { ...product.product_information.data },
+				data: { ...product.product_information.data,product_name: product.product_name, product_plan_number: product.product_plan_number, product_description: product.product_description, status: product.status, target_date: product.target_date, actual_completion_date: product.actual_completion_date, custom_fields: product.product_information.custom_fields },
 				tab_completed: product.product_information.tab_completed,
 			};
 			break;

--- a/src/controllers/products/productData/symbols-graphics.ts
+++ b/src/controllers/products/productData/symbols-graphics.ts
@@ -72,20 +72,21 @@ export function UpdateSymbolsGraphics(
         
 		const missingFieldsValidation = validateMissingFields({
 			id: updatedSymbolsGraphics.id,
-			image: updatedSymbolsGraphics.image,
 			text: updatedSymbolsGraphics.text,
-			description: updatedSymbolsGraphics.description,
 		})
 		if(missingFieldsValidation) throw new Error(missingFieldsValidation.body);
-
-		const booleanValidation = validateBoolean(updatedSymbolsGraphics.text_present, 'text_present');
-		if(booleanValidation) throw new Error(booleanValidation.body);
 
 		const stringArrayValidation = validateStringArray(updatedSymbolsGraphics.label_presence, 'label_presence');
 		if(stringArrayValidation) throw new Error(stringArrayValidation.body);
 
 		const enumValidation = validateEnum(SYMBOLS_GRAPHICS_ENTITIES, updatedSymbolsGraphics.entity);
 		if(enumValidation) throw new Error(enumValidation.body);
+
+		// Only validate text_present when entity is "Symbols"
+		if (updatedSymbolsGraphics.entity === 'Symbols') {
+			const booleanValidation = validateBoolean(updatedSymbolsGraphics.text_present, 'text_present');
+			if(booleanValidation) throw new Error(booleanValidation.body);
+		}
 
 		const objectIdValidation =validateAllObjectIds({id: updatedSymbolsGraphics.id})
 		if(objectIdValidation) throw new Error(objectIdValidation.body);

--- a/src/controllers/users/updateUser.ts
+++ b/src/controllers/users/updateUser.ts
@@ -5,6 +5,7 @@ import { AuditLog, AuditLogAction } from '../../models/auditLog';
 import { updateAuditLog } from '../../utils/auditLog';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
+import { validateMissingFields } from '../../utils/validationUtils';
 
 /**
  * Update a user
@@ -22,9 +23,15 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const input: User = JSON.parse(event.body);
 
 		// Validate required fields
-		if (!input.name || !input.email || !input.userType) {
-			return ResponseWrapper.badRequest('Missing required fields: name, email, and userType are required');
-		}
+		const missingFields = validateMissingFields({
+			name: input.name,
+			email: input.email,
+			designation: input.designation,
+			organization: input.organization,
+		});
+
+		if(missingFields) return missingFields;
+
 
 		const db = await getDb();
 
@@ -43,10 +50,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				name: input.name,
 				profileAvatar: input.profileAvatar,
 				designation: input.designation,
+				organization: input.organization,
 				email: input.email,
 				phone: input.phone,
-				confirmed: input.confirmed,
-				userType: input.userType,
+				location: input.location
 			}
 		});
 

--- a/src/models/product.ts
+++ b/src/models/product.ts
@@ -3,16 +3,27 @@ import { ObjectId } from 'mongodb';
 export type ProductInformation = {
 	data: {
 			_id: ObjectId;
+			product_name: string;
+			product_plan_number: string;
+			product_description: string;
+			status: string;
+			target_date: Date | undefined | null;
+			actual_completion_date: Date | undefined | null;
 			market_geography: string;
 			country_of_origin: string;
 			oem_contract_manufacturer: string;
 			commercial_clinical: string;
 			custom_fields?: Array<{
-					_id: ObjectId;
-					label: string;
-					value: string;
+				_id: ObjectId;
+				label: string;
+				value: string;
 			}>;
 	};
+	custom_fields?: Array<{
+		_id: ObjectId;
+		label: string;
+		value: string;
+	}>;
 	tab_completed: boolean;
 };
 

--- a/src/models/sourceFiles.ts
+++ b/src/models/sourceFiles.ts
@@ -1,0 +1,25 @@
+import { ObjectId } from "mongodb"
+
+export interface SourceFileFolder {
+    _id: ObjectId
+    file_name: string,
+    url: string  
+}
+
+// For the adjacency list pattern - represents either a file or folder
+export interface SourceFileNode {
+    _id: ObjectId
+    name: string
+    type: 'file' | 'folder'
+    parentId: ObjectId | null // null for root folders
+    url?: string // Only for files
+    workspace_id: ObjectId
+}
+
+// Legacy interface for backward compatibility during migration
+export type SourceFiles = {
+  _id: ObjectId, 
+  folder_name: String,
+  workspace_id: ObjectId,
+  folder: Array<SourceFileFolder>
+}

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -3,10 +3,12 @@ import { ObjectId } from 'mongodb';
 export type User = {
 	_id?: ObjectId;
 	name: string;
+	email: string;
 	profileAvatar: string;
 	designation: string;
-	email: string;
-	phone: string;
-	confirmed: boolean;
-	userType: string;
+	organization: string;
+	phone?: string;
+	confirmed?: string;
+	userType?: string;
+	location?: string;
 };

--- a/template.yaml
+++ b/template.yaml
@@ -588,6 +588,10 @@ Resources:
         <<: *EsbuildProps
         EntryPoints: [controllers/bookmarks/getProductsFromBookmark.ts]
 
+  # ──────────────────────────────────────────────────────────────────────────
+  # DASHBOARD
+  # ──────────────────────────────────────────────────────────────────────────
+
   GetDashboardStatsFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:


### PR DESCRIPTION
- Adds an 'all-tabs' option to the product data endpoint, allowing clients to fetch all product-related tab information in a single API call.
- Enriches the `product-information` tab data to include core product fields (e.g., name, plan number, status) for a more comprehensive view.
- Fixes a bug in the symbols & graphics validation logic that incorrectly required a text field for graphics.
- An update to the user profile to allow editing `organization` and `location`.
- The inclusion of `folder_name` in the response when listing products within a bookmark folder.