### PR TITLE
Feature/source files CRUD controllers

### DIFF
--- a/src/controllers/sourceFiles/createSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/createSourceFileAndFolder.ts
@@ -25,6 +25,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			workspace_id: input.workspace_id,
 			name: input.name,
 			type: input.type,
+			...(input.type === 'file' && { url: input.url })
 		});
 		if (missingFieldsResult) return missingFieldsResult;
 
@@ -42,7 +43,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const workspaceId = ObjectId.createFromHexString(input.workspace_id);
 		const parentId = input.parentId ? ObjectId.createFromHexString(input.parentId) : null;
 
-		const trimmedFolderName = input.name.trim();
+		const trimmedName = input.name.trim();
 
 		if (parentId) {
 			const parentFolder = await sourceFilesCollection.findOne({
@@ -53,29 +54,29 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			if (!parentFolder) return ResponseWrapper.badRequest('Parent folder not found or is not a folder.');
 		}
 
-		const existingFolder = await sourceFilesCollection.findOne({
+		const existingFileOrFolder = await sourceFilesCollection.findOne({
 			workspace_id: workspaceId,
 			parentId: parentId,
-			name: trimmedFolderName,
-			type: 'folder',
+			name: trimmedName,
 		});
 
-		if (existingFolder) return ResponseWrapper.conflict('A folder with the same name already exists in this location.');
+		if (existingFileOrFolder) return ResponseWrapper.conflict(`A ${existingFileOrFolder.type} with the same name already exists in this location.`);
 
 
-		const newSourceFileFolder: SourceFile = {
+		const newSourceFile: SourceFile = {
 			_id: new ObjectId(),
 			workspace_id: workspaceId,
-			name: trimmedFolderName,
+			name: trimmedName,
 			type: input.type,
 			parentId: parentId,
+			...(input.type === 'file' && {url: input.url})
 		};
 
-		await sourceFilesCollection.insertOne(newSourceFileFolder);
+		await sourceFilesCollection.insertOne(newSourceFile);
 
 		await updateAuditLog({
 			entity: 'SourceFile',
-			entityId: newSourceFileFolder._id.toString(),
+			entityId: newSourceFile._id.toString(),
 			action: AuditLogAction.CREATE,
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
@@ -83,11 +84,11 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		});
 
 		return ResponseWrapper.created({
-			message: 'Source file folder created successfully.',
-			folder: newSourceFileFolder
+			message: input.type === 'file'  ? 'Source file created successfully.' : 'Source folder created successfully.',
+			folder: newSourceFile
 		});
 	} catch (error) {
-		console.error('Error in creating the source file folder:', error);
-		return ResponseWrapper.internalServerError('An error occurred while creating the source file folder.');
+		console.error('Error in creating the source file or folder:', error);
+		return ResponseWrapper.internalServerError('An error occurred while creating the source file or folder.');
 	}
 }

--- a/src/controllers/sourceFiles/createSourceFilesFolder.ts
+++ b/src/controllers/sourceFiles/createSourceFilesFolder.ts
@@ -1,0 +1,93 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ResponseWrapper } from "../../utils/responseWrapper";
+import { authenticateRequest } from "../../utils/authUtils";
+import { validateAllObjectIds, validateEnum, validateMissingFields } from "../../utils/validationUtils";
+import { getDb } from "../../utils/db";
+import { SourceFile } from "../../models/sourceFiles";
+import { ObjectId } from "mongodb";
+import { updateAuditLog } from "../../utils/auditLog";
+import { AuditLogAction } from "../../models/auditLog";
+
+/**
+ * @param {APIGatewayProxyEvent} event
+ * @return {Promise<APIGatewayProxyResult>}
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const auth = await authenticateRequest(event);
+		if (!auth.isValid) return auth.error;
+
+		if (!event.body) return ResponseWrapper.badRequest('Request body is missing.');
+
+		const input = JSON.parse(event.body);
+
+		const missingFieldsResult = validateMissingFields({
+			workspace_id: input.workspace_id,
+			name: input.name,
+			type: input.type,
+		});
+		if (missingFieldsResult) return missingFieldsResult;
+
+		const isValidEnum = validateEnum(['file', 'folder'], input.type)
+		if(isValidEnum) return isValidEnum
+
+		const objectIdValidation = validateAllObjectIds({
+			workspace_id: input.workspace_id,
+			...(input.parentId && { 'parentId': input.parentId })
+		});
+		if (objectIdValidation) return objectIdValidation;
+
+		const db = await getDb();
+		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
+		const workspaceId = ObjectId.createFromHexString(input.workspace_id);
+		const parentId = input.parentId ? ObjectId.createFromHexString(input.parentId) : null;
+
+		const trimmedFolderName = input.name.trim();
+
+		if (parentId) {
+			const parentFolder = await sourceFilesCollection.findOne({
+				_id: parentId,
+				workspace_id: workspaceId,
+				type: 'folder'
+			});
+			if (!parentFolder) return ResponseWrapper.badRequest('Parent folder not found or is not a folder.');
+		}
+
+		const existingFolder = await sourceFilesCollection.findOne({
+			workspace_id: workspaceId,
+			parentId: parentId,
+			name: trimmedFolderName,
+			type: 'folder',
+		});
+
+		if (existingFolder) return ResponseWrapper.conflict('A folder with the same name already exists in this location.');
+
+
+		const newSourceFileFolder: SourceFile = {
+			_id: new ObjectId(),
+			workspace_id: workspaceId,
+			name: trimmedFolderName,
+			type: input.type,
+			parentId: parentId,
+		};
+
+		await sourceFilesCollection.insertOne(newSourceFileFolder);
+
+		await updateAuditLog({
+			entity: 'SourceFile',
+			entityId: newSourceFileFolder._id.toString(),
+			action: AuditLogAction.CREATE,
+			actionBy: auth.payload?.name?.toString()!,
+			actionAt: new Date(),
+			active: true,
+		});
+
+		return ResponseWrapper.created({
+			message: 'Source file folder created successfully.',
+			folder: newSourceFileFolder
+		});
+	} catch (error) {
+		console.error('Error in creating the source file folder:', error);
+		return ResponseWrapper.internalServerError('An error occurred while creating the source file folder.');
+	}
+}

--- a/src/controllers/sourceFiles/deleteSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/deleteSourceFileAndFolder.ts
@@ -1,0 +1,82 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ResponseWrapper } from "../../utils/responseWrapper";
+import { authenticateRequest } from "../../utils/authUtils";
+import { getDb } from "../../utils/db";
+import { validateAllObjectIds } from "../../utils/validationUtils";
+import { Collection, ObjectId } from "mongodb";
+import { SourceFile } from "../../models/sourceFiles";
+import { updateAuditLog } from "../../utils/auditLog";
+import { AuditLogAction } from "../../models/auditLog";
+
+/**
+ * Recursively finds all descendant node IDs for a given parent folder.
+ * @param {Collection<SourceFile>} collection The MongoDB collection to search.
+ * @param {ObjectId} parentId The ID of the parent folder.
+ * @return {Promise<ObjectId[]>} A promise that resolves to an array of descendant IDs.
+ */
+async function findDescendantIds(collection: Collection<SourceFile>, parentId: ObjectId): Promise<ObjectId[]> {
+	let idsToDelete = [parentId];
+	const children = await collection.find({ parentId: parentId }).toArray();
+	for (const child of children) {
+		if (child.type === 'folder') {
+			const descendantIds = await findDescendantIds(collection, child._id);
+			idsToDelete = idsToDelete.concat(descendantIds);
+		} else {
+			idsToDelete.push(child._id);
+		}
+	}
+	return idsToDelete;
+}
+
+/**
+ * @param {APIGatewayProxyEvent} event 
+ * @return {Promise<APIGatewayProxyResult>}
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const auth = await authenticateRequest(event);
+		if(!auth.isValid) return auth.error;
+
+		const fileId = event.pathParameters?.fileId;
+		if (!fileId) return ResponseWrapper.badRequest('Missing required path parameter: fileId');
+
+		const  validateFileId = validateAllObjectIds({ fileId });
+		if (validateFileId) return validateFileId;
+
+		const db = await getDb();
+		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
+		const fileObjectId = new ObjectId(fileId);
+
+		const fileOrFolder = await sourceFilesCollection.findOne({ _id: fileObjectId });
+		if (!fileOrFolder) {
+			return ResponseWrapper.notFound('File or folder not found.');
+		}
+
+		let idsToDelete: ObjectId[];
+
+		if (fileOrFolder.type === 'folder') {
+			idsToDelete = await findDescendantIds(sourceFilesCollection, fileObjectId);
+		} else {
+			idsToDelete = [fileObjectId];
+		}
+
+		await sourceFilesCollection.deleteMany({ _id: { $in: idsToDelete } });
+
+		await updateAuditLog({
+			entity: 'SourceFile',
+			entityId: fileId,
+			action: AuditLogAction.DELETE,
+			actionBy: auth.payload?.name?.toString()!,
+			actionAt: new Date(),
+			active: true,
+		});
+
+		return ResponseWrapper.success({
+			message: 'Source file or folder and its contents deleted successfully.',
+		})
+        
+	} catch (error) {
+		console.error('Error in deleteSourceFilesFolder:', error);
+		return ResponseWrapper.internalServerError(error instanceof Error ? error.message : 'Something went wrong while deleting source file folder.');
+	}
+}

--- a/src/controllers/sourceFiles/getAllSourceFilesFolders.ts
+++ b/src/controllers/sourceFiles/getAllSourceFilesFolders.ts
@@ -1,0 +1,49 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ResponseWrapper } from "../../utils/responseWrapper";
+import { authenticateRequest } from "../../utils/authUtils";
+import { getDb } from "../../utils/db";
+import { validateAllObjectIds } from "../../utils/validationUtils";
+import { ObjectId } from "mongodb";
+import { SourceFile } from "../../models/sourceFiles";
+
+/**
+ * @param {APIGatewayProxyEvent} event 
+ * @return {Promise<APIGatewayProxyResult>}
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const auth = await authenticateRequest(event);
+		if(!auth.isValid) return auth.error;
+
+		const workspaceId = event.queryStringParameters?.workspaceId;
+		if (!workspaceId) return ResponseWrapper.badRequest('Missing required query parameter: workspace_id');
+
+		const  validateWorkspaceId = validateAllObjectIds({ workspaceId });
+		if (validateWorkspaceId) return validateWorkspaceId;
+
+		const db = await getDb();
+		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
+
+		const sourceFileFolders = await sourceFilesCollection.find({
+			workspace_id: new ObjectId(workspaceId),
+			type: 'folder',
+			parentId: {$eq: null}
+		}).toArray();
+
+		if(!sourceFileFolders || sourceFileFolders.length === 0) {
+			return ResponseWrapper.success({
+				message: 'No source file folders found for the given workspace.',
+				result: []
+			});
+		}
+
+		return ResponseWrapper.success({
+			message: 'Source file folders fetched successfully.',
+			result: sourceFileFolders
+		})
+        
+	} catch (error) {
+		console.error('Error in getAllSourceFilesFolders:', error);
+		return ResponseWrapper.internalServerError(error instanceof Error ? error.message : 'Something went wrong while fetching source file folders.');
+	}
+}

--- a/src/controllers/sourceFiles/getSourceFilesByParent.ts
+++ b/src/controllers/sourceFiles/getSourceFilesByParent.ts
@@ -18,32 +18,36 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const workspaceId = event.queryStringParameters?.workspaceId;
 		if (!workspaceId) return ResponseWrapper.badRequest('Missing required query parameter: workspace_id');
 
-		const  validateWorkspaceId = validateAllObjectIds({ workspaceId });
-		if (validateWorkspaceId) return validateWorkspaceId;
+		const parentId = event.queryStringParameters?.parentId;
+		if (!parentId) return ResponseWrapper.badRequest('Missing required query parameter: parentId');
+
+		const validationError = validateAllObjectIds({ workspaceId, parentId });
+		if (validationError) return validationError;
 
 		const db = await getDb();
 		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
 
-		const sourceFileFolders = await sourceFilesCollection.find({
+		const query: any = {
 			workspace_id: new ObjectId(workspaceId),
-			type: 'folder',
-			parentId: { $eq: null }
-		}).toArray();
+			parentId: new ObjectId(parentId),
+		};
 
-		if(!sourceFileFolders || sourceFileFolders.length === 0) {
+		const sourceFilesAndFolders = await sourceFilesCollection.find(query).toArray();
+
+		if(!sourceFilesAndFolders || sourceFilesAndFolders.length === 0) {
 			return ResponseWrapper.success({
-				message: 'No source file folders found for the given workspace.',
+				message: 'No source files or folders found for the given criteria.',
 				result: []
 			});
 		}
 
 		return ResponseWrapper.success({
-			message: 'Source file folders fetched successfully.',
-			result: sourceFileFolders
+			message: 'Source files and folders fetched successfully.',
+			result: sourceFilesAndFolders
 		})
         
 	} catch (error) {
-		console.error('Error in getAllSourceFilesFolders:', error);
-		return ResponseWrapper.internalServerError(error instanceof Error ? error.message : 'Something went wrong while fetching source file folders.');
+		console.error('Error in getSourceFilesByParent:', error);
+		return ResponseWrapper.internalServerError(error instanceof Error ? error.message : 'Something went wrong while fetching source files and folders.');
 	}
 }

--- a/src/controllers/sourceFiles/updateSourceFilesFolder.ts
+++ b/src/controllers/sourceFiles/updateSourceFilesFolder.ts
@@ -1,0 +1,68 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ResponseWrapper } from "../../utils/responseWrapper";
+import { authenticateRequest } from "../../utils/authUtils";
+import { getDb } from "../../utils/db";
+import { validateAllObjectIds, validateMissingFields } from "../../utils/validationUtils";
+import { ObjectId } from "mongodb";
+import { SourceFile } from "../../models/sourceFiles";
+import { updateAuditLog } from "../../utils/auditLog";
+import { AuditLogAction } from "../../models/auditLog";
+
+/**
+ * @param {APIGatewayProxyEvent} event 
+ * @return {Promise<APIGatewayProxyResult>}
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const auth = await authenticateRequest(event);
+		if(!auth.isValid) return auth.error;
+
+		if (!event.body) return ResponseWrapper.badRequest('Request body is missing.');
+
+		const folderId = event.pathParameters?.folderId;
+		if (!folderId) return ResponseWrapper.badRequest('Missing required path parameter: folderId');
+
+		const input = JSON.parse(event.body);
+
+		const missingFieldsResult = validateMissingFields({
+			name: input.name,
+		});
+		if (missingFieldsResult) return missingFieldsResult;
+
+		const  validateFolderId = validateAllObjectIds({ folderId });
+		if (validateFolderId) return validateFolderId;
+
+		const db = await getDb();
+		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
+		const folderObjectId = new ObjectId(folderId);
+		const trimmedFolderName = input.name.trim();
+
+		const updatedFolder = await sourceFilesCollection.findOneAndUpdate(
+			{ _id: folderObjectId, type: 'folder' },
+			{ $set: { name: trimmedFolderName } },
+			{ returnDocument: 'after' }
+		);
+
+		if (!updatedFolder) {
+			return ResponseWrapper.notFound('Folder not found.');
+		}
+
+		await updateAuditLog({
+			entity: 'SourceFile',
+			entityId: folderId,
+			action: AuditLogAction.UPDATE,
+			actionBy: auth.payload?.name?.toString()!,
+			actionAt: new Date(),
+			active: true,
+		});
+
+		return ResponseWrapper.success({
+			message: 'Source file folder updated successfully.',
+			result: updatedFolder
+		})
+        
+	} catch (error) {
+		console.error('Error while update the source files folder name:', error);
+		return ResponseWrapper.internalServerError(error instanceof Error ? error.message : 'Something went wrong while updating source file folder.');
+	}
+}

--- a/src/models/sourceFiles.ts
+++ b/src/models/sourceFiles.ts
@@ -1,25 +1,11 @@
 import { ObjectId } from "mongodb"
 
-export interface SourceFileFolder {
-    _id: ObjectId
-    file_name: string,
-    url: string  
-}
 
-// For the adjacency list pattern - represents either a file or folder
-export interface SourceFileNode {
+export interface SourceFile {
     _id: ObjectId
+    workspace_id: ObjectId
     name: string
     type: 'file' | 'folder'
-    parentId: ObjectId | null // null for root folders
-    url?: string // Only for files
-    workspace_id: ObjectId
-}
-
-// Legacy interface for backward compatibility during migration
-export type SourceFiles = {
-  _id: ObjectId, 
-  folder_name: String,
-  workspace_id: ObjectId,
-  folder: Array<SourceFileFolder>
+    parentId: ObjectId | null
+    url?: string
 }

--- a/template.yaml
+++ b/template.yaml
@@ -609,6 +609,43 @@ Resources:
         <<: *EsbuildProps
         EntryPoints: [controllers/dashboard/getDashboardStats.ts]
 
+  # ──────────────────────────────────────────────────────────────────────────
+  # SOURCE FILES
+  # ──────────────────────────────────────────────────────────────────────────
+  CreateSourceFilesFolderFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/sourceFiles/createSourceFilesFolder.lambdaHandler
+      Events:
+        CreateSourceFilesFolder:
+          Type: Api
+          Properties:
+            Path: /source-files/folder
+            Method: post
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/sourceFiles/createSourceFilesFolder.ts]
+
+  GetAllSourceFilesFoldersFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/sourceFiles/getAllSourceFilesFolders.lambdaHandler
+      Events:
+        GetAllSourceFilesFolders:
+          Type: Api
+          Properties:
+            Path: /source-files/folders
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/sourceFiles/getAllSourceFilesFolders.ts]
+
   ApplicationResourceGroup:
     Type: AWS::ResourceGroups::Group
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -612,22 +612,22 @@ Resources:
   # ──────────────────────────────────────────────────────────────────────────
   # SOURCE FILES
   # ──────────────────────────────────────────────────────────────────────────
-  CreateSourceFilesFolderFunction:
+  CreateSourceFileAndFolderFunction:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/
-      Handler: controllers/sourceFiles/createSourceFilesFolder.lambdaHandler
+      Handler: controllers/sourceFiles/createSourceFileAndFolder.lambdaHandler
       Events:
-        CreateSourceFilesFolder:
+        CreateSourceFileAndFolder:
           Type: Api
           Properties:
-            Path: /source-files/folder
+            Path: /source-files
             Method: post
     Metadata:
       <<: *EsbuildBase
       BuildProperties:
         <<: *EsbuildProps
-        EntryPoints: [controllers/sourceFiles/createSourceFilesFolder.ts]
+        EntryPoints: [controllers/sourceFiles/createSourceFileAndFolder.ts]
 
   GetAllSourceFilesFoldersFunction:
     Type: AWS::Serverless::Function
@@ -638,13 +638,64 @@ Resources:
         GetAllSourceFilesFolders:
           Type: Api
           Properties:
-            Path: /source-files/folders
+            Path: /source-files
             Method: get
     Metadata:
       <<: *EsbuildBase
       BuildProperties:
         <<: *EsbuildProps
         EntryPoints: [controllers/sourceFiles/getAllSourceFilesFolders.ts]
+
+  GetSourceFilesByParentFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/sourceFiles/getSourceFilesByParent.lambdaHandler
+      Events:
+        GetSourceFilesByParent:
+          Type: Api
+          Properties:
+            Path: /source-files/folder
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/sourceFiles/getSourceFilesByParent.ts]
+
+  DeleteSourceFileFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/sourceFiles/deleteSourceFileAndFolder.lambdaHandler
+      Events:
+        DeleteSourceFileAndFolder:
+          Type: Api
+          Properties:
+            Path: /source-files/{fileId}
+            Method: delete
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/sourceFiles/deleteSourceFileAndFolder.ts]
+
+  UpdateSourceFilesFolderFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/sourceFiles/updateSourceFilesFolder.lambdaHandler
+      Events:
+        UpdateSourceFilesFolder:
+          Type: Api
+          Properties:
+            Path: /source-files/{folderId}
+            Method: patch
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/sourceFiles/updateSourceFilesFolder.ts]
 
   ApplicationResourceGroup:
     Type: AWS::ResourceGroups::Group


### PR DESCRIPTION
- Consolidates the creation endpoint to handle both files and folders via a single `POST /source-files` request.
- Adds 2 GET endpoints to get top top-level folder and data from a parent folder, a PATCH endpoint to update the folder name.
- DELETE endpoint to delete a folder or file