### PR TITLE
feat: add `annotation_state` field to label tags and update `updateLabelTagTaggedImage` to support it

### DIFF
--- a/src/controllers/products/productData/label-tags.ts
+++ b/src/controllers/products/productData/label-tags.ts
@@ -201,10 +201,10 @@ export function updateLabelTagsTabCompletion(
  * @return {LabelTagReturn}
  */
 export function updateLabelTagTaggedImage(
-	inputData: { id: string; tagged_image: string },
+	inputData: { id: string; tagged_image: string; annotation_state?: object },
 	tab: string,
 	action: string,
-): Omit<LabelTagReturn, 'updatedData'> & { updatedData: { id: string; tagged_image: string } } {
+): Omit<LabelTagReturn, 'updatedData'> & { updatedData: { id: string; tagged_image: string; annotation_state?: object } } {
 	try {
 		const isValidatedTab = validateTab(tab, 'label-tags', action);
 		if (isValidatedTab) throw new Error(isValidatedTab.body);
@@ -221,11 +221,12 @@ export function updateLabelTagTaggedImage(
 		const updateQuery = {
 			$set: {
 				'label_tags.data.$[elem].tagged_image': inputData.tagged_image,
+				'label_tags.data.$[elem].annotation_state': inputData.annotation_state,
 			},
 			arrayFilters: [{ 'elem._id': new ObjectId(inputData.id) }],
 		};
 
-		const updatedData = { id: inputData.id, tagged_image: inputData.tagged_image };
+		const updatedData = { id: inputData.id, tagged_image: inputData.tagged_image, annotation_state: inputData.annotation_state };
 		const actionLog = 'UPDATE';
 
 		return { updateQuery, updatedData, actionLog, error: null };

--- a/src/controllers/products/productData/label-tags.ts
+++ b/src/controllers/products/productData/label-tags.ts
@@ -218,11 +218,16 @@ export function updateLabelTagTaggedImage(
 		const objectIdValidation = validateAllObjectIds({ id: inputData.id });
 		if (objectIdValidation) throw new Error(objectIdValidation.body);
 
+		const setFields: Record<string, unknown> = {
+			'label_tags.data.$[elem].tagged_image': inputData.tagged_image,
+		};
+
+		if (inputData.annotation_state !== undefined) {
+			setFields['label_tags.data.$[elem].annotation_state'] = inputData.annotation_state;
+		}
+
 		const updateQuery = {
-			$set: {
-				'label_tags.data.$[elem].tagged_image': inputData.tagged_image,
-				'label_tags.data.$[elem].annotation_state': inputData.annotation_state,
-			},
+			$set: setFields,
 			arrayFilters: [{ 'elem._id': new ObjectId(inputData.id) }],
 		};
 
@@ -234,13 +239,13 @@ export function updateLabelTagTaggedImage(
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
-				updatedData: { id: inputData.id, tagged_image: '' },
+				updatedData: { id: inputData.id, tagged_image: '', annotation_state: undefined },
 				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
-			updatedData: { id: inputData.id, tagged_image: '' },
+			updatedData: { id: inputData.id, tagged_image: '', annotation_state: undefined },
 			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update label tag tagged image'),
 		};

--- a/src/models/product.ts
+++ b/src/models/product.ts
@@ -98,6 +98,7 @@ export type LabelTags = {
 			type?: string;
 			image?: string;
 			tagged_image?: string;
+			annotation_state?: object;
 	}>;
 	tab_completed: boolean;
 };

--- a/src/types/products/label-tags.ts
+++ b/src/types/products/label-tags.ts
@@ -5,6 +5,7 @@ export interface LabelTag {
     type?: string,
     image?: string,
     tagged_image?: string,
+    annotation_state?: object,
 }
 
 export type BaseLabelTag<Action extends string, TData> = {
@@ -16,6 +17,6 @@ export type BaseLabelTag<Action extends string, TData> = {
 
 export type AddLabelTag = BaseLabelTag<'add_label_tags', LabelTag[]>;
 export type UpdateLabelTag = BaseLabelTag<'update_label_tags', Required<LabelTag>>;
-export type UpdateLabelTagTaggedImage = BaseLabelTag<'update_label_tag_tagged_image', { id: string; tagged_image: string }>;
+export type UpdateLabelTagTaggedImage = BaseLabelTag<'update_label_tag_tagged_image', { id: string; tagged_image: string; annotation_state?: object }>;
 export type DeleteLabelTag = BaseLabelTag<'delete_label_tags', { id: string }>;
 export type LabelTagsTabCompletion = BaseLabelTag<'update_label_tags_tab_completion', { tab_completed: boolean }>;


### PR DESCRIPTION
• Added `annotation_state` field to label tags interface
• Updated `updateLabelTagTaggedImage` function to support annotation state
• Modified TypeScript types to include a new optional field
• Extended MongoDB schema for annotation state storage
