### PR TITLE
feat: add count field to barcodes in symbols-graphics

### DIFF
--- a/src/controllers/products/productData/symbols-graphics.ts
+++ b/src/controllers/products/productData/symbols-graphics.ts
@@ -91,14 +91,20 @@ export function UpdateSymbolsGraphics(
 		const objectIdValidation =validateAllObjectIds({id: updatedSymbolsGraphics.id})
 		if(objectIdValidation) throw new Error(objectIdValidation.body);
 
-		const updateQuery = {$set: {
+		const updateSet: Record<string, unknown> = {
 			'symbols_graphics.data.$[elem].image': updatedSymbolsGraphics.image,
 			'symbols_graphics.data.$[elem].text': updatedSymbolsGraphics.text,
 			'symbols_graphics.data.$[elem].description': updatedSymbolsGraphics.description,
 			'symbols_graphics.data.$[elem].text_present': updatedSymbolsGraphics.text_present,
 			'symbols_graphics.data.$[elem].label_presence': updatedSymbolsGraphics.label_presence,
-			'symbols_graphics.data.$[elem].entity': updatedSymbolsGraphics.entity
-		}, arrayFilters: [{'elem._id': new ObjectId(updatedSymbolsGraphics.id!)}]}
+			'symbols_graphics.data.$[elem].entity': updatedSymbolsGraphics.entity,
+		};
+
+		if (typeof updatedSymbolsGraphics.count === 'number') {
+			updateSet['symbols_graphics.data.$[elem].count'] = updatedSymbolsGraphics.count;
+		}
+
+		const updateQuery = {$set: updateSet, arrayFilters: [{'elem._id': new ObjectId(updatedSymbolsGraphics.id!)}]}
 
 		const updatedData = updatedSymbolsGraphics;
 		const actionLog = 'UPDATE';

--- a/src/controllers/products/updateProductData.ts
+++ b/src/controllers/products/updateProductData.ts
@@ -340,9 +340,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const updateResult = await db
 			.collection<Product>('products')
 			.updateOne({ _id: new ObjectId(input.id) }, updateQuery, options);
-		
-		console.error('updateResult 🚨', updateResult);
-
 		if (updateResult.modifiedCount === 0) {
 			return ResponseWrapper.notFound(
 				'Product data not modified successfully, please check the data and try again.',

--- a/src/models/product.ts
+++ b/src/models/product.ts
@@ -76,6 +76,7 @@ export type SymbolsGraphics = {
 			text_present?: boolean;
 			label_presence: string[];
 			entity: 'Symbols' | 'Schematics' | 'Barcodes' | 'Other Components';
+			count?: number;
 	}>;
 	tab_completed: boolean;
 };

--- a/src/types/products/symbols-graphics.ts
+++ b/src/types/products/symbols-graphics.ts
@@ -13,7 +13,8 @@ export interface SymbolsGraphics {
     description?: string,
     text_present?: boolean,
     label_presence?: string[],
-    entity?: SymbolsGraphicsEntity
+    entity?: SymbolsGraphicsEntity,
+    count?: number
 }
 
 export type BaseSymbolsGraphics<Action extends string, TData> = {
@@ -24,6 +25,6 @@ export type BaseSymbolsGraphics<Action extends string, TData> = {
 }
 
 export type AddSymbolsGraphics = BaseSymbolsGraphics<'add_symbols_graphics', SymbolsGraphics[]>;
-export type UpdateSymbolsGraphics = BaseSymbolsGraphics<'update_symbols_graphics', Required<SymbolsGraphics>>;
+export type UpdateSymbolsGraphics = BaseSymbolsGraphics<'update_symbols_graphics', SymbolsGraphics>;
 export type DeleteSymbolsGraphics = BaseSymbolsGraphics<'delete_symbols_graphics', { id: string }>;
 export type SymbolsGraphicsTabCompletion = BaseSymbolsGraphics<'update_symbols_graphics_tab_completion', { tab_completed: boolean }>;


### PR DESCRIPTION
Add optional count field to barcodes in symbols-graphics feature.

- Added `count?: number` to SymbolsGraphics type definition
- Updated product model to include count field
- Modified UpdateSymbolsGraphics to include count in update query when it's a number
- Removed debug console.error from updateProductData