### PR TITLE
Feature/audit log v2

### DIFF
--- a/src/controllers/auditLogs/getAuditLogs.ts
+++ b/src/controllers/auditLogs/getAuditLogs.ts
@@ -10,7 +10,7 @@ import {
 } from '../../models/auditLogV2';
 import { authenticateRequest } from '../../utils/authUtils';
 import { getDb } from '../../utils/db';
-import { logError } from '../../utils/logger';
+import { logError, logInfo } from '../../utils/logger';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 
 const ADMIN_ONLY_SCOPES: AuditScopeType[] = ['department', 'project', 'archive'];
@@ -62,6 +62,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const page = Number.parseInt(event.queryStringParameters?.page ?? '1', 10);
 		const limit = Number.parseInt(event.queryStringParameters?.limit ?? '20', 10);
 
+		logInfo('🔎 auditLogs/getAuditLogs request params', {
+			queryStringParameters: event.queryStringParameters ?? {},
+			parsedPage: page,
+			parsedLimit: limit,
+			requestId: event.requestContext?.requestId,
+		});
+
 		if (!workspaceId || !ObjectId.isValid(workspaceId)) {
 			return ResponseWrapper.badRequest('workspaceId query parameter must be a valid ObjectId.');
 		}
@@ -78,6 +85,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		if (!Number.isFinite(limit) || limit < 1 || limit > 100) {
 			return ResponseWrapper.badRequest('limit must be a number between 1 and 100.');
+		}
+
+		if (!Number.isFinite(page) || page < 1) {
+			return ResponseWrapper.badRequest('page must be a number greater than or equal to 1.');
 		}
 
 		const adminUser = isAdminUser(auth.payload['cognito:groups']);
@@ -145,15 +156,34 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const skip = (page - 1) * limit;
 
+		logInfo('📄 auditLogs/getAuditLogs pagination', {
+			page,
+			limit,
+			skip,
+			scopeType,
+			scopeId,
+			requestId: event.requestContext?.requestId,
+		});
+
 		const [logs, totalCount] = await Promise.all([
 			collection
 				.find(query)
-				.sort({ occurredAt: -1 })
+				.sort({ occurredAt: -1, _id: -1 })
 				.skip(skip)
 				.limit(limit)
 				.toArray(),
 			collection.countDocuments(query),
 		]);
+
+		logInfo('✅ auditLogs/getAuditLogs result', {
+			page,
+			limit,
+			totalCount,
+			returnedCount: logs.length,
+			firstLogId: logs[0]?._id?.toString(),
+			lastLogId: logs.length ? logs[logs.length - 1]?._id?.toString() : undefined,
+			requestId: event.requestContext?.requestId,
+		});
 
 		return ResponseWrapper.success({
 			message: 'Audit logs fetched successfully',

--- a/src/controllers/auditLogs/getAuditLogs.ts
+++ b/src/controllers/auditLogs/getAuditLogs.ts
@@ -1,0 +1,171 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import {
+	AUDIT_ACTIONS,
+	AUDIT_LOG_V2_COLLECTION,
+	AUDIT_SCOPE_TYPES,
+	type AuditAction,
+	type AuditLogV2,
+	type AuditScopeType,
+} from '../../models/auditLogV2';
+import { authenticateRequest } from '../../utils/authUtils';
+import { getDb } from '../../utils/db';
+import { logError } from '../../utils/logger';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+
+const ADMIN_ONLY_SCOPES: AuditScopeType[] = ['department', 'project', 'archive'];
+
+const parseGroups = (groups: unknown): string[] => {
+	if (Array.isArray(groups)) return groups.filter((group): group is string => typeof group === 'string');
+	if (typeof groups === 'string') return groups.split(',').map((group) => group.trim()).filter(Boolean);
+	return [];
+};
+
+const isAdminUser = (groups: unknown) => parseGroups(groups).includes('admin');
+
+const parseActions = (rawActions: string | undefined): AuditAction[] | null => {
+	if (!rawActions) return null;
+
+	const actions = rawActions
+		.split(',')
+		.map((action) => action.trim().toLowerCase())
+		.filter(Boolean);
+
+	if (!actions.length) return null;
+
+	const invalidAction = actions.find((action) => !AUDIT_ACTIONS.includes(action as AuditAction));
+	if (invalidAction) throw new Error(`Invalid action filter: ${invalidAction}`);
+
+	return actions as AuditAction[];
+};
+
+/**
+ * Fetches paginated auditLogV2 records for a workspace scope.
+ *
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Paginated audit log response
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const auth = await authenticateRequest(event);
+		if (!auth.isValid) return auth.error;
+
+		const workspaceId = event.queryStringParameters?.workspaceId;
+		const scopeTypeRaw = event.queryStringParameters?.scopeType;
+		const scopeId = event.queryStringParameters?.scopeId;
+		const search = event.queryStringParameters?.search?.trim();
+		const fromDate = event.queryStringParameters?.from;
+		const toDate = event.queryStringParameters?.to;
+		const page = Number.parseInt(event.queryStringParameters?.page ?? '1', 10);
+		const limit = Number.parseInt(event.queryStringParameters?.limit ?? '20', 10);
+
+		if (!workspaceId || !ObjectId.isValid(workspaceId)) {
+			return ResponseWrapper.badRequest('workspaceId query parameter must be a valid ObjectId.');
+		}
+
+		if (!scopeTypeRaw || !AUDIT_SCOPE_TYPES.includes(scopeTypeRaw as AuditScopeType)) {
+			return ResponseWrapper.badRequest(`scopeType query parameter must be one of: ${AUDIT_SCOPE_TYPES.join(', ')}`);
+		}
+
+		const scopeType = scopeTypeRaw as AuditScopeType;
+
+		if (scopeType !== 'archive' && !scopeId) {
+			return ResponseWrapper.badRequest('scopeId query parameter is required for this scope type.');
+		}
+
+		if (!Number.isFinite(limit) || limit < 1 || limit > 100) {
+			return ResponseWrapper.badRequest('limit must be a number between 1 and 100.');
+		}
+
+		const adminUser = isAdminUser(auth.payload['cognito:groups']);
+		if (ADMIN_ONLY_SCOPES.includes(scopeType) && !adminUser) {
+			return ResponseWrapper.forbidden('Insufficient permissions to view this log scope.');
+		}
+
+		let actionFilters: AuditAction[] | null = null;
+		try {
+			actionFilters = parseActions(event.queryStringParameters?.actions);
+		} catch (error) {
+			return ResponseWrapper.badRequest(error instanceof Error ? error.message : 'Invalid actions filter.');
+		}
+		const db = await getDb();
+		const collection = db.collection<AuditLogV2>(AUDIT_LOG_V2_COLLECTION);
+
+		const query: Record<string, unknown> = {
+			workspaceId: new ObjectId(workspaceId),
+		};
+
+		if (!adminUser) {
+			query.visibility = 'all';
+		}
+
+		if (scopeType === 'archive') {
+			query.action = { $in: ['archive', 'restore'] };
+		} else {
+			query['scope.type'] = scopeType;
+			query['scope.id'] = scopeId;
+		}
+
+		if (actionFilters?.length) {
+			if (scopeType === 'archive') {
+				const archiveActions = actionFilters.filter((action) => action === 'archive' || action === 'restore');
+				query.action = { $in: archiveActions.length ? archiveActions : ['archive', 'restore'] };
+			} else {
+				query.action = { $in: actionFilters };
+			}
+		}
+
+		if (search) {
+			query.summary = { $regex: search, $options: 'i' };
+		}
+
+		if (fromDate || toDate) {
+			const dateQuery: Record<string, Date> = {};
+			if (fromDate) {
+				const parsedFrom = new Date(fromDate);
+				if (Number.isNaN(parsedFrom.getTime())) return ResponseWrapper.badRequest('from must be a valid date value.');
+				dateQuery.$gte = parsedFrom;
+			}
+
+			if (toDate) {
+				const parsedTo = new Date(toDate);
+				if (Number.isNaN(parsedTo.getTime())) return ResponseWrapper.badRequest('to must be a valid date value.');
+				dateQuery.$lte = parsedTo;
+			}
+
+			query.occurredAt = dateQuery;
+		}
+
+		const skip = (page - 1) * limit;
+
+		const [logs, totalCount] = await Promise.all([
+			collection
+				.find(query)
+				.sort({ occurredAt: -1 })
+				.skip(skip)
+				.limit(limit)
+				.toArray(),
+			collection.countDocuments(query),
+		]);
+
+		return ResponseWrapper.success({
+			message: 'Audit logs fetched successfully',
+			result: {
+				logs,
+				pagination: {
+					page,
+					limit,
+					totalCount,
+					totalPages: Math.max(1, Math.ceil(totalCount / limit)),
+					hasNextPage: page * limit < totalCount,
+					hasPrevPage: page > 1,
+				},
+			},
+		});
+	} catch (error) {
+		logError('Get audit logs handler failed', error);
+		return ResponseWrapper.internalServerError(
+			`Failed to get audit logs: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+};

--- a/src/controllers/auditLogs/getAuditLogs.ts
+++ b/src/controllers/auditLogs/getAuditLogs.ts
@@ -14,6 +14,7 @@ import { logError } from '../../utils/logger';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 
 const ADMIN_ONLY_SCOPES: AuditScopeType[] = ['department', 'project', 'archive'];
+const MAX_SEARCH_LENGTH = 200;
 
 const parseGroups = (groups: unknown): string[] => {
 	if (Array.isArray(groups)) return groups.filter((group): group is string => typeof group === 'string');
@@ -22,6 +23,8 @@ const parseGroups = (groups: unknown): string[] => {
 };
 
 const isAdminUser = (groups: unknown) => parseGroups(groups).includes('admin');
+
+const escapeRegex = (pattern: string): string => pattern.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&');
 
 const parseActions = (rawActions: string | undefined): AuditAction[] | null => {
 	if (!rawActions) return null;
@@ -115,8 +118,12 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			}
 		}
 
+		if (search && search.length > MAX_SEARCH_LENGTH) {
+			return ResponseWrapper.badRequest(`search must not exceed ${MAX_SEARCH_LENGTH} characters.`);
+		}
+
 		if (search) {
-			query.summary = { $regex: search, $options: 'i' };
+			query.summary = { $regex: escapeRegex(search), $options: 'i' };
 		}
 
 		if (fromDate || toDate) {
@@ -164,8 +171,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		});
 	} catch (error) {
 		logError('Get audit logs handler failed', error);
-		return ResponseWrapper.internalServerError(
-			`Failed to get audit logs: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		return ResponseWrapper.internalServerError('Failed to get audit logs in auditLogs/getAuditLogs handler.');
 	}
 };

--- a/src/controllers/departments/archiveDepartment.ts
+++ b/src/controllers/departments/archiveDepartment.ts
@@ -1,8 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import type { Department } from '../../models/department';
-import { type AuditLog, AuditLogAction } from '../../models/auditLog';
-import { updateAuditLog } from '../../utils/auditLog';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
@@ -67,19 +65,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				},
 			},
 		);
-
-		const action = isArchived ? AuditLogAction.ARCHIVE : AuditLogAction.UNARCHIVE;
-
-		const auditRecord: AuditLog = {
-			entity: 'department',
-			entityId: (event.pathParameters?.id).toString(),
-			action: action,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		};
-
-		await updateAuditLog(auditRecord);
 
 		await recordAuditEvent({
 			workspaceId: departmentRecord.workspace_id.toString(),

--- a/src/controllers/departments/archiveDepartment.ts
+++ b/src/controllers/departments/archiveDepartment.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateBoolean } from '../../utils/validationUtils';
 import { authenticateWithRole } from '../../utils/authUtils';
+import { recordAuditEvent } from '../../utils/auditLogV2';
 
 /**
  * Archive a department
@@ -79,6 +80,23 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		};
 
 		await updateAuditLog(auditRecord);
+
+		await recordAuditEvent({
+			workspaceId: departmentRecord.workspace_id.toString(),
+			scope: { type: 'department', id: (event.pathParameters?.id).toString() },
+			entity: { type: 'department', id: (event.pathParameters?.id).toString() },
+			action: isArchived ? 'archive' : 'restore',
+			eventKey: isArchived ? 'department.archived' : 'department.restored',
+			visibility: 'admin',
+			where: { module: 'departments' },
+			auth: auth.payload,
+			before: { isArchived: departmentRecord.isArchived },
+			after: { isArchived },
+			changedPaths: ['isArchived'],
+			meta: {
+				departmentName: departmentRecord.department_name,
+			},
+		});
 
 		return ResponseWrapper.success({
 			message: `Department ${isArchived ? 'archived' : 'restored'} successfully`,

--- a/src/controllers/departments/archiveDepartment.ts
+++ b/src/controllers/departments/archiveDepartment.ts
@@ -34,6 +34,8 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return validationResult;
 		}
 
+		const departmentId = event.pathParameters.id.toString();
+
 		const db = await getDb();
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
@@ -48,7 +50,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 
 		const departmentRecord: Department | null = await db.collection<Department>('departments').findOne({
-			_id: new ObjectId(event.pathParameters.id),
+			_id: new ObjectId(departmentId),
 		});
 
 		if (!departmentRecord) {
@@ -57,7 +59,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const department = await db.collection<Department>('departments').updateOne(
 			{
-				_id: new ObjectId(event.pathParameters.id),
+				_id: new ObjectId(departmentId),
 			},
 			{
 				$set: {
@@ -66,22 +68,34 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			},
 		);
 
-		await recordAuditEvent({
-			workspaceId: departmentRecord.workspace_id.toString(),
-			scope: { type: 'department', id: (event.pathParameters?.id).toString() },
-			entity: { type: 'department', id: (event.pathParameters?.id).toString() },
-			action: isArchived ? 'archive' : 'restore',
-			eventKey: isArchived ? 'department.archived' : 'department.restored',
-			visibility: 'admin',
-			where: { module: 'departments' },
-			auth: auth.payload,
-			before: { isArchived: departmentRecord.isArchived },
-			after: { isArchived },
-			changedPaths: ['isArchived'],
-			meta: {
+		const action = isArchived ? 'archive' : 'restore';
+		const eventKey = isArchived ? 'department.archived' : 'department.restored';
+
+		try {
+			await recordAuditEvent({
+				workspaceId: departmentRecord.workspace_id.toString(),
+				scope: { type: 'department', id: departmentId },
+				entity: { type: 'department', id: departmentId },
+				action,
+				eventKey,
+				visibility: 'admin',
+				where: { module: 'departments' },
+				auth: auth.payload,
+				before: { isArchived: departmentRecord.isArchived },
+				after: { isArchived },
+				changedPaths: ['isArchived'],
+				meta: {
+					departmentName: departmentRecord.department_name,
+				},
+			});
+		} catch (auditError) {
+			logError('Department archive audit event failed', auditError, {
 				departmentName: departmentRecord.department_name,
-			},
-		});
+				workspaceId: departmentRecord.workspace_id.toString(),
+				action,
+				departmentId,
+			});
+		}
 
 		return ResponseWrapper.success({
 			message: `Department ${isArchived ? 'archived' : 'restored'} successfully`,

--- a/src/controllers/departments/createDepartment.ts
+++ b/src/controllers/departments/createDepartment.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
 import { authenticateWithRole } from '../../utils/authUtils';
+import { recordAuditEvent } from '../../utils/auditLogV2';
 
 /**
  * Create a department
@@ -19,7 +20,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 	try {
 		const auth = await authenticateWithRole(event, 'admin');
 		if(!auth.isValid) return auth.error;
-
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
 
@@ -69,6 +69,26 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
 			active: true,
+		});
+
+		await recordAuditEvent({
+			workspaceId: workspaceObjectId.toString(),
+			scope: { type: 'department', id: department.insertedId.toString() },
+			entity: { type: 'department', id: department.insertedId.toString() },
+			action: 'create',
+			eventKey: 'department.created',
+			visibility: 'admin',
+			where: { module: 'departments' },
+			auth: auth.payload,
+			after: {
+				department_name: input.department_name,
+				department_description: input.department_description,
+				manager: input.manager,
+			},
+			changedPaths: ['department_name', 'department_description', 'manager'],
+			meta: {
+				departmentName: input.department_name,
+			},
 		});
 
 		return ResponseWrapper.created({

--- a/src/controllers/departments/createDepartment.ts
+++ b/src/controllers/departments/createDepartment.ts
@@ -1,8 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import type { Department } from '../../models/department';
-import { AuditLogAction } from '../../models/auditLog';
-import { updateAuditLog } from '../../utils/auditLog';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
@@ -60,15 +58,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			workspace_id: workspaceObjectId,
 			users: userObjectIds,
 			isArchived: false,
-		});
-
-		await updateAuditLog({
-			entity: 'department',
-			entityId: department.insertedId.toString(),
-			action: AuditLogAction.CREATE,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
 		});
 
 		await recordAuditEvent({

--- a/src/controllers/departments/getAllDepartments.ts
+++ b/src/controllers/departments/getAllDepartments.ts
@@ -5,6 +5,7 @@ import { Department } from '../../models/department';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { authenticateRequest } from '../../utils/authUtils';
+import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 
 /**
  * Get all departments
@@ -84,39 +85,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 						as: 'users',
 					},
 				},
-				{
-					$lookup: {
-						from: 'audit_log',
-						let: { deptIdString: { $toString: '$_id' } },
-						pipeline: [
-							{
-								$match: {
-									$expr: {
-										$and: [
-											{ $eq: ['$entity', 'department'] },
-											{ $eq: ['$entityId', '$$deptIdString'] },
-											{ $in: ['$action', ['create', 'update']] },
-											{ $eq: ['$active', true] }
-										]
-									}
-								}
-							},
-							{ $sort: { actionAt: -1 } },
-							{
-								$project: {
-									entity: 1,
-									entityId: 1,
-									action: 1,
-									actionBy: 1,
-									actionAt: 1,
-									active: 1
-								}
-							},
-							{ $limit: 2 }
-						],
-						as: 'auditLogs'
-					}
-				},
+				isArchive
+					? buildLegacyAuditLookupStage({ scopeType: 'department', mode: 'archive' })
+					: buildLegacyAuditLookupStage({ scopeType: 'department', updateActions: ['update', 'restore'] }),
 			])
 			.toArray();
 

--- a/src/controllers/departments/getDepartment.ts
+++ b/src/controllers/departments/getDepartment.ts
@@ -5,6 +5,7 @@ import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { authenticateRequest } from '../../utils/authUtils';
+import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 
 /**
  * Get a department
@@ -50,39 +51,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 					as: 'users',
 				},
 			},
-			{
-				$lookup: {
-					from: 'audit_log',
-					let: { deptIdString: { $toString: '$_id' } },
-					pipeline: [
-						{
-							$match: {
-								$expr: {
-									$and: [
-										{ $eq: ['$entity', 'department'] },
-										{ $eq: ['$entityId', '$$deptIdString'] },
-										{ $in: ['$action', ['create', 'update']] },
-										{ $eq: ['$active', true] }
-									]
-								}
-							}
-						},
-						{ $sort: { actionAt: -1 } },
-						{
-							$project: {
-								entity: 1,
-								entityId: 1,
-								action: 1,
-								actionBy: 1,
-								actionAt: 1,
-								active: 1
-							}
-						},
-						{ $limit: 2 }
-					],
-					as: 'auditLogs'
-				}
-			}
+			buildLegacyAuditLookupStage({
+				scopeType: 'department',
+				updateActions: ['update', 'restore'],
+			})
 		]).toArray();
 
 		const department = departmentData[0];

--- a/src/controllers/departments/updateDepartment.ts
+++ b/src/controllers/departments/updateDepartment.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
 import { authenticateWithRole } from '../../utils/authUtils';
+import { recordAuditEvent } from '../../utils/auditLogV2';
 
 /**
  * Update a department
@@ -94,6 +95,33 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		};
 
 		await updateAuditLog(auditRecord);
+
+		await recordAuditEvent({
+			workspaceId: workspaceObjectId.toString(),
+			scope: { type: 'department', id: (departmentRecord._id as ObjectId).toString() },
+			entity: { type: 'department', id: (departmentRecord._id as ObjectId).toString() },
+			action: 'update',
+			eventKey: 'department.updated',
+			visibility: 'admin',
+			where: { module: 'departments' },
+			auth: auth.payload,
+			before: {
+				department_name: departmentRecord.department_name,
+				department_description: departmentRecord.department_description,
+				manager: departmentRecord.manager,
+				users: departmentRecord.users?.map((user) => user.toString()) ?? [],
+			},
+			after: {
+				department_name: input.department_name,
+				department_description: input.department_description,
+				manager: input.manager,
+				users: input.users ?? [],
+			},
+			changedPaths: ['department_name', 'department_description', 'manager', 'users'],
+			meta: {
+				departmentName: input.department_name,
+			},
+		});
 
 		return ResponseWrapper.success({
 			message: 'Department updated successfully',

--- a/src/controllers/departments/updateDepartment.ts
+++ b/src/controllers/departments/updateDepartment.ts
@@ -1,8 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import type { Department } from '../../models/department';
-import { type AuditLog, AuditLogAction } from '../../models/auditLog';
-import { updateAuditLog } from '../../utils/auditLog';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
@@ -84,17 +82,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				},
 			},
 		);
-
-		const auditRecord: AuditLog = {
-			entity: 'department',
-			entityId: (departmentRecord._id as ObjectId).toString(),
-			action: AuditLogAction.UPDATE,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		};
-
-		await updateAuditLog(auditRecord);
 
 		await recordAuditEvent({
 			workspaceId: workspaceObjectId.toString(),

--- a/src/controllers/products/createProduct.ts
+++ b/src/controllers/products/createProduct.ts
@@ -1,8 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import type { Product } from '../../models/product';
-import { AuditLogAction } from '../../models/auditLog';
-import { updateAuditLog } from '../../utils/auditLog';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { validateEnum, validateMissingFields, validateObjectIds } from '../../utils/validationUtils';
@@ -131,15 +129,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		};
 
 		const product = await db.collection<Product>('products').insertOne(productData);
-
-		await updateAuditLog({
-			entity: 'product',
-			entityId: product.insertedId.toString(),
-			action: AuditLogAction.CREATE,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		});
 
 		await recordAuditEvent({
 			workspaceId: workspaceObjectId.toString(),

--- a/src/controllers/products/createProduct.ts
+++ b/src/controllers/products/createProduct.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { validateEnum, validateMissingFields, validateObjectIds } from '../../utils/validationUtils';
 import { authenticateRequest } from '../../utils/authUtils';
 import { logError } from '../../utils/logger';
+import { recordAuditEvent } from '../../utils/auditLogV2';
 
 /**
  * Create a product
@@ -138,6 +139,28 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
 			active: true,
+		});
+
+		await recordAuditEvent({
+			workspaceId: workspaceObjectId.toString(),
+			scope: { type: 'product', id: product.insertedId.toString() },
+			entity: { type: 'product', id: product.insertedId.toString() },
+			action: 'create',
+			eventKey: 'product.created',
+			visibility: 'all',
+			where: { module: 'products' },
+			auth: auth.payload,
+			after: {
+				product_plan_number: input.product_plan_number,
+				product_name: input.product_name,
+				product_description: input.product_description,
+				status: input.status,
+				version: input.version,
+			},
+			changedPaths: ['product_plan_number', 'product_name', 'product_description', 'status', 'version'],
+			meta: {
+				productName: input.product_name,
+			},
 		});
 
 		return ResponseWrapper.created({

--- a/src/controllers/products/createProductVersion.ts
+++ b/src/controllers/products/createProductVersion.ts
@@ -6,8 +6,6 @@ import { getDb } from "../../utils/db";
 import { ObjectId } from "mongodb";
 import { Product } from "../../models/product";
 import { deepCopyWithFreshIds } from "../../utils/deepCopy";
-import { updateAuditLog } from "../../utils/auditLog";
-import { AuditLogAction } from "../../models/auditLog";
 import { recordAuditEvent } from "../../utils/auditLogV2";
 
 
@@ -39,15 +37,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
        
 		const insertedProduct = await db.collection<Product>('products').insertOne(revisedUpdatedProduct);
 		
-
-		await updateAuditLog({
-			entity: 'product',
-			entityId: insertedProduct.insertedId.toString(),
-			action: AuditLogAction.CREATE,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		});
 
 		await recordAuditEvent({
 			workspaceId: revisedUpdatedProduct.workspace_id.toString(),

--- a/src/controllers/products/createProductVersion.ts
+++ b/src/controllers/products/createProductVersion.ts
@@ -8,6 +8,7 @@ import { Product } from "../../models/product";
 import { deepCopyWithFreshIds } from "../../utils/deepCopy";
 import { updateAuditLog } from "../../utils/auditLog";
 import { AuditLogAction } from "../../models/auditLog";
+import { recordAuditEvent } from "../../utils/auditLogV2";
 
 
 /**
@@ -46,6 +47,33 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
 			active: true,
+		});
+
+		await recordAuditEvent({
+			workspaceId: revisedUpdatedProduct.workspace_id.toString(),
+			scope: { type: 'product', id: insertedProduct.insertedId.toString() },
+			entity: { type: 'product', id: insertedProduct.insertedId.toString() },
+			action: 'create',
+			eventKey: 'product.version.created',
+			visibility: 'all',
+			where: { module: 'products' },
+			auth: auth.payload,
+			before: {
+				version: currentProduct.version,
+				is_latest: currentProduct.is_latest,
+				status: currentProduct.status,
+			},
+			after: {
+				version: revisedUpdatedProduct.version,
+				is_latest: revisedUpdatedProduct.is_latest,
+				status: revisedUpdatedProduct.status,
+			},
+			changedPaths: ['version', 'is_latest', 'status'],
+			meta: {
+				productName: revisedUpdatedProduct.product_name,
+				fromVersion: currentProduct.version,
+				toVersion: revisedUpdatedProduct.version,
+			},
 		});
 
 		return ResponseWrapper.created({

--- a/src/controllers/products/getAllProductVersions.ts
+++ b/src/controllers/products/getAllProductVersions.ts
@@ -6,6 +6,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { authenticateRequest } from '../../utils/authUtils';
 import { validateAllObjectIds } from '../../utils/validationUtils';
+import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 
 /**
  * Get all versions of a product
@@ -62,39 +63,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		// Find all versions with the same product_plan_number, sorted by version descending
 		const pipeline: any[] = [
 			{ $match: matchFilter },
-			{
-				$lookup: {
-					from: 'audit_log',
-					let: { productIdString: { $toString: '$_id' } },
-					pipeline: [
-						{
-							$match: {
-								$expr: {
-									$and: [
-										{ $eq: ['$entity', 'product'] },
-										{ $eq: ['$entityId', '$$productIdString'] },
-										{ $in: ['$action', ['create', 'update']] },
-										{ $eq: ['$active', true] }
-									]
-								}
-							}
-						},
-						{ $sort: { actionAt: -1 } },
-						{
-							$project: {
-								entity: 1,
-								entityId: 1,
-								action: 1,
-								actionBy: 1,
-								actionAt: 1,
-								active: 1
-							}
-						},
-						{ $limit: 2 }
-					],
-					as: 'auditLogs'
-				}
-			},
+			buildLegacyAuditLookupStage({
+				scopeType: 'product',
+				updateActions: ['update', 'submit', 'delete', 'move', 'link', 'unlink', 'restore'],
+			}),
 			{ $sort: { version: -1 } },
 			{ $skip: skip },
 			{ $limit: limit }

--- a/src/controllers/products/getAllProducts.ts
+++ b/src/controllers/products/getAllProducts.ts
@@ -5,6 +5,7 @@ import { Product } from '../../models/product';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { authenticateRequest } from '../../utils/authUtils';
+import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 
 /**
  * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
@@ -62,6 +63,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		// Build filter object
 		const filter: any = {};
+		let statusValues: string[] | null = null;
 
 		if (workspaceId) filter.workspace_id = new ObjectId(workspaceId);
 		
@@ -71,15 +73,20 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				const statusArray = JSON.parse(statusFilter);
 				if (Array.isArray(statusArray) && statusArray.length > 0) {
 					filter.status = { $in: statusArray };
+					statusValues = statusArray;
 				}
 			} catch (e) {
 				// If parsing fails, treat as single status
 				filter.status = statusFilter;
+				statusValues = [statusFilter];
 			}
 		} else {
 			// Default status filter
 			filter.status = { $in: ['draft', 'submitted'] };
+			statusValues = ['draft', 'submitted'];
 		}
+
+		const isArchiveOnlyStatus = statusValues?.length === 1 && statusValues[0] === 'archived';
 
 		// General filter parameter for text search
 		if (filterParam) {
@@ -97,39 +104,14 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const pipeline: any[] = [
 			{ $match: filter },
-			{
-				$lookup: {
-					from: 'audit_log',
-					let: { productIdString: { $toString: '$_id' } },
-					pipeline: [
-						{
-							$match: {
-								$expr: {
-									$and: [
-										{ $eq: ['$entity', 'product'] },
-										{ $eq: ['$entityId', '$$productIdString'] },
-										{ $in: ['$action', ['create', 'update']] },
-										{ $eq: ['$active', true] }
-									]
-								}
-							}
-						},
-						{ $sort: { actionAt: -1 } },
-						{
-							$project: {
-								entity: 1,
-								entityId: 1,
-								action: 1,
-								actionBy: 1,
-								actionAt: 1,
-								active: 1
-							}
-						},
-						{ $limit: 2 }
-					],
-					as: 'auditLogs'
-				}
-			},
+			buildLegacyAuditLookupStage(
+				isArchiveOnlyStatus
+					? { scopeType: 'product', mode: 'archive' }
+					: {
+						scopeType: 'product',
+						updateActions: ['update', 'submit', 'delete', 'move', 'link', 'unlink', 'restore'],
+					}
+			),
 			{
 				$lookup: {
 					from: 'departments',

--- a/src/controllers/products/getProductData.ts
+++ b/src/controllers/products/getProductData.ts
@@ -6,6 +6,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateEnum } from '../../utils/validationUtils';
 import { authenticateRequest } from '../../utils/authUtils';
+import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 
 /**
  * Get product data
@@ -60,39 +61,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const pipeline = [
 			{ $match: { _id: productObjectId } },
-			{
-				$lookup: {
-					from: 'audit_log',
-					let: { productIdString: { $toString: '$_id' } },
-					pipeline: [
-						{
-							$match: {
-								$expr: {
-									$and: [
-										{ $eq: ['$entity', 'product'] },
-										{ $eq: ['$entityId', '$$productIdString'] },
-										{ $in: ['$action', ['create', 'update']] },
-										{ $eq: ['$active', true] }
-									]
-								}
-							}
-						},
-						{ $sort: { actionAt: -1 } },
-						{
-							$project: {
-								entity: 1,
-								entityId: 1,
-								action: 1,
-								actionBy: 1,
-								actionAt: 1,
-								active: 1
-							}
-						},
-						{ $limit: 2 }
-					],
-					as: 'auditLogs'
-				}
-			}
+			buildLegacyAuditLookupStage({
+				scopeType: 'product',
+				updateActions: ['update', 'submit', 'delete', 'move', 'link', 'unlink', 'restore'],
+			}),
 		];
 
 		const products = await db.collection<Product>('products').aggregate(pipeline).toArray();

--- a/src/controllers/products/productData/compliance-standard.ts
+++ b/src/controllers/products/productData/compliance-standard.ts
@@ -14,7 +14,6 @@ type ComplianceStandardReturn = {
 		| (ComplianceStandard & { _id: string })[]
 		| DeleteComplianceStandardData
 		| UpdateComplianceTabCompletionData;
-	actionLog: string;
 	error: APIGatewayProxyResult | null;
 };
 
@@ -56,21 +55,18 @@ export function addComplianceStandard(
 			...standard,
 			_id: standard._id.toString(),
 		}));
-		const actionLog = 'CREATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: [],
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: [],
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to add compliance standards'),
 		};
 	}
@@ -116,21 +112,18 @@ export function updateComplianceStandard(
 		};
 
 		const updatedData = updatedComplianceStandard;
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: {} as ComplianceStandard & { id: string },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: {} as ComplianceStandard & { id: string },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update compliance standards'),
 		};
 	}
@@ -170,21 +163,17 @@ export function deleteComplianceStandard(
 			},
 		};
 
-		const actionLog = 'DELETE';
-
-		return { updateQuery, updatedData: standardId, actionLog, error: null };
+		return { updateQuery, updatedData: standardId, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: { id: '' },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: { id: '' },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to delete compliance standard'),
 		};
 	}
@@ -210,21 +199,18 @@ export function updateComplianceTabCompletion(
 
 		const updateQuery = { $set: { 'compliance_information.tab_completed': inputData.tab_completed } };
 		const updatedData = { tab_completed: inputData.tab_completed };
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: { tab_completed: false },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: { tab_completed: false },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update compliance tab completion'),
 		};
 	}

--- a/src/controllers/products/productData/label-components.ts
+++ b/src/controllers/products/productData/label-components.ts
@@ -7,7 +7,6 @@ import { ObjectId } from 'mongodb';
 type LabelComponentReturn = {
 	updateQuery: Record<string, unknown>;
 	updatedData: labelComponent | labelComponent[];
-	actionLog: string;
 	error: APIGatewayProxyResult | null;
 };
 
@@ -38,21 +37,18 @@ export function addLabelComponent(
 
 		const updateQuery = { $push: { 'label_components.data': { $each: componentsWithIds } } };
 		const updatedData = componentsWithIds;
-		const actionLog = 'CREATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: [],
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: [],
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to add label component'),
 		};
 	}
@@ -99,21 +95,18 @@ export function updateLabelComponent(
 			arrayFilters: [{ 'elem._id': new ObjectId(updatedLabelComponent.id) }],
 		};
 		const updatedData = updatedLabelComponent;
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: {} as labelComponent,
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: {} as labelComponent,
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update label component'),
 		};
 	}
@@ -154,21 +147,17 @@ export function deleteLabelComponent(
 			},
 		};
 
-		const actionLog = 'DELETE';
-
-		return { updateQuery, updatedData: deletedLabelComponent, actionLog, error: null };
+		return { updateQuery, updatedData: deletedLabelComponent, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: {} as labelComponent,
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: {} as labelComponent,
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update label component'),
 		};
 	}
@@ -194,21 +183,18 @@ export function updateLabelComponentTabCompletion(
 
 		const updateQuery = { $set: { 'label_components.tab_completed': inputData.tab_completed } };
 		const updatedData = { tab_completed: inputData.tab_completed };
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: { tab_completed: false },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: { tab_completed: false },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update label component tab completion'),
 		};
 	}

--- a/src/controllers/products/productData/label-tags.ts
+++ b/src/controllers/products/productData/label-tags.ts
@@ -7,7 +7,6 @@ import { ObjectId } from "mongodb";
 type LabelTagReturn = {
     updateQuery: Record<string, unknown>;
     updatedData: LabelTag | LabelTag[];
-    actionLog: string;
     error: APIGatewayProxyResult | null;
 }
 
@@ -37,21 +36,18 @@ export function addLabelTag(
 
 		const updateQuery = { $push: { 'label_tags.data': { $each: componentsWithIds } } }
 		const updatedData = componentsWithIds;
-		const actionLog = 'CREATE';
 
-		return { updateQuery, updatedData, actionLog, error: null }
+		return { updateQuery, updatedData, error: null }
 	} catch (error) {
 		if (error instanceof Error) return {
 			updateQuery: {},
 			updatedData: [],
-			actionLog: '',
 			error: ResponseWrapper.badRequest(error.message),
 		}
 
 		return {
 			updateQuery: {},
 			updatedData: [],
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to add label tag'),
 		}
 	}
@@ -91,13 +87,12 @@ export function updateLabelTag(
 		}, arrayFilters: [{'elem._id': new ObjectId(updatedLabelTag.id!)}]}
 
 		const updatedData = updatedLabelTag;
-		const actionLog = 'UPDATE';
 
-		return {updateQuery, updatedData, actionLog, error: null}
+		return {updateQuery, updatedData, error: null}
 	} catch (error) {
-		if(error instanceof Error) return {updateQuery:{}, updatedData: {} as LabelTag, actionLog: '', error: ResponseWrapper.badRequest(error.message)}
+		if(error instanceof Error) return {updateQuery:{}, updatedData: {} as LabelTag, error: ResponseWrapper.badRequest(error.message)}
 
-		return {updateQuery:{}, updatedData: {} as LabelTag, actionLog: '', error: ResponseWrapper.internalServerError('Failed to update label tag')}
+		return {updateQuery:{}, updatedData: {} as LabelTag, error: ResponseWrapper.internalServerError('Failed to update label tag')}
 	}
 }
 
@@ -134,21 +129,17 @@ export function deleteLabelTag(
 			},
 		};
 
-		const actionLog = 'DELETE';
-
-		return { updateQuery, updatedData: labelTagId, actionLog, error: null };
+		return { updateQuery, updatedData: labelTagId, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: { id: labelTagId.id },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: { id: labelTagId.id },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to delete label tag'),
 		};
 	}
@@ -174,21 +165,18 @@ export function updateLabelTagsTabCompletion(
 
 		const updateQuery = { $set: { 'label_tags.tab_completed': inputData.tab_completed } };
 		const updatedData = { tab_completed: inputData.tab_completed };
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: { tab_completed: false },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: { tab_completed: false },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update label tags tab completion'),
 		};
 	}
@@ -232,21 +220,18 @@ export function updateLabelTagTaggedImage(
 		};
 
 		const updatedData = { id: inputData.id, tagged_image: inputData.tagged_image, annotation_state: inputData.annotation_state };
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: { id: inputData.id, tagged_image: '', annotation_state: undefined },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: { id: inputData.id, tagged_image: '', annotation_state: undefined },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update label tag tagged image'),
 		};
 	}
@@ -291,21 +276,18 @@ export function updateLabelTagLegend(
 		};
 
 		const updatedData = { id: inputData.id, legend_items: inputData.legend_items };
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: { id: inputData.id, legend_items: [] },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: { id: inputData.id, legend_items: [] },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update label tag legend'),
 		};
 	}

--- a/src/controllers/products/productData/operational-parameters.ts
+++ b/src/controllers/products/productData/operational-parameters.ts
@@ -7,7 +7,6 @@ import { ObjectId } from 'mongodb';
 type OperationalParametersReturn = {
 	updateQuery: Record<string, unknown>;
 	updatedData: OperationalParameters;
-	actionLog: string;
 	error: APIGatewayProxyResult | null;
 };
 
@@ -37,15 +36,13 @@ export function addOperationalParameters(
 
 		const updateQuery = { $set: { 'operational_parameters.data': newOperationalParametersWithId } };
 		const updatedData = newOperationalParametersWithId;
-		const actionLog = 'CREATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error) {
 			return {
 				updateQuery: {},
 				updatedData: {},
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		}
@@ -53,7 +50,6 @@ export function addOperationalParameters(
 		return {
 			updateQuery: {},
 			updatedData: {},
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to add operational parameters'),
 		};
 	}
@@ -81,15 +77,13 @@ export function updateOperationalParameters(
 
 		const updateQuery = { $set: { 'operational_parameters.data': updatedOperationalParameters.workbook_data } };
 		const updatedData = updatedOperationalParameters;
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error) {
 			return {
 				updateQuery: {},
 				updatedData: {},
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		}
@@ -97,7 +91,6 @@ export function updateOperationalParameters(
 		return {
 			updateQuery: {},
 			updatedData: {},
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update operational parameters'),
 		};
 	}
@@ -122,21 +115,17 @@ export function deleteOperationalParameters(
 			$set: { 'operational_parameters.data': {} },
 		};
 
-		const actionLog = 'DELETE';
-
-		return { updateQuery, updatedData: {}, actionLog, error: null };
+		return { updateQuery, updatedData: {}, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: {},
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: {},
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to delete operational parameters'),
 		};
 	}
@@ -164,22 +153,19 @@ export function updateOperationalParametersTabCompletion(
 
 		const updateQuery = { $set: { 'operational_parameters.tab_completed': inputData.tab_completed } };
 		const updatedData = { tab_completed: inputData.tab_completed };
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error) {
 			return {
 				updateQuery: {},
 				updatedData: { tab_completed: false },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		}
 		return {
 			updateQuery: {},
 			updatedData: { tab_completed: false },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update operational parameters tab completion'),
 		};
 	}

--- a/src/controllers/products/productData/product-data.ts
+++ b/src/controllers/products/productData/product-data.ts
@@ -7,7 +7,6 @@ import { ObjectId } from 'mongodb';
 type ProductDataReturn = {
 	updateQuery: Record<string, unknown>;
 	updatedData: ProductData;
-	actionLog: string;
 	error: APIGatewayProxyResult | null;
 };
 
@@ -37,15 +36,13 @@ export function addProductData(
 
 		const updateQuery = { $set: { 'product_data.data': newProductDataWithId } };
 		const updatedData = newProductDataWithId;
-		const actionLog = 'CREATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error) {
 			return {
 				updateQuery: {},
 				updatedData: {},
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		}
@@ -53,7 +50,6 @@ export function addProductData(
 		return {
 			updateQuery: {},
 			updatedData: {},
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to add product data'),
 		};
 	}
@@ -81,15 +77,13 @@ export function updateProductData(
 
 		const updateQuery = { $set: { 'product_data.data': updatedProductData.workbook_data } };
 		const updatedData = updatedProductData;
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error) {
 			return {
 				updateQuery: {},
 				updatedData: {} as ProductData,
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		}
@@ -97,7 +91,6 @@ export function updateProductData(
 		return {
 			updateQuery: {},
 			updatedData: {} as ProductData,
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update product data'),
 		};
 	}
@@ -122,21 +115,17 @@ export function deleteProductData(
 			$set: { 'product_data.data': {} },
 		};
 
-		const actionLog = 'DELETE';
-
-		return { updateQuery, updatedData: {}, actionLog, error: null };
+		return { updateQuery, updatedData: {}, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: {},
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: {},
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to delete product data'),
 		};
 	}
@@ -164,22 +153,19 @@ export function updateProductDataTabCompletion(
 
 		const updateQuery = { $set: { 'product_data.tab_completed': inputData.tab_completed } };
 		const updatedData = { tab_completed: inputData.tab_completed };
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error) {
 			return {
 				updateQuery: {},
 				updatedData: { tab_completed: false },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		}
 		return {
 			updateQuery: {},
 			updatedData: { tab_completed: false },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update product data tab completion'),
 		};
 	}

--- a/src/controllers/products/productData/product-info.ts
+++ b/src/controllers/products/productData/product-info.ts
@@ -23,7 +23,6 @@ export function updateProductInformation(
 ): {
     updateQuery: Record<string, unknown>;
     updatedData: UpdateProductInformationData;
-    actionLog: string;
     error: APIGatewayProxyResult | null;
 } {
 	try {
@@ -62,12 +61,11 @@ export function updateProductInformation(
 	
 		const updateQuery = { $set: updateSet };
 		const updatedData = inputData;
-		const actionLog = 'UPDATE';
 	
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
-		if (error instanceof Error) return { updateQuery: {}, updatedData: {} as UpdateProductInformationData, actionLog: '', error: ResponseWrapper.badRequest(error.message) };
-		return { updateQuery: {}, updatedData: {} as UpdateProductInformationData, actionLog: '', error: ResponseWrapper.internalServerError('Failed to update product information') };
+		if (error instanceof Error) return { updateQuery: {}, updatedData: {} as UpdateProductInformationData, error: ResponseWrapper.badRequest(error.message) };
+		return { updateQuery: {}, updatedData: {} as UpdateProductInformationData, error: ResponseWrapper.internalServerError('Failed to update product information') };
 	}
 }
 
@@ -85,7 +83,6 @@ export function addCustomField(
 ): {
     updateQuery: Record<string, unknown>;
     updatedData: { customFields: CustomFieldInput[] };
-    actionLog: string;
     error: APIGatewayProxyResult | null;
 } {
 	try {
@@ -107,13 +104,12 @@ export function addCustomField(
 	
 		const updateQuery = { $push: { 'product_information.custom_fields': { $each: newCustomFields } } };
 		const updatedData = { customFields: newCustomFields };
-		const actionLog = 'CREATE';
 	
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
-		if (error instanceof Error) return { updateQuery: {}, updatedData: { customFields: [] }, actionLog: '', error: ResponseWrapper.badRequest(error.message) };
+		if (error instanceof Error) return { updateQuery: {}, updatedData: { customFields: [] }, error: ResponseWrapper.badRequest(error.message) };
 
-		return { updateQuery: {}, updatedData: { customFields: [] }, actionLog: '', error: ResponseWrapper.internalServerError('Failed to add custom field') };
+		return { updateQuery: {}, updatedData: { customFields: [] }, error: ResponseWrapper.internalServerError('Failed to add custom field') };
 	}
 }
 
@@ -131,7 +127,6 @@ export function updateCustomField(
 ): {
     updateQuery: Record<string, unknown>;
     updatedData: { customFields: CustomFieldInput[] };
-    actionLog: string;
     error: APIGatewayProxyResult | null;
 } {
 	try {
@@ -147,13 +142,12 @@ export function updateCustomField(
 	
 		const updateQuery = { $set: { 'product_information.custom_fields': validatedCustomFields } };
 		const updatedData = { customFields: inputData };
-		const actionLog = 'UPDATE';
 	
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
-		if (error instanceof Error) return { updateQuery: {}, updatedData: { customFields: [] }, actionLog: '', error: ResponseWrapper.badRequest(error.message) };
+		if (error instanceof Error) return { updateQuery: {}, updatedData: { customFields: [] }, error: ResponseWrapper.badRequest(error.message) };
 
-		return { updateQuery: {}, updatedData: { customFields: [] }, actionLog: '', error: ResponseWrapper.internalServerError('Failed to update custom field') };
+		return { updateQuery: {}, updatedData: { customFields: [] }, error: ResponseWrapper.internalServerError('Failed to update custom field') };
 	}
 }
 
@@ -171,7 +165,6 @@ export function deleteCustomField(
 ): {
     updateQuery: Record<string, unknown>;
     updatedData: { id: string };
-    actionLog: string;
     error: APIGatewayProxyResult | null;
 } {
 	try {
@@ -179,17 +172,16 @@ export function deleteCustomField(
 		if (isValidTabDeleteCustomField) throw new Error(isValidTabDeleteCustomField.body);
 	
 		const validatedFieldId = validateAllObjectIds({ id: inputData.id });
-		if (validatedFieldId) return { updateQuery: {}, updatedData: { id: '' }, actionLog: '', error: validatedFieldId };
+		if (validatedFieldId) return { updateQuery: {}, updatedData: { id: '' }, error: validatedFieldId };
 	
 		const updateQuery = { $pull: { 'product_information.custom_fields': { _id: new ObjectId(inputData.id) } } };
 		const updatedData = { id: inputData.id };
-		const actionLog = 'DELETE';
 	
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
-		if (error instanceof Error) return { updateQuery: {}, updatedData: { id: '' }, actionLog: '', error: ResponseWrapper.badRequest(error.message) };
+		if (error instanceof Error) return { updateQuery: {}, updatedData: { id: '' }, error: ResponseWrapper.badRequest(error.message) };
 
-		return { updateQuery: {}, updatedData: { id: '' }, actionLog: '', error: ResponseWrapper.internalServerError('Failed to delete custom field') };
+		return { updateQuery: {}, updatedData: { id: '' }, error: ResponseWrapper.internalServerError('Failed to delete custom field') };
 	}
 }
 
@@ -207,7 +199,6 @@ export function updateProductInfoTabCompletion(
 ): {
     updateQuery: Record<string, unknown>;
     updatedData: { tab_completed: boolean };
-    actionLog: string;
     error: APIGatewayProxyResult | null;
 } {
 	try {
@@ -218,12 +209,11 @@ export function updateProductInfoTabCompletion(
 	
 		const updateQuery = { $set: { 'product_information.tab_completed': inputData.tab_completed } };
 		const updatedData = { tab_completed: inputData.tab_completed };
-		const actionLog = 'UPDATE';
 	
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
-		if (error instanceof Error) return { updateQuery: {}, updatedData: { tab_completed: false }, actionLog: '', error: ResponseWrapper.badRequest(error.message) };
+		if (error instanceof Error) return { updateQuery: {}, updatedData: { tab_completed: false }, error: ResponseWrapper.badRequest(error.message) };
 		
-		return { updateQuery: {}, updatedData: { tab_completed: false }, actionLog: '', error: ResponseWrapper.internalServerError('Failed to update product information tab completion') };
+		return { updateQuery: {}, updatedData: { tab_completed: false }, error: ResponseWrapper.internalServerError('Failed to update product information tab completion') };
 	}
 }

--- a/src/controllers/products/productData/symbols-graphics.ts
+++ b/src/controllers/products/productData/symbols-graphics.ts
@@ -7,7 +7,6 @@ import { ObjectId } from "mongodb";
 type SymbolsGraphicsReturn = {
     updateQuery: Record<string, unknown>;
     updatedData: SymbolsGraphics | SymbolsGraphics[];
-    actionLog: string;
     error: APIGatewayProxyResult | null;
 }
 
@@ -35,21 +34,18 @@ export function AddSymbolsGraphics(
         
 		const updateQuery = {$push: {'symbols_graphics.data': {$each: componentsWithIds}}}
 		const updatedData = componentsWithIds;
-		const actionLog = 'CREATE';
 
-		return { updateQuery, updatedData, actionLog, error: null }
+		return { updateQuery, updatedData, error: null }
 	} catch (error) {
 		if (error instanceof Error) return {
 			updateQuery: {},
 			updatedData: [],
-			actionLog: '',
 			error: ResponseWrapper.badRequest(error.message),
 		}
 
 		return {
 			updateQuery: {},
 			updatedData: [],
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to add symbols and graphics'),
 		}
 	}
@@ -107,13 +103,12 @@ export function UpdateSymbolsGraphics(
 		const updateQuery = {$set: updateSet, arrayFilters: [{'elem._id': new ObjectId(updatedSymbolsGraphics.id!)}]}
 
 		const updatedData = updatedSymbolsGraphics;
-		const actionLog = 'UPDATE';
 
-		return {updateQuery, updatedData, actionLog, error: null}
+		return {updateQuery, updatedData, error: null}
 	} catch (error) {
-		if(error instanceof Error) return {updateQuery:{}, updatedData: {} as SymbolsGraphics, actionLog: '', error: ResponseWrapper.badRequest(error.message)}
+		if(error instanceof Error) return {updateQuery:{}, updatedData: {} as SymbolsGraphics, error: ResponseWrapper.badRequest(error.message)}
 
-		return {updateQuery:{}, updatedData: {} as SymbolsGraphics, actionLog: '', error: ResponseWrapper.internalServerError('Failed to update symbols and graphics')}
+		return {updateQuery:{}, updatedData: {} as SymbolsGraphics, error: ResponseWrapper.internalServerError('Failed to update symbols and graphics')}
 	}
 }
 
@@ -150,21 +145,17 @@ export function deleteSymbolsGraphics(
 			},
 		};
 
-		const actionLog = 'DELETE';
-
-		return { updateQuery, updatedData: SymbolsGraphicsId, actionLog, error: null };
+		return { updateQuery, updatedData: SymbolsGraphicsId, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: { id: '' },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: { id: '' },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to delete symbols graphics'),
 		};
 	}
@@ -190,21 +181,18 @@ export function updateSymbolsGraphicsTabCompletion(
 
 		const updateQuery = { $set: { 'symbols_graphics.tab_completed': inputData.tab_completed } };
 		const updatedData = { tab_completed: inputData.tab_completed };
-		const actionLog = 'UPDATE';
 
-		return { updateQuery, updatedData, actionLog, error: null };
+		return { updateQuery, updatedData, error: null };
 	} catch (error) {
 		if (error instanceof Error)
 			return {
 				updateQuery: {},
 				updatedData: { tab_completed: false },
-				actionLog: '',
 				error: ResponseWrapper.badRequest(error.message),
 			};
 		return {
 			updateQuery: {},
 			updatedData: { tab_completed: false },
-			actionLog: '',
 			error: ResponseWrapper.internalServerError('Failed to update symbols graphics tab completion'),
 		};
 	}

--- a/src/controllers/products/updateProduct.ts
+++ b/src/controllers/products/updateProduct.ts
@@ -7,6 +7,7 @@ import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { authenticateRequest, authenticateWithRole } from '../../utils/authUtils';
+import { recordAuditEvent } from '../../utils/auditLogV2';
 
 /**
  * @param {APIGatewayProxyEvent} event - API Gateway Lambda Proxy Input Format
@@ -113,6 +114,41 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const updatedProduct = await db.collection<Product>('products').findOne({
 			_id: productObjectId,
+		});
+
+		let eventKey = 'product.updated';
+		let auditAction: 'update' | 'submit' | 'archive' | 'restore' = 'update';
+		let visibility: 'all' | 'admin' = 'all';
+
+		if (input.action === 'update-status') {
+			visibility = 'admin';
+			if (input.data.status === 'submitted') {
+				eventKey = 'product.submitted';
+				auditAction = 'submit';
+			} else if (input.data.status === 'archived') {
+				eventKey = 'product.archived';
+				auditAction = 'archive';
+			} else {
+				eventKey = 'product.restored';
+				auditAction = 'restore';
+			}
+		}
+
+		await recordAuditEvent({
+			workspaceId: existingProduct.workspace_id.toString(),
+			scope: { type: 'product', id: productId },
+			entity: { type: 'product', id: productId },
+			action: auditAction,
+			eventKey,
+			visibility,
+			where: { module: 'products' },
+			auth: auth.payload,
+			before: existingProduct as unknown as Record<string, unknown>,
+			after: (updatedProduct ?? existingProduct) as unknown as Record<string, unknown>,
+			changedPaths: Object.keys(updateData),
+			meta: {
+				productName: (updatedProduct?.product_name ?? existingProduct.product_name),
+			},
 		});
 
 		return ResponseWrapper.success({

--- a/src/controllers/products/updateProduct.ts
+++ b/src/controllers/products/updateProduct.ts
@@ -1,8 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import type { Product } from '../../models/product';
-import { AuditLogAction } from '../../models/auditLog';
-import { updateAuditLog } from '../../utils/auditLog';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
@@ -102,15 +100,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (result.matchedCount === 0) {
 			return ResponseWrapper.notFound('Product not found');
 		}
-
-		await updateAuditLog({
-			entity: 'product',
-			entityId: productId,
-			action: AuditLogAction.UPDATE,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		});
 
 		const updatedProduct = await db.collection<Product>('products').findOne({
 			_id: productObjectId,

--- a/src/controllers/products/updateProductData.ts
+++ b/src/controllers/products/updateProductData.ts
@@ -22,6 +22,7 @@ import { addProductData, deleteProductData, updateProductData, updateProductData
 import { addOperationalParameters, deleteOperationalParameters, updateOperationalParameters, updateOperationalParametersTabCompletion } from './productData/operational-parameters';
 import { addLabelTag, deleteLabelTag, updateLabelTag, updateLabelTagsTabCompletion, updateLabelTagTaggedImage, updateLabelTagLegend } from './productData/label-tags';
 import { SymbolsGraphics } from '../../types/products/symbols-graphics';
+import { recordAuditEvent } from '../../utils/auditLogV2';
 
 const validTabs = [
 	'product-information',
@@ -32,6 +33,181 @@ const validTabs = [
 	'operational-parameters',
 	'label-tags',
 ];
+
+type ProductDataAuditMeta = {
+	eventKey: string;
+	action: 'create' | 'update' | 'delete';
+	changedPaths: string[];
+};
+
+const PRODUCT_DATA_ACTION_AUDIT_META: Record<string, ProductDataAuditMeta> = {
+	update_product_information: {
+		eventKey: 'product.product_information.updated',
+		action: 'update',
+		changedPaths: [
+			'product_name',
+			'product_plan_number',
+			'product_description',
+			'target_date',
+			'actual_completion_date',
+			'product_information.data.market_geography',
+			'product_information.data.country_of_origin',
+			'product_information.data.oem_contract_manufacturer',
+			'product_information.data.commercial_clinical',
+			'product_information.data.manufacturing_location',
+		],
+	},
+	add_custom_field: {
+		eventKey: 'product.product_information.custom_field.added',
+		action: 'create',
+		changedPaths: ['product_information.custom_fields'],
+	},
+	update_custom_field: {
+		eventKey: 'product.product_information.custom_field.updated',
+		action: 'update',
+		changedPaths: ['product_information.custom_fields'],
+	},
+	delete_custom_field: {
+		eventKey: 'product.product_information.custom_field.deleted',
+		action: 'delete',
+		changedPaths: ['product_information.custom_fields'],
+	},
+	update_product_information_completion: {
+		eventKey: 'product.product_information.completion.updated',
+		action: 'update',
+		changedPaths: ['product_information.tab_completed'],
+	},
+	add_compliance_standard: {
+		eventKey: 'product.compliance_item.added',
+		action: 'create',
+		changedPaths: ['compliance_information.data'],
+	},
+	update_compliance_standard: {
+		eventKey: 'product.compliance_item.updated',
+		action: 'update',
+		changedPaths: ['compliance_information.data'],
+	},
+	delete_compliance_standard: {
+		eventKey: 'product.compliance_item.deleted',
+		action: 'delete',
+		changedPaths: ['compliance_information.data'],
+	},
+	update_compliance_tab_completion: {
+		eventKey: 'product.compliance_information.completion.updated',
+		action: 'update',
+		changedPaths: ['compliance_information.tab_completed'],
+	},
+	add_label_component: {
+		eventKey: 'product.label_component.added',
+		action: 'create',
+		changedPaths: ['label_components.data'],
+	},
+	update_label_component: {
+		eventKey: 'product.label_component.updated',
+		action: 'update',
+		changedPaths: ['label_components.data'],
+	},
+	delete_label_component: {
+		eventKey: 'product.label_component.deleted',
+		action: 'delete',
+		changedPaths: ['label_components.data'],
+	},
+	update_label_component_tab_completion: {
+		eventKey: 'product.label_components.completion.updated',
+		action: 'update',
+		changedPaths: ['label_components.tab_completed'],
+	},
+	add_symbols_graphics: {
+		eventKey: 'product.symbol_graphic.added',
+		action: 'create',
+		changedPaths: ['symbols_graphics.data'],
+	},
+	update_symbols_graphics: {
+		eventKey: 'product.symbol_graphic.updated',
+		action: 'update',
+		changedPaths: ['symbols_graphics.data'],
+	},
+	delete_symbols_graphics: {
+		eventKey: 'product.symbol_graphic.deleted',
+		action: 'delete',
+		changedPaths: ['symbols_graphics.data'],
+	},
+	update_symbols_graphics_tab_completion: {
+		eventKey: 'product.symbol_graphics.completion.updated',
+		action: 'update',
+		changedPaths: ['symbols_graphics.tab_completed'],
+	},
+	add_product_data: {
+		eventKey: 'product.product_specification.added',
+		action: 'create',
+		changedPaths: ['product_data.data.workbook_data'],
+	},
+	update_product_data: {
+		eventKey: 'product.product_specification.updated',
+		action: 'update',
+		changedPaths: ['product_data.data.workbook_data'],
+	},
+	delete_product_data: {
+		eventKey: 'product.product_specification.deleted',
+		action: 'delete',
+		changedPaths: ['product_data.data'],
+	},
+	update_product_data_tab_completion: {
+		eventKey: 'product.product_specifications.completion.updated',
+		action: 'update',
+		changedPaths: ['product_data.tab_completed'],
+	},
+	add_operational_parameters: {
+		eventKey: 'product.operational_parameter.added',
+		action: 'create',
+		changedPaths: ['operational_parameters.data.workbook_data'],
+	},
+	update_operational_parameters: {
+		eventKey: 'product.operational_parameter.updated',
+		action: 'update',
+		changedPaths: ['operational_parameters.data.workbook_data'],
+	},
+	delete_operational_parameters: {
+		eventKey: 'product.operational_parameter.deleted',
+		action: 'delete',
+		changedPaths: ['operational_parameters.data'],
+	},
+	update_operational_parameters_tab_completion: {
+		eventKey: 'product.operational_parameters.completion.updated',
+		action: 'update',
+		changedPaths: ['operational_parameters.tab_completed'],
+	},
+	add_label_tags: {
+		eventKey: 'product.label_tag.added',
+		action: 'create',
+		changedPaths: ['label_tags.data'],
+	},
+	update_label_tags: {
+		eventKey: 'product.label_tag.updated',
+		action: 'update',
+		changedPaths: ['label_tags.data'],
+	},
+	delete_label_tags: {
+		eventKey: 'product.label_tag.deleted',
+		action: 'delete',
+		changedPaths: ['label_tags.data'],
+	},
+	update_label_tag_tagged_image: {
+		eventKey: 'product.label_tag.tagged_image.updated',
+		action: 'update',
+		changedPaths: ['label_tags.data'],
+	},
+	update_label_tag_legend: {
+		eventKey: 'product.label_tag.legend.updated',
+		action: 'update',
+		changedPaths: ['label_tags.data'],
+	},
+	update_label_tags_tab_completion: {
+		eventKey: 'product.label_tags.completion.updated',
+		action: 'update',
+		changedPaths: ['label_tags.tab_completed'],
+	},
+};
 
 
 /**
@@ -404,9 +580,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		const auditLog: AuditLog = {
-			entity: 'Product',
+			entity: 'product',
 			entityId: input.id,
-			action: actionLog as AuditLog['action'],
+			action: actionLog.toLowerCase() as AuditLog['action'],
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
 			active: true,
@@ -428,6 +604,37 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		await updateAuditLog(auditLog);
+
+		const updatedProduct = await db.collection<Product>('products').findOne({ _id: new ObjectId(input.id) });
+		const auditMeta = PRODUCT_DATA_ACTION_AUDIT_META[input.action];
+
+		if (updatedProduct && auditMeta) {
+			const payloadMeta: Record<string, unknown> = {
+				productName: updatedProduct.product_name,
+				tab: input.tab,
+			};
+
+			if (typeof input.data === 'object' && input.data) {
+				if ('tab_completed' in (input.data as Record<string, unknown>)) {
+					payloadMeta.tabCompleted = (input.data as Record<string, unknown>).tab_completed;
+				}
+			}
+
+			await recordAuditEvent({
+				workspaceId: updatedProduct.workspace_id.toString(),
+				scope: { type: 'product', id: input.id },
+				entity: { type: 'product', id: input.id },
+				action: auditMeta.action,
+				eventKey: auditMeta.eventKey,
+				visibility: 'all',
+				where: { module: 'products', tab: input.tab },
+				auth: auth.payload,
+				before: product as unknown as Record<string, unknown>,
+				after: updatedProduct as unknown as Record<string, unknown>,
+				changedPaths: auditMeta.changedPaths,
+				meta: payloadMeta,
+			});
+		}
 
 		return ResponseWrapper.success({
 			message: 'Product updated successfully',

--- a/src/controllers/products/updateProductData.ts
+++ b/src/controllers/products/updateProductData.ts
@@ -4,9 +4,7 @@ import { validateAllObjectIds, validateMissingFields } from '../../utils/validat
 import { getDb } from '../../utils/db';
 import { Product } from '../../models/product';
 import { ObjectId } from 'mongodb';
-import { AuditLog } from '../../models/auditLog';
 import { authenticateRequest } from '../../utils/authUtils';
-import { updateAuditLog } from '../../utils/auditLog';
 import {
 	addCustomField,
 	deleteCustomField,
@@ -251,14 +249,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		let updateQuery = {};
 		let updatedData = {};
-		let actionLog = '';
 
 		switch (input.action) {
 		case 'update_product_information':
 			const result = updateProductInformation(input.data, input.tab, input.action);
 			if (result.error) return result.error;
 
-			({ updateQuery, updatedData, actionLog } = result);
+			({ updateQuery, updatedData } = result);
 
 			break;
 
@@ -266,7 +263,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const addCustomFieldResult = addCustomField(input.data, input.tab, input.action);
 			if (addCustomFieldResult.error) return addCustomFieldResult.error;
 
-			({ updateQuery, updatedData, actionLog } = addCustomFieldResult);
+			({ updateQuery, updatedData } = addCustomFieldResult);
 
 			break;
 
@@ -274,7 +271,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateCustomFieldResult = updateCustomField(input.data, input.tab, input.action);
 			if (updateCustomFieldResult.error) return updateCustomFieldResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateCustomFieldResult);
+			({ updateQuery, updatedData } = updateCustomFieldResult);
 
 			break;
 
@@ -282,7 +279,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const deleteCustomFieldResult = deleteCustomField(input.data, input.tab, input.action);
 			if (deleteCustomFieldResult.error) return deleteCustomFieldResult.error;
 
-			({ updateQuery, updatedData, actionLog } = deleteCustomFieldResult);
+			({ updateQuery, updatedData } = deleteCustomFieldResult);
 
 			break;
 
@@ -290,7 +287,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateTabCompletionResult = updateProductInfoTabCompletion(input.data, input.tab, input.action);
 			if (updateTabCompletionResult.error) return updateTabCompletionResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateTabCompletionResult);
+			({ updateQuery, updatedData } = updateTabCompletionResult);
 
 			break;
 
@@ -298,7 +295,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const addComplianceStandardResult = addComplianceStandard(input.data, input.tab, input.action);
 			if (addComplianceStandardResult.error) return addComplianceStandardResult.error;
 
-			({ updateQuery, updatedData, actionLog } = addComplianceStandardResult);
+			({ updateQuery, updatedData } = addComplianceStandardResult);
 
 			break;
 
@@ -306,7 +303,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateComplianceStandardResult = updateComplianceStandard(input.data, input.tab, input.action);
 			if (updateComplianceStandardResult.error) return updateComplianceStandardResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateComplianceStandardResult);
+			({ updateQuery, updatedData } = updateComplianceStandardResult);
 
 			break;
 
@@ -314,7 +311,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const deleteComplianceStandardResult = deleteComplianceStandard(input.data, input.tab, input.action);
 			if (deleteComplianceStandardResult.error) return deleteComplianceStandardResult.error;
 
-			({ updateQuery, actionLog } = deleteComplianceStandardResult);
+			({ updateQuery } = deleteComplianceStandardResult);
 			updatedData = input.data;
 
 			break;
@@ -323,7 +320,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateComplianceTabCompletionResult = updateComplianceTabCompletion(input.data, input.tab, input.action);
 			if (updateComplianceTabCompletionResult.error) return updateComplianceTabCompletionResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateComplianceTabCompletionResult);
+			({ updateQuery, updatedData } = updateComplianceTabCompletionResult);
 
 			break;
 
@@ -337,7 +334,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			});
 			if (isDuplicateAddLabelComponent) return ResponseWrapper.conflict('Component number already exists, please use a different component number.');
 
-			({ updateQuery, updatedData, actionLog } = addLabelComponentResult);
+			({ updateQuery, updatedData } = addLabelComponentResult);
 
 			break;
 
@@ -356,7 +353,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			});
 			if (isDuplicateUpdateLabelComponent) return ResponseWrapper.conflict('Component number already exists, please use a different component number.');
 
-			({ updateQuery, updatedData, actionLog } = updateLabelComponentResult);
+			({ updateQuery, updatedData } = updateLabelComponentResult);
 
 			break;
 
@@ -364,7 +361,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const deleteLabelComponentResult = deleteLabelComponent(input.data, input.tab, input.action);
 			if (deleteLabelComponentResult.error) return deleteLabelComponentResult.error;
 
-			({ updateQuery, updatedData, actionLog } = deleteLabelComponentResult);
+			({ updateQuery, updatedData } = deleteLabelComponentResult);
 
 			break;
 
@@ -372,7 +369,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateLabelComponentTabCompletionResult = updateLabelComponentTabCompletion(input.data, input.tab, input.action);
 			if (updateLabelComponentTabCompletionResult.error) return updateLabelComponentTabCompletionResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateLabelComponentTabCompletionResult);
+			({ updateQuery, updatedData } = updateLabelComponentTabCompletionResult);
 
 			break;
 		case 'add_symbols_graphics': {
@@ -405,7 +402,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				if (isDuplicategraphics) return ResponseWrapper.conflict('Graphics description already exists, please use a different graphics description.');
 			}
 
-			({ updateQuery, updatedData, actionLog } = addSymbolsGraphicsResult);
+			({ updateQuery, updatedData } = addSymbolsGraphicsResult);
 
 			break;
 		}
@@ -442,7 +439,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				if (isDuplicategraphics) return ResponseWrapper.conflict('Graphics description already exists, please use a different graphics description.');
 			}
 
-			({ updateQuery, updatedData, actionLog } = updateSymbolsGraphicsResult);
+			({ updateQuery, updatedData } = updateSymbolsGraphicsResult);
 
 			break;
 		}
@@ -451,7 +448,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const deleteSymbolsGraphicsResult = deleteSymbolsGraphics(input.data, input.tab, input.action);
 			if (deleteSymbolsGraphicsResult.error) return deleteSymbolsGraphicsResult.error;
 
-			({ updateQuery, updatedData, actionLog } = deleteSymbolsGraphicsResult);
+			({ updateQuery, updatedData } = deleteSymbolsGraphicsResult);
 
 			break;
 
@@ -459,7 +456,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateSymbolsGraphicsTabCompletionResult = updateSymbolsGraphicsTabCompletion(input.data, input.tab, input.action);
 			if (updateSymbolsGraphicsTabCompletionResult.error) return updateSymbolsGraphicsTabCompletionResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateSymbolsGraphicsTabCompletionResult);
+			({ updateQuery, updatedData } = updateSymbolsGraphicsTabCompletionResult);
 
 			break;
 
@@ -467,7 +464,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const addProductDataResult = addProductData(input.data, input.tab, input.action);
 			if (addProductDataResult.error) return addProductDataResult.error;
 
-			({ updateQuery, updatedData, actionLog } = addProductDataResult);
+			({ updateQuery, updatedData } = addProductDataResult);
 
 			break;
 
@@ -475,7 +472,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateProductDataResult = updateProductData(input.data, input.tab, input.action);
 			if (updateProductDataResult.error) return updateProductDataResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateProductDataResult);
+			({ updateQuery, updatedData } = updateProductDataResult);
 
 			break;
 
@@ -483,7 +480,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const deleteProductDataResult = deleteProductData(input.tab, input.action);
 			if (deleteProductDataResult.error) return deleteProductDataResult.error;
 
-			({ updateQuery, updatedData, actionLog } = deleteProductDataResult);
+			({ updateQuery, updatedData } = deleteProductDataResult);
 
 			break;
 
@@ -491,7 +488,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateProductDataTabCompletionResult = updateProductDataTabCompletion(input.data, input.tab, input.action);
 			if (updateProductDataTabCompletionResult.error) return updateProductDataTabCompletionResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateProductDataTabCompletionResult);
+			({ updateQuery, updatedData } = updateProductDataTabCompletionResult);
 
 			break;
 
@@ -499,7 +496,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const addOperationalParametersResult = addOperationalParameters(input.data, input.tab, input.action);
 			if (addOperationalParametersResult.error) return addOperationalParametersResult.error;
 
-			({ updateQuery, updatedData, actionLog } = addOperationalParametersResult);
+			({ updateQuery, updatedData } = addOperationalParametersResult);
 
 			break;
 
@@ -507,7 +504,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateOperationalParametersResult = updateOperationalParameters(input.data, input.tab, input.action);
 			if (updateOperationalParametersResult.error) return updateOperationalParametersResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateOperationalParametersResult);
+			({ updateQuery, updatedData } = updateOperationalParametersResult);
 
 			break;
 
@@ -515,7 +512,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const deleteOperationalParametersResult = deleteOperationalParameters(input.tab, input.action);
 			if (deleteOperationalParametersResult.error) return deleteOperationalParametersResult.error;
 
-			({ updateQuery, updatedData, actionLog } = deleteOperationalParametersResult);
+			({ updateQuery, updatedData } = deleteOperationalParametersResult);
 
 			break;
 
@@ -523,7 +520,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateOperationalParametersTabCompletionResult = updateOperationalParametersTabCompletion(input.data, input.tab, input.action);
 			if (updateOperationalParametersTabCompletionResult.error) return updateOperationalParametersTabCompletionResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateOperationalParametersTabCompletionResult);
+			({ updateQuery, updatedData } = updateOperationalParametersTabCompletionResult);
 
 			break;
 
@@ -531,7 +528,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const addLabelTagResult = addLabelTag(input.data, input.tab, input.action);
 			if (addLabelTagResult.error) return addLabelTagResult.error;
 
-			({ updateQuery, updatedData, actionLog } = addLabelTagResult);
+			({ updateQuery, updatedData } = addLabelTagResult);
 
 			break;
 
@@ -539,7 +536,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateLabelTagResult = updateLabelTag(input.data, input.tab, input.action);
 			if (updateLabelTagResult.error) return updateLabelTagResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateLabelTagResult);
+			({ updateQuery, updatedData } = updateLabelTagResult);
 
 			break;
 
@@ -547,7 +544,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const deleteLabelTagResult = deleteLabelTag(input.data, input.tab, input.action);
 			if (deleteLabelTagResult.error) return deleteLabelTagResult.error;
 
-			({ updateQuery, updatedData, actionLog } = deleteLabelTagResult);
+			({ updateQuery, updatedData } = deleteLabelTagResult);
 
 			break;
 
@@ -555,7 +552,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateLabelTagsTabCompletionResult = updateLabelTagsTabCompletion(input.data, input.tab, input.action);
 			if (updateLabelTagsTabCompletionResult.error) return updateLabelTagsTabCompletionResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateLabelTagsTabCompletionResult);
+			({ updateQuery, updatedData } = updateLabelTagsTabCompletionResult);
 
 			break;
 
@@ -563,7 +560,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateLabelTagTaggedImageResult = updateLabelTagTaggedImage(input.data, input.tab, input.action);
 			if (updateLabelTagTaggedImageResult.error) return updateLabelTagTaggedImageResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateLabelTagTaggedImageResult);
+			({ updateQuery, updatedData } = updateLabelTagTaggedImageResult);
 
 			break;
 
@@ -571,22 +568,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const updateLabelTagLegendResult = updateLabelTagLegend(input.data, input.tab, input.action);
 			if (updateLabelTagLegendResult.error) return updateLabelTagLegendResult.error;
 
-			({ updateQuery, updatedData, actionLog } = updateLabelTagLegendResult);
+			({ updateQuery, updatedData } = updateLabelTagLegendResult);
 
 			break;
 
 		default:
 			return ResponseWrapper.badRequest('Invalid action');
 		}
-
-		const auditLog: AuditLog = {
-			entity: 'product',
-			entityId: input.id,
-			action: actionLog.toLowerCase() as AuditLog['action'],
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		};
 
 		const options: { arrayFilters?: any[] } = {};
 		if ('arrayFilters' in updateQuery) {
@@ -602,8 +590,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				'Product data not modified successfully, please check the data and try again.',
 			);
 		}
-
-		await updateAuditLog(auditLog);
 
 		const updatedProduct = await db.collection<Product>('products').findOne({ _id: new ObjectId(input.id) });
 		const auditMeta = PRODUCT_DATA_ACTION_AUDIT_META[input.action];

--- a/src/controllers/projects/archiveProject.ts
+++ b/src/controllers/projects/archiveProject.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { authenticateWithRole } from '../../utils/authUtils';
 import { validateBoolean } from '../../utils/validationUtils';
+import { recordAuditEvent } from '../../utils/auditLogV2';
 
 /**
  * Archive a project
@@ -71,6 +72,23 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
 			active: true,
+		});
+
+		await recordAuditEvent({
+			workspaceId: projectRecord.workspace_id.toString(),
+			scope: { type: 'project', id: event.pathParameters.id },
+			entity: { type: 'project', id: event.pathParameters.id },
+			action: isArchived ? 'archive' : 'restore',
+			eventKey: isArchived ? 'project.archived' : 'project.restored',
+			visibility: 'admin',
+			where: { module: 'projects' },
+			auth: auth.payload,
+			before: { isArchived: projectRecord.isArchived },
+			after: { isArchived },
+			changedPaths: ['isArchived'],
+			meta: {
+				projectName: projectRecord.project_name,
+			},
 		});
 
 		return ResponseWrapper.success({

--- a/src/controllers/projects/archiveProject.ts
+++ b/src/controllers/projects/archiveProject.ts
@@ -1,8 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import type { Project } from '../../models/project';
-import { AuditLogAction } from '../../models/auditLog';
-import { updateAuditLog } from '../../utils/auditLog';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
@@ -62,17 +60,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				},
 			},
 		);
-
-		const action = isArchived ? AuditLogAction.ARCHIVE : AuditLogAction.UNARCHIVE;
-
-		await updateAuditLog({
-			entity: 'project',
-			entityId: event.pathParameters.id,
-			action: action,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		});
 
 		await recordAuditEvent({
 			workspaceId: projectRecord.workspace_id.toString(),

--- a/src/controllers/projects/createProject.ts
+++ b/src/controllers/projects/createProject.ts
@@ -1,8 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import type { Project } from '../../models/project';
-import { AuditLogAction } from '../../models/auditLog';
-import { updateAuditLog } from '../../utils/auditLog';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
@@ -82,15 +80,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			users: userObjectIds,
 			isArchived: false,
 			image: input.image,
-		});
-
-		await updateAuditLog({
-			entity: 'project',
-			entityId: project.insertedId.toString(),
-			action: AuditLogAction.CREATE,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
 		});
 
 		await recordAuditEvent({

--- a/src/controllers/projects/createProject.ts
+++ b/src/controllers/projects/createProject.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
 import { authenticateWithRole } from '../../utils/authUtils';
+import { recordAuditEvent } from '../../utils/auditLogV2';
 
 /**
  * Create a project
@@ -90,6 +91,27 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
 			active: true,
+		});
+
+		await recordAuditEvent({
+			workspaceId: workspaceObjectId.toString(),
+			scope: { type: 'project', id: project.insertedId.toString() },
+			entity: { type: 'project', id: project.insertedId.toString() },
+			action: 'create',
+			eventKey: 'project.created',
+			visibility: 'admin',
+			where: { module: 'projects' },
+			auth: auth.payload,
+			after: {
+				project_name: input.project_name,
+				project_number: input.project_number,
+				project_description: input.project_description,
+				project_manager: input.project_manager,
+			},
+			changedPaths: ['project_name', 'project_number', 'project_description', 'project_manager'],
+			meta: {
+				projectName: input.project_name,
+			},
 		});
 
 		return ResponseWrapper.created({

--- a/src/controllers/projects/getAllProjects.ts
+++ b/src/controllers/projects/getAllProjects.ts
@@ -5,6 +5,7 @@ import { Project } from '../../models/project';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { authenticateRequest } from '../../utils/authUtils';
+import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 
 /**
  * Get all projects
@@ -71,6 +72,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		// If sorting by actionAt, use aggregation to join with audit_logs
 		if (sort === 'actionAt') {
+			const projectAuditLookupStage = isArchive
+				? buildLegacyAuditLookupStage({ scopeType: 'project', mode: 'archive' })
+				: buildLegacyAuditLookupStage({ scopeType: 'project', updateActions: ['update', 'restore'] });
+
 			// aggregation pipeline
 			const pipeline = [
 				{ $match: filter },
@@ -92,39 +97,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 						as: 'users',
 					},
 				},
-				{
-					$lookup: {
-						from: 'audit_log',
-						let: { projectIdString: { $toString: '$_id' } },
-						pipeline: [
-							{
-								$match: {
-									$expr: {
-										$and: [
-											{ $eq: ['$entity', 'project'] },
-											{ $eq: ['$entityId', '$$projectIdString'] },
-											{ $in: ['$action', ['create', 'update']] },
-											{ $eq: ['$active', true] }
-										]
-									}
-								}
-							},
-							{ $sort: { actionAt: -1 } },
-							{
-								$project: {
-									entity: 1,
-									entityId: 1,
-									action: 1,
-									actionBy: 1,
-									actionAt: 1,
-									active: 1
-								}
-							},
-							{ $limit: 2 }
-						],
-						as: 'auditLogs'
-					}
-				},
+				projectAuditLookupStage,
 			];
 
 			// Get total count for pagination

--- a/src/controllers/projects/getProject.ts
+++ b/src/controllers/projects/getProject.ts
@@ -5,6 +5,7 @@ import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { authenticateRequest } from '../../utils/authUtils';
+import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 
 /**
  * Get a project
@@ -51,39 +52,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 					as: 'users',
 				},
 			},
-			{
-				$lookup: {
-					from: 'audit_log',
-					let: { projectIdString: { $toString: '$_id' } },
-					pipeline: [
-						{
-							$match: {
-								$expr: {
-									$and: [
-										{ $eq: ['$entity', 'project'] },
-										{ $eq: ['$entityId', '$$projectIdString'] },
-										{ $in: ['$action', ['create', 'update']] },
-										{ $eq: ['$active', true] }
-									]
-								}
-							}
-						},
-						{ $sort: { actionAt: -1 } },
-						{
-							$project: {
-								entity: 1,
-								entityId: 1,
-								action: 1,
-								actionBy: 1,
-								actionAt: 1,
-								active: 1
-							}
-						},
-						{ $limit: 2 }
-					],
-					as: 'auditLogs'
-				}
-			}
+			buildLegacyAuditLookupStage({
+				scopeType: 'project',
+				updateActions: ['update', 'restore'],
+			})
 		]).toArray();
 
 		const project = projectData[0];

--- a/src/controllers/projects/updateProject.ts
+++ b/src/controllers/projects/updateProject.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
 import { authenticateWithRole } from '../../utils/authUtils';
+import { recordAuditEvent } from '../../utils/auditLogV2';
 
 /**
  * Update a project
@@ -116,6 +117,35 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		};
 
 		await updateAuditLog(auditRecord);
+
+		await recordAuditEvent({
+			workspaceId: workspaceObjectId.toString(),
+			scope: { type: 'project', id: input._id!.toString() },
+			entity: { type: 'project', id: input._id!.toString() },
+			action: 'update',
+			eventKey: 'project.updated',
+			visibility: 'admin',
+			where: { module: 'projects' },
+			auth: auth.payload,
+			before: {
+				project_name: projectRecord.project_name,
+				project_number: projectRecord.project_number,
+				project_description: projectRecord.project_description,
+				project_manager: projectRecord.project_manager,
+				users: projectRecord.users?.map((user) => user.toString()) ?? [],
+			},
+			after: {
+				project_name: input.project_name,
+				project_number: input.project_number,
+				project_description: input.project_description,
+				project_manager: input.project_manager,
+				users: (input.users as unknown as string[]) ?? [],
+			},
+			changedPaths: ['project_name', 'project_number', 'project_description', 'project_manager', 'users'],
+			meta: {
+				projectName: input.project_name,
+			},
+		});
 
 		return ResponseWrapper.success({
 			message: 'Project updated successfully',

--- a/src/controllers/projects/updateProject.ts
+++ b/src/controllers/projects/updateProject.ts
@@ -1,8 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import type { Project } from '../../models/project';
-import { type AuditLog, AuditLogAction } from '../../models/auditLog';
-import { updateAuditLog } from '../../utils/auditLog';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
@@ -106,17 +104,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				image: input.image,
 			}
 		});
-
-		const auditRecord: AuditLog = {
-			entity: 'project',
-			entityId: input._id!.toString(),
-			action: AuditLogAction.UPDATE,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		};
-
-		await updateAuditLog(auditRecord);
 
 		await recordAuditEvent({
 			workspaceId: workspaceObjectId.toString(),

--- a/src/controllers/sourceFiles/createSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/createSourceFileAndFolder.ts
@@ -6,8 +6,6 @@ import { validateAllObjectIds, validateEnum, validateMissingFields } from "../..
 import { getDb } from "../../utils/db";
 import { SourceFile } from "../../models/sourceFiles";
 import { ObjectId } from "mongodb";
-import { updateAuditLog } from "../../utils/auditLog";
-import { AuditLogAction } from "../../models/auditLog";
 import { recordAuditEvent } from "../../utils/auditLogV2";
 
 /**
@@ -86,15 +84,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		};
 
 		await sourceFilesCollection.insertOne(newSourceFile);
-
-		await updateAuditLog({
-			entity: 'SourceFile',
-			entityId: newSourceFile._id.toString(),
-			action: AuditLogAction.CREATE,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		});
 
 		const isFolder = newSourceFile.type === 'folder';
 		await recordAuditEvent({

--- a/src/controllers/sourceFiles/createSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/createSourceFileAndFolder.ts
@@ -8,6 +8,7 @@ import { SourceFile } from "../../models/sourceFiles";
 import { ObjectId } from "mongodb";
 import { updateAuditLog } from "../../utils/auditLog";
 import { AuditLogAction } from "../../models/auditLog";
+import { recordAuditEvent } from "../../utils/auditLogV2";
 
 /**
  * @param {APIGatewayProxyEvent} event
@@ -93,6 +94,31 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
 			active: true,
+		});
+
+		const isFolder = newSourceFile.type === 'folder';
+		await recordAuditEvent({
+			workspaceId: workspaceId.toString(),
+			scope: { type: 'source-files', id: workspaceId.toString() },
+			entity: { type: isFolder ? 'source_folder' : 'source_file', id: newSourceFile._id.toString() },
+			action: 'create',
+			eventKey: isFolder ? 'source_files.folder.created' : 'source_files.file.uploaded',
+			visibility: 'all',
+			where: {
+				module: 'source-files',
+				parentId: parentId?.toString() ?? undefined,
+			},
+			auth: auth.payload,
+			after: {
+				name: newSourceFile.name,
+				type: newSourceFile.type,
+				url: newSourceFile.url,
+				product_id: newSourceFile.product_id?.toString() ?? null,
+			},
+			changedPaths: ['name', 'type', 'url', 'product_id'],
+			meta: isFolder
+				? { folderName: newSourceFile.name }
+				: { fileName: newSourceFile.name },
 		});
 
 		return ResponseWrapper.created({

--- a/src/controllers/sourceFiles/deleteSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/deleteSourceFileAndFolder.ts
@@ -6,8 +6,6 @@ import { getDb } from "../../utils/db";
 import { validateAllObjectIds } from "../../utils/validationUtils";
 import { Collection, ObjectId } from "mongodb";
 import { SourceFile } from "../../models/sourceFiles";
-import { updateAuditLog } from "../../utils/auditLog";
-import { AuditLogAction } from "../../models/auditLog";
 import { recordAuditEvent } from "../../utils/auditLogV2";
 
 /**
@@ -63,15 +61,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		await sourceFilesCollection.deleteMany({ _id: { $in: idsToDelete } });
-
-		await updateAuditLog({
-			entity: 'SourceFile',
-			entityId: id,
-			action: AuditLogAction.DELETE,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		});
 
 		await recordAuditEvent({
 			workspaceId: fileOrFolder.workspace_id.toString(),

--- a/src/controllers/sourceFiles/deleteSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/deleteSourceFileAndFolder.ts
@@ -8,6 +8,7 @@ import { Collection, ObjectId } from "mongodb";
 import { SourceFile } from "../../models/sourceFiles";
 import { updateAuditLog } from "../../utils/auditLog";
 import { AuditLogAction } from "../../models/auditLog";
+import { recordAuditEvent } from "../../utils/auditLogV2";
 
 /**
  * Recursively finds all descendant node IDs for a given parent folder.
@@ -70,6 +71,30 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
 			active: true,
+		});
+
+		await recordAuditEvent({
+			workspaceId: fileOrFolder.workspace_id.toString(),
+			scope: { type: 'source-files', id: fileOrFolder.workspace_id.toString() },
+			entity: { type: fileOrFolder.type === 'folder' ? 'source_folder' : 'source_file', id },
+			action: 'delete',
+			eventKey: fileOrFolder.type === 'folder' ? 'source_files.folder.deleted' : 'source_files.file.deleted',
+			visibility: 'all',
+			where: {
+				module: 'source-files',
+				parentId: fileOrFolder.parentId?.toString() ?? undefined,
+			},
+			auth: auth.payload,
+			before: {
+				name: fileOrFolder.name,
+				type: fileOrFolder.type,
+				url: fileOrFolder.url,
+				product_id: fileOrFolder.product_id?.toString() ?? null,
+			},
+			changedPaths: ['name', 'type', 'url', 'product_id'],
+			meta: fileOrFolder.type === 'folder'
+				? { folderName: fileOrFolder.name }
+				: { fileName: fileOrFolder.name },
 		});
 
 		return ResponseWrapper.success({

--- a/src/controllers/sourceFiles/updateSourceFilesFolder.ts
+++ b/src/controllers/sourceFiles/updateSourceFilesFolder.ts
@@ -6,8 +6,6 @@ import { getDb } from "../../utils/db";
 import { validateAllObjectIds } from "../../utils/validationUtils";
 import { ObjectId } from "mongodb";
 import { SourceFile } from "../../models/sourceFiles";
-import { updateAuditLog } from "../../utils/auditLog";
-import { AuditLogAction } from "../../models/auditLog";
 import { recordAuditEvent } from "../../utils/auditLogV2";
 
 /**
@@ -78,15 +76,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (!updatedFolder) {
 			return ResponseWrapper.notFound('Folder not found.');
 		}
-
-		await updateAuditLog({
-			entity: 'SourceFile',
-			entityId: folderId,
-			action: AuditLogAction.UPDATE,
-			actionBy: auth.payload?.name?.toString()!,
-			actionAt: new Date(),
-			active: true,
-		});
 
 		const changedPaths = Object.keys(updateFields);
 		const hasNameChange = Object.prototype.hasOwnProperty.call(updateFields, 'name');

--- a/src/controllers/sourceFiles/updateSourceFilesFolder.ts
+++ b/src/controllers/sourceFiles/updateSourceFilesFolder.ts
@@ -8,6 +8,7 @@ import { ObjectId } from "mongodb";
 import { SourceFile } from "../../models/sourceFiles";
 import { updateAuditLog } from "../../utils/auditLog";
 import { AuditLogAction } from "../../models/auditLog";
+import { recordAuditEvent } from "../../utils/auditLogV2";
 
 /**
  * @param {APIGatewayProxyEvent} event 
@@ -66,6 +67,8 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				: null;
 		}
 
+		const beforeFolder = await sourceFilesCollection.findOne({ _id: folderObjectId, type: 'folder' });
+
 		const updatedFolder = await sourceFilesCollection.findOneAndUpdate(
 			{ _id: folderObjectId, type: 'folder' },
 			{ $set: updateFields },
@@ -83,6 +86,38 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
 			active: true,
+		});
+
+		const changedPaths = Object.keys(updateFields);
+		const hasNameChange = Object.prototype.hasOwnProperty.call(updateFields, 'name');
+		const hasProductChange = Object.prototype.hasOwnProperty.call(updateFields, 'product_id');
+
+		const eventKey = hasProductChange
+			? (updateFields.product_id ? 'source_files.folder.product_linked' : 'source_files.folder.product_unlinked')
+			: 'source_files.folder.renamed';
+
+		const action = hasProductChange ? (updateFields.product_id ? 'link' : 'unlink') : 'update';
+
+		await recordAuditEvent({
+			workspaceId: updatedFolder.workspace_id.toString(),
+			scope: { type: 'source-files', id: updatedFolder.workspace_id.toString() },
+			entity: { type: 'source_folder', id: folderId },
+			action,
+			eventKey,
+			visibility: 'all',
+			where: {
+				module: 'source-files',
+				parentId: updatedFolder.parentId?.toString() ?? undefined,
+			},
+			auth: auth.payload,
+			before: beforeFolder as unknown as Record<string, unknown>,
+			after: updatedFolder as unknown as Record<string, unknown>,
+			changedPaths,
+			meta: {
+				folderName: updatedFolder.name,
+				fromName: hasNameChange ? beforeFolder?.name : undefined,
+				toName: hasNameChange ? updatedFolder.name : undefined,
+			},
 		});
 
 		return ResponseWrapper.success({

--- a/src/controllers/sourceFiles/updateSourceFilesFolder.ts
+++ b/src/controllers/sourceFiles/updateSourceFilesFolder.ts
@@ -77,37 +77,63 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.notFound('Folder not found.');
 		}
 
-		const changedPaths = Object.keys(updateFields);
 		const hasNameChange = Object.prototype.hasOwnProperty.call(updateFields, 'name');
 		const hasProductChange = Object.prototype.hasOwnProperty.call(updateFields, 'product_id');
 
-		const eventKey = hasProductChange
-			? (updateFields.product_id ? 'source_files.folder.product_linked' : 'source_files.folder.product_unlinked')
-			: 'source_files.folder.renamed';
+		const auditEvents: Array<{
+			action: 'update' | 'link' | 'unlink';
+			eventKey: string;
+			changedPaths: string[];
+			meta: Record<string, unknown>;
+		}> = [];
 
-		const action = hasProductChange ? (updateFields.product_id ? 'link' : 'unlink') : 'update';
+		if (hasNameChange) {
+			auditEvents.push({
+				action: 'update',
+				eventKey: 'source_files.folder.renamed',
+				changedPaths: ['name'],
+				meta: {
+					folderName: updatedFolder.name,
+					fromName: beforeFolder?.name,
+					toName: updatedFolder.name,
+				},
+			});
+		}
 
-		await recordAuditEvent({
-			workspaceId: updatedFolder.workspace_id.toString(),
-			scope: { type: 'source-files', id: updatedFolder.workspace_id.toString() },
-			entity: { type: 'source_folder', id: folderId },
-			action,
-			eventKey,
-			visibility: 'all',
-			where: {
-				module: 'source-files',
-				parentId: updatedFolder.parentId?.toString() ?? undefined,
-			},
-			auth: auth.payload,
-			before: beforeFolder as unknown as Record<string, unknown>,
-			after: updatedFolder as unknown as Record<string, unknown>,
-			changedPaths,
-			meta: {
-				folderName: updatedFolder.name,
-				fromName: hasNameChange ? beforeFolder?.name : undefined,
-				toName: hasNameChange ? updatedFolder.name : undefined,
-			},
-		});
+		if (hasProductChange) {
+			auditEvents.push({
+				action: updateFields.product_id ? 'link' : 'unlink',
+				eventKey: updateFields.product_id
+					? 'source_files.folder.product_linked'
+					: 'source_files.folder.product_unlinked',
+				changedPaths: ['product_id'],
+				meta: {
+					folderName: updatedFolder.name,
+					fromProductId: beforeFolder?.product_id?.toString() ?? null,
+					toProductId: updatedFolder.product_id?.toString() ?? null,
+				},
+			});
+		}
+
+		for (const auditEvent of auditEvents) {
+			await recordAuditEvent({
+				workspaceId: updatedFolder.workspace_id.toString(),
+				scope: { type: 'source-files', id: updatedFolder.workspace_id.toString() },
+				entity: { type: 'source_folder', id: folderId },
+				action: auditEvent.action,
+				eventKey: auditEvent.eventKey,
+				visibility: 'all',
+				where: {
+					module: 'source-files',
+					parentId: updatedFolder.parentId?.toString() ?? undefined,
+				},
+				auth: auth.payload,
+				before: beforeFolder as unknown as Record<string, unknown>,
+				after: updatedFolder as unknown as Record<string, unknown>,
+				changedPaths: auditEvent.changedPaths,
+				meta: auditEvent.meta,
+			});
+		}
 
 		return ResponseWrapper.success({
 			message: 'Source file folder updated successfully.',

--- a/src/models/auditLogV2.ts
+++ b/src/models/auditLogV2.ts
@@ -1,0 +1,57 @@
+import { ObjectId } from 'mongodb';
+
+export const AUDIT_LOG_V2_COLLECTION = 'auditLogV2';
+
+export const AUDIT_SCOPE_TYPES = ['product', 'project', 'department', 'source-files', 'archive'] as const;
+export type AuditScopeType = typeof AUDIT_SCOPE_TYPES[number];
+
+export const AUDIT_ENTITY_TYPES = ['product', 'project', 'department', 'source_file', 'source_folder'] as const;
+export type AuditEntityType = typeof AUDIT_ENTITY_TYPES[number];
+
+export const AUDIT_ACTIONS = ['create', 'update', 'delete', 'move', 'archive', 'restore', 'submit', 'link', 'unlink'] as const;
+export type AuditAction = typeof AUDIT_ACTIONS[number];
+
+export const AUDIT_VISIBILITY = ['all', 'admin'] as const;
+export type AuditVisibility = typeof AUDIT_VISIBILITY[number];
+
+export type AuditLogV2Change = {
+	path: string;
+	from?: unknown;
+	to?: unknown;
+};
+
+export type AuditLogV2 = {
+	_id?: ObjectId;
+	schemaVersion: 2;
+	workspaceId: ObjectId;
+	scope: {
+		type: AuditScopeType;
+		id: string;
+	};
+	entity?: {
+		type: AuditEntityType;
+		id: string;
+	};
+	action: AuditAction;
+	eventKey: string;
+	summary: string;
+	actor: {
+		userId?: string;
+		name: string;
+		email?: string;
+		role?: 'admin' | 'user';
+	};
+	where: {
+		module: 'products' | 'projects' | 'departments' | 'source-files' | 'archive';
+		tab?: string;
+		parentId?: string;
+	};
+	changes?: AuditLogV2Change[];
+	visibility: AuditVisibility;
+	occurredAt: Date;
+	legacy?: {
+		source: 'audit_log';
+		legacyId?: string;
+		isBackfilled?: boolean;
+	};
+};

--- a/src/scripts/backfillAuditLogV2.ts
+++ b/src/scripts/backfillAuditLogV2.ts
@@ -1,0 +1,208 @@
+import { ObjectId } from 'mongodb';
+import { AuditLog } from '../models/auditLog';
+import { type AuditAction, type AuditLogV2, AUDIT_LOG_V2_COLLECTION } from '../models/auditLogV2';
+import { getDb } from '../utils/db';
+import { buildAuditEventSummary } from '../utils/auditEventCatalog';
+import { Product } from '../models/product';
+import { Project } from '../models/project';
+import { Department } from '../models/department';
+import { SourceFile } from '../models/sourceFiles';
+
+const toNewAction = (action: AuditLog['action'] | string): AuditAction => {
+	const normalized = action.toLowerCase();
+	if (normalized === 'unarchive') return 'restore';
+	if (normalized === 'create') return 'create';
+	if (normalized === 'update') return 'update';
+	if (normalized === 'delete') return 'delete';
+	if (normalized === 'archive') return 'archive';
+	return 'update';
+};
+
+const toScope = (entity: string): AuditLogV2['scope']['type'] | null => {
+	const normalized = entity.toLowerCase();
+	if (normalized === 'project') return 'project';
+	if (normalized === 'department') return 'department';
+	if (normalized === 'product') return 'product';
+	if (normalized === 'sourcefile' || normalized === 'source_file' || normalized === 'source-folder') return 'source-files';
+	return null;
+};
+
+const toEventKey = (scopeType: AuditLogV2['scope']['type'], action: AuditAction) => {
+	if (scopeType === 'source-files') {
+		if (action === 'create') return 'source_files.file.uploaded';
+		if (action === 'delete') return 'source_files.file.deleted';
+		return `source_files.file.${action === 'restore' ? 'uploaded' : 'deleted'}`;
+	}
+
+	if (scopeType === 'product' && action === 'submit') return 'product.submitted';
+	if (scopeType === 'product' && action === 'restore') return 'product.restored';
+	if (scopeType === 'project' && action === 'restore') return 'project.restored';
+	if (scopeType === 'department' && action === 'restore') return 'department.restored';
+
+	if (scopeType === 'product') {
+		if (action === 'create') return 'product.created';
+		if (action === 'archive') return 'product.archived';
+		return 'product.updated';
+	}
+
+	if (scopeType === 'project') {
+		if (action === 'create') return 'project.created';
+		if (action === 'archive') return 'project.archived';
+		return 'project.updated';
+	}
+
+	if (scopeType === 'department') {
+		if (action === 'create') return 'department.created';
+		if (action === 'archive') return 'department.archived';
+		return 'department.updated';
+	}
+
+	return `${scopeType}.updated`;
+};
+
+const createSummary = (actorName: string, eventKey: string, action: AuditAction) =>
+	buildAuditEventSummary({
+		eventKey,
+		action,
+		changes: [],
+		meta: { name: 'legacy record' },
+		actorName,
+	});
+
+const inferVisibility = (scopeType: AuditLogV2['scope']['type']): AuditLogV2['visibility'] =>
+	(scopeType === 'department' || scopeType === 'project' || scopeType === 'archive') ? 'admin' : 'all';
+
+const inferModule = (scopeType: AuditLogV2['scope']['type']): AuditLogV2['where']['module'] => {
+	if (scopeType === 'source-files') return 'source-files';
+	if (scopeType === 'product') return 'products';
+	if (scopeType === 'project') return 'projects';
+	if (scopeType === 'department') return 'departments';
+	return 'archive';
+};
+
+/**
+ * Backfills legacy `audit_log` entries into `auditLogV2`.
+ * @return {Promise<void>} Resolves when backfill processing completes.
+ */
+async function run() {
+	const db = await getDb();
+	const legacyCollection = db.collection<AuditLog>('audit_log');
+	const targetCollection = db.collection<AuditLogV2>(AUDIT_LOG_V2_COLLECTION);
+	const dryRun = process.argv.includes('--dry-run');
+
+	const records = await legacyCollection.find({}).sort({ actionAt: 1 }).toArray();
+
+	const resolveWorkspaceId = async (record: AuditLog): Promise<string | null> => {
+		if (!ObjectId.isValid(record.entityId)) return null;
+		const entityId = new ObjectId(record.entityId);
+		const entity = record.entity.toLowerCase();
+
+		if (entity === 'product') {
+			const product = await db.collection<Product>('products').findOne({ _id: entityId }, { projection: { workspace_id: 1 } });
+			return product?.workspace_id?.toString() ?? null;
+		}
+
+		if (entity === 'project') {
+			const project = await db.collection<Project>('projects').findOne({ _id: entityId }, { projection: { workspace_id: 1 } });
+			return project?.workspace_id?.toString() ?? null;
+		}
+
+		if (entity === 'department') {
+			const department = await db.collection<Department>('departments').findOne({ _id: entityId }, { projection: { workspace_id: 1 } });
+			return department?.workspace_id?.toString() ?? null;
+		}
+
+		if (entity === 'sourcefile' || entity === 'source_file') {
+			const source = await db.collection<SourceFile>('sourceFiles').findOne({ _id: entityId }, { projection: { workspace_id: 1 } });
+			return source?.workspace_id?.toString() ?? null;
+		}
+
+		return null;
+	};
+
+	const operations: Array<{
+		updateOne: {
+			filter: Record<string, unknown>;
+			update: Record<string, unknown>;
+			upsert: boolean;
+		};
+	}> = [];
+
+	for (const record of records) {
+		if (!ObjectId.isValid(record.entityId)) continue;
+
+		const scopeType = toScope(record.entity);
+		if (!scopeType) continue;
+
+		const workspaceId = await resolveWorkspaceId(record);
+		if (!workspaceId) continue;
+
+		const action = toNewAction(record.action);
+		const eventKey = toEventKey(scopeType, action);
+		const actorName = record.actionBy || 'Unknown User';
+
+		const payload: AuditLogV2 = {
+			schemaVersion: 2,
+			workspaceId: new ObjectId(workspaceId),
+			scope: {
+				type: scopeType,
+				id: record.entityId,
+			},
+			action,
+			eventKey,
+			summary: createSummary(actorName, eventKey, action),
+			actor: {
+				name: actorName,
+				role: 'user',
+			},
+			where: {
+				module: inferModule(scopeType),
+			},
+			visibility: inferVisibility(scopeType),
+			occurredAt: record.actionAt,
+			legacy: {
+				source: 'audit_log',
+				legacyId: record._id?.toString(),
+				isBackfilled: true,
+			},
+		};
+
+		operations.push({
+			updateOne: {
+				filter: {
+					'legacy.source': 'audit_log',
+					'legacy.legacyId': record._id?.toString(),
+				},
+				update: {
+					$setOnInsert: payload,
+				},
+				upsert: true,
+			},
+		});
+	}
+
+	if (dryRun) {
+		// eslint-disable-next-line no-console
+		console.log(`[dry-run] Prepared ${operations.length} auditLogV2 backfill operations.`);
+		return;
+	}
+
+	if (!operations.length) {
+		// eslint-disable-next-line no-console
+		console.log('No legacy audit_log records eligible for backfill.');
+		return;
+	}
+
+	const result = await targetCollection.bulkWrite(operations, { ordered: false });
+
+	// eslint-disable-next-line no-console
+	console.log(
+		`Backfill complete. matched=${result.matchedCount}, inserted=${result.upsertedCount}, modified=${result.modifiedCount}`,
+	);
+}
+
+run().catch((error) => {
+	// eslint-disable-next-line no-console
+	console.error('Backfill failed', error);
+	process.exit(1);
+});

--- a/src/utils/auditEventCatalog.ts
+++ b/src/utils/auditEventCatalog.ts
@@ -1,0 +1,209 @@
+import { AuditAction, AuditLogV2Change } from '../models/auditLogV2';
+
+type SummaryContext = {
+	eventKey: string;
+	action: AuditAction;
+	changes: AuditLogV2Change[];
+	meta?: Record<string, unknown>;
+	actorName: string;
+};
+
+type SummaryBuilder = (context: SummaryContext) => string;
+
+const pickText = (meta: Record<string, unknown> | undefined, keys: string[]): string | undefined => {
+	if (!meta) return undefined;
+
+	for (const key of keys) {
+		const value = meta[key];
+		if (typeof value === 'string' && value.trim()) return value.trim();
+	}
+
+	return undefined;
+};
+
+const formatFieldName = (path: string) => {
+	const normalized = path
+		.split('.')
+		.at(-1)
+		?.replace(/_/g, ' ')
+		.replace(/\[(\d+)\]/g, '');
+
+	return normalized ?? path;
+};
+
+const listChangedFields = (changes: AuditLogV2Change[]) => {
+	if (!changes.length) return '';
+
+	const labels = Array.from(new Set(changes.map((change) => formatFieldName(change.path)))).filter(Boolean);
+	if (!labels.length) return '';
+
+	return ` (${labels.slice(0, 4).join(', ')}${labels.length > 4 ? ', ...' : ''})`;
+};
+
+const subjectForScope = (eventKey: string) => {
+	if (eventKey.startsWith('department.')) return 'department';
+	if (eventKey.startsWith('project.')) return 'project';
+	if (eventKey.startsWith('product.')) return 'product';
+	if (eventKey.startsWith('source_files.')) return 'source item';
+	return 'record';
+};
+
+const withActor = (actorName: string, message: string) => `${actorName} ${message}`;
+
+const productItemSummary = (
+	actorName: string,
+	verb: 'added' | 'updated' | 'deleted',
+	label: string,
+	changes: AuditLogV2Change[],
+) => withActor(actorName, `${verb} ${label}${verb === 'updated' ? listChangedFields(changes) : ''}`);
+
+const summaryBuilders: Record<string, SummaryBuilder> = {
+	'department.created': ({ actorName, meta }) => {
+		const name = pickText(meta, ['departmentName', 'name']);
+		return withActor(actorName, `created department${name ? ` "${name}"` : ''}`);
+	},
+	'department.updated': ({ actorName, meta, changes }) => {
+		const name = pickText(meta, ['departmentName', 'name']);
+		return withActor(actorName, `updated department${name ? ` "${name}"` : ''}${listChangedFields(changes)}`);
+	},
+	'department.archived': ({ actorName, meta }) => {
+		const name = pickText(meta, ['departmentName', 'name']);
+		return withActor(actorName, `archived department${name ? ` "${name}"` : ''}`);
+	},
+	'department.restored': ({ actorName, meta }) => {
+		const name = pickText(meta, ['departmentName', 'name']);
+		return withActor(actorName, `restored department${name ? ` "${name}"` : ''}`);
+	},
+	'project.created': ({ actorName, meta }) => {
+		const name = pickText(meta, ['projectName', 'name']);
+		return withActor(actorName, `created project${name ? ` "${name}"` : ''}`);
+	},
+	'project.updated': ({ actorName, meta, changes }) => {
+		const name = pickText(meta, ['projectName', 'name']);
+		return withActor(actorName, `updated project${name ? ` "${name}"` : ''}${listChangedFields(changes)}`);
+	},
+	'project.archived': ({ actorName, meta }) => {
+		const name = pickText(meta, ['projectName', 'name']);
+		return withActor(actorName, `archived project${name ? ` "${name}"` : ''}`);
+	},
+	'project.restored': ({ actorName, meta }) => {
+		const name = pickText(meta, ['projectName', 'name']);
+		return withActor(actorName, `restored project${name ? ` "${name}"` : ''}`);
+	},
+	'product.created': ({ actorName, meta }) => {
+		const name = pickText(meta, ['productName', 'name']);
+		return withActor(actorName, `created product${name ? ` "${name}"` : ''}`);
+	},
+	'product.updated': ({ actorName, meta, changes }) => {
+		const name = pickText(meta, ['productName', 'name']);
+		return withActor(actorName, `updated product${name ? ` "${name}"` : ''}${listChangedFields(changes)}`);
+	},
+	'product.submitted': ({ actorName, meta }) => {
+		const name = pickText(meta, ['productName', 'name']);
+		return withActor(actorName, `submitted product${name ? ` "${name}"` : ''}`);
+	},
+	'product.archived': ({ actorName, meta }) => {
+		const name = pickText(meta, ['productName', 'name']);
+		return withActor(actorName, `archived product${name ? ` "${name}"` : ''}`);
+	},
+	'product.restored': ({ actorName, meta }) => {
+		const name = pickText(meta, ['productName', 'name']);
+		return withActor(actorName, `restored product${name ? ` "${name}"` : ''}`);
+	},
+	'product.version.created': ({ actorName, meta }) => {
+		const name = pickText(meta, ['productName', 'name']);
+		const fromVersion = meta?.fromVersion;
+		const toVersion = meta?.toVersion;
+		const versionText = typeof fromVersion === 'number' && typeof toVersion === 'number'
+			? ` from v${fromVersion} to v${toVersion}`
+			: '';
+		return withActor(actorName, `created a new version${versionText}${name ? ` for product "${name}"` : ''}`);
+	},
+	'product.product_information.updated': ({ actorName, changes }) =>
+		withActor(actorName, `updated product information${listChangedFields(changes)}`),
+	'product.product_information.custom_field.added': ({ actorName }) =>
+		withActor(actorName, 'added custom field in product information'),
+	'product.product_information.custom_field.updated': ({ actorName, changes }) =>
+		withActor(actorName, `updated custom field in product information${listChangedFields(changes)}`),
+	'product.product_information.custom_field.deleted': ({ actorName }) =>
+		withActor(actorName, 'deleted custom field from product information'),
+	'product.product_information.completion.updated': ({ actorName, meta }) =>
+		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} product information tab as complete`),
+	'product.compliance_item.added': ({ actorName }) => productItemSummary(actorName, 'added', 'compliance item', []),
+	'product.compliance_item.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'compliance item', changes),
+	'product.compliance_item.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'compliance item', []),
+	'product.compliance_information.completion.updated': ({ actorName, meta }) =>
+		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} compliance information tab as complete`),
+	'product.label_component.added': ({ actorName }) => productItemSummary(actorName, 'added', 'label component', []),
+	'product.label_component.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'label component', changes),
+	'product.label_component.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'label component', []),
+	'product.label_components.completion.updated': ({ actorName, meta }) =>
+		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} label components tab as complete`),
+	'product.symbol_graphic.added': ({ actorName }) => productItemSummary(actorName, 'added', 'symbol/graphic item', []),
+	'product.symbol_graphic.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'symbol/graphic item', changes),
+	'product.symbol_graphic.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'symbol/graphic item', []),
+	'product.symbol_graphics.completion.updated': ({ actorName, meta }) =>
+		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} symbols and graphics tab as complete`),
+	'product.product_specification.added': ({ actorName }) => productItemSummary(actorName, 'added', 'product specification data', []),
+	'product.product_specification.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'product specification data', changes),
+	'product.product_specification.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'product specification data', []),
+	'product.product_specifications.completion.updated': ({ actorName, meta }) =>
+		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} product specifications tab as complete`),
+	'product.operational_parameter.added': ({ actorName }) => productItemSummary(actorName, 'added', 'operational parameter data', []),
+	'product.operational_parameter.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'operational parameter data', changes),
+	'product.operational_parameter.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'operational parameter data', []),
+	'product.operational_parameters.completion.updated': ({ actorName, meta }) =>
+		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} operational parameters tab as complete`),
+	'product.label_tag.added': ({ actorName }) => productItemSummary(actorName, 'added', 'label tag', []),
+	'product.label_tag.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'label tag', changes),
+	'product.label_tag.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'label tag', []),
+	'product.label_tag.tagged_image.updated': ({ actorName, changes }) =>
+		withActor(actorName, `updated label tag tagged image${listChangedFields(changes)}`),
+	'product.label_tag.legend.updated': ({ actorName, changes }) =>
+		withActor(actorName, `updated label tag legend${listChangedFields(changes)}`),
+	'product.label_tags.completion.updated': ({ actorName, meta }) =>
+		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} label tags tab as complete`),
+	'source_files.folder.created': ({ actorName, meta }) => withActor(actorName, `created folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''}`),
+	'source_files.folder.renamed': ({ actorName, meta }) => {
+		const from = pickText(meta, ['fromName']);
+		const to = pickText(meta, ['toName', 'folderName', 'name']);
+		if (from && to) return withActor(actorName, `renamed folder from "${from}" to "${to}"`);
+		return withActor(actorName, `renamed folder${to ? ` to "${to}"` : ''}`);
+	},
+	'source_files.folder.deleted': ({ actorName, meta }) => withActor(actorName, `deleted folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''}`),
+	'source_files.folder.product_linked': ({ actorName, meta }) => withActor(actorName, `linked folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''} to a product`),
+	'source_files.folder.product_unlinked': ({ actorName, meta }) => withActor(actorName, `unlinked folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''} from product`),
+	'source_files.file.uploaded': ({ actorName, meta }) => withActor(actorName, `uploaded file${pickText(meta, ['fileName', 'name']) ? ` "${pickText(meta, ['fileName', 'name'])}"` : ''}`),
+	'source_files.file.deleted': ({ actorName, meta }) => withActor(actorName, `deleted file${pickText(meta, ['fileName', 'name']) ? ` "${pickText(meta, ['fileName', 'name'])}"` : ''}`),
+};
+
+export const buildAuditEventSummary = (context: SummaryContext): string => {
+	const builder = summaryBuilders[context.eventKey];
+	if (builder) return builder(context);
+
+	const subject = subjectForScope(context.eventKey);
+	const changed = listChangedFields(context.changes);
+
+	switch (context.action) {
+	case 'create':
+		return withActor(context.actorName, `created ${subject}`);
+	case 'update':
+		return withActor(context.actorName, `updated ${subject}${changed}`);
+	case 'delete':
+		return withActor(context.actorName, `deleted ${subject}`);
+	case 'archive':
+		return withActor(context.actorName, `archived ${subject}`);
+	case 'restore':
+		return withActor(context.actorName, `restored ${subject}`);
+	case 'submit':
+		return withActor(context.actorName, `submitted ${subject}`);
+	case 'move':
+		return withActor(context.actorName, `moved ${subject}`);
+	case 'link':
+		return withActor(context.actorName, `linked ${subject}`);
+	case 'unlink':
+		return withActor(context.actorName, `unlinked ${subject}`);
+	default:
+		return withActor(context.actorName, `updated ${subject}`);
+	}
+};

--- a/src/utils/auditLogV2.ts
+++ b/src/utils/auditLogV2.ts
@@ -1,0 +1,238 @@
+import type { CognitoAccessTokenPayload } from 'aws-jwt-verify/jwt-model';
+import { type Db, ObjectId } from 'mongodb';
+import {
+	AUDIT_LOG_V2_COLLECTION,
+	type AuditAction,
+	type AuditEntityType,
+	type AuditLogV2,
+	type AuditLogV2Change,
+	type AuditScopeType,
+	type AuditVisibility,
+} from '../models/auditLogV2';
+import type { User } from '../models/user';
+import { getDb } from './db';
+import { buildAuditEventSummary } from './auditEventCatalog';
+
+let hasEnsuredAuditLogV2Indexes = false;
+const actorEmailCache = new Map<string, string | null>();
+
+type AuditWhere = {
+	module: 'products' | 'projects' | 'departments' | 'source-files' | 'archive';
+	tab?: string;
+	parentId?: string;
+};
+
+export type RecordAuditEventInput = {
+	workspaceId: string;
+	scope: {
+		type: AuditScopeType;
+		id: string;
+	};
+	entity?: {
+		type: AuditEntityType;
+		id: string;
+	};
+	action: AuditAction;
+	eventKey: string;
+	visibility: AuditVisibility;
+	where: AuditWhere;
+	auth: Partial<CognitoAccessTokenPayload>;
+	before?: Record<string, unknown> | null;
+	after?: Record<string, unknown> | null;
+	changedPaths?: string[];
+	changes?: AuditLogV2Change[];
+	meta?: Record<string, unknown>;
+	occurredAt?: Date;
+};
+
+const parseGroups = (groups: unknown): string[] => {
+	if (Array.isArray(groups)) return groups.filter((group): group is string => typeof group === 'string');
+	if (typeof groups === 'string') return groups.split(',').map((group) => group.trim()).filter(Boolean);
+	return [];
+};
+
+const getClaimString = (claims: Partial<CognitoAccessTokenPayload>, keys: string[]): string | undefined => {
+	const rawClaims = claims as Record<string, unknown>;
+	for (const key of keys) {
+		const value = rawClaims[key];
+		if (typeof value === 'string' && value.trim()) return value.trim();
+	}
+
+	return undefined;
+};
+
+const isLikelyEmail = (value: string) => /^\S+@\S+\.\S+$/.test(value);
+
+const resolveActorEmail = async ({
+	db,
+	workspaceId,
+	auth,
+}: {
+	db: Db;
+	workspaceId: string;
+	auth: Partial<CognitoAccessTokenPayload>;
+}): Promise<string | undefined> => {
+	const emailClaim = getClaimString(auth, ['email']);
+	if (emailClaim) return emailClaim;
+
+	const usernameClaim = getClaimString(auth, ['username', 'cognito:username']);
+	if (usernameClaim && isLikelyEmail(usernameClaim)) return usernameClaim;
+
+	const sub = getClaimString(auth, ['sub']);
+	if (!sub || !ObjectId.isValid(workspaceId)) return undefined;
+
+	const cacheKey = `${workspaceId}:${sub}`;
+	if (actorEmailCache.has(cacheKey)) {
+		return actorEmailCache.get(cacheKey) ?? undefined;
+	}
+
+	try {
+		const user = await db.collection<User>('users').findOne(
+			{
+				cognitoSub: sub,
+				workspaceId: new ObjectId(workspaceId),
+			},
+			{
+				projection: { email: 1 },
+			},
+		);
+
+		const resolvedEmail = typeof user?.email === 'string' && user.email.trim() ? user.email.trim() : undefined;
+		actorEmailCache.set(cacheKey, resolvedEmail ?? null);
+		return resolvedEmail;
+	} catch {
+		return undefined;
+	}
+};
+
+const normalizeValue = (value: unknown): unknown => {
+	if (value instanceof ObjectId) return value.toString();
+	if (value instanceof Date) return value.toISOString();
+
+	if (Array.isArray(value)) return value.map((item) => normalizeValue(item));
+
+	if (value && typeof value === 'object') {
+		const normalizedEntries = Object.entries(value as Record<string, unknown>).map(([key, entryValue]) => [key, normalizeValue(entryValue)]);
+		return Object.fromEntries(normalizedEntries);
+	}
+
+	return value;
+};
+
+const getValueByPath = (source: Record<string, unknown> | null | undefined, path: string): unknown => {
+	if (!source) return undefined;
+
+	const tokens = path.replace(/\[(\d+)\]/g, '.$1').split('.').filter(Boolean);
+	let current: unknown = source;
+
+	for (const token of tokens) {
+		if (current == null || typeof current !== 'object') return undefined;
+		current = (current as Record<string, unknown>)[token];
+	}
+
+	return normalizeValue(current);
+};
+
+const valuesDiffer = (first: unknown, second: unknown) => JSON.stringify(first) !== JSON.stringify(second);
+
+export const buildChangesFromPaths = ({
+	before,
+	after,
+	paths,
+}: {
+	before?: Record<string, unknown> | null;
+	after?: Record<string, unknown> | null;
+	paths?: string[];
+}): AuditLogV2Change[] => {
+	if (!before && !after) return [];
+
+	const candidatePaths = paths && paths.length
+		? paths
+		: Array.from(new Set([
+			...Object.keys((before ?? {}) as Record<string, unknown>),
+			...Object.keys((after ?? {}) as Record<string, unknown>),
+		]));
+
+	const changes: AuditLogV2Change[] = [];
+
+	for (const path of candidatePaths) {
+		const from = getValueByPath(before ?? undefined, path);
+		const to = getValueByPath(after ?? undefined, path);
+
+		if (!valuesDiffer(from, to)) continue;
+
+		changes.push({ path, from, to });
+	}
+
+	return changes;
+};
+
+const ensureAuditLogV2Indexes = async () => {
+	if (hasEnsuredAuditLogV2Indexes) return;
+
+	const db = await getDb();
+	const collection = db.collection<AuditLogV2>(AUDIT_LOG_V2_COLLECTION);
+
+	await Promise.all([
+		collection.createIndex({ workspaceId: 1, 'scope.type': 1, 'scope.id': 1, occurredAt: -1 }),
+		collection.createIndex({ workspaceId: 1, action: 1, occurredAt: -1 }),
+		collection.createIndex({ workspaceId: 1, visibility: 1, occurredAt: -1 }),
+		collection.createIndex({ 'entity.type': 1, 'entity.id': 1, occurredAt: -1 }),
+		collection.createIndex({ 'legacy.source': 1, 'legacy.legacyId': 1 }, { unique: true, sparse: true }),
+	]);
+
+	hasEnsuredAuditLogV2Indexes = true;
+};
+
+export const recordAuditEvent = async (input: RecordAuditEventInput) => {
+	await ensureAuditLogV2Indexes();
+
+	const db = await getDb();
+	const collection = db.collection<AuditLogV2>(AUDIT_LOG_V2_COLLECTION);
+
+	const groups = parseGroups(input.auth['cognito:groups']);
+	const actorRole: 'admin' | 'user' = groups.includes('admin') ? 'admin' : 'user';
+	const usernameClaim = getClaimString(input.auth, ['username', 'cognito:username']);
+	const actorEmail = await resolveActorEmail({
+		db,
+		workspaceId: input.workspaceId,
+		auth: input.auth,
+	});
+	const actorName = getClaimString(input.auth, ['name']) ?? actorEmail ?? usernameClaim ?? 'Unknown User';
+
+	const computedChanges = input.changes ?? buildChangesFromPaths({
+		before: input.before,
+		after: input.after,
+		paths: input.changedPaths,
+	});
+
+	const summary = buildAuditEventSummary({
+		eventKey: input.eventKey,
+		action: input.action,
+		changes: computedChanges,
+		meta: input.meta,
+		actorName,
+	});
+
+	const payload: AuditLogV2 = {
+		schemaVersion: 2,
+		workspaceId: new ObjectId(input.workspaceId),
+		scope: input.scope,
+		entity: input.entity,
+		action: input.action,
+		eventKey: input.eventKey,
+		summary,
+		actor: {
+			userId: input.auth.sub,
+			name: actorName,
+			email: actorEmail,
+			role: actorRole,
+		},
+		where: input.where,
+		changes: computedChanges,
+		visibility: input.visibility,
+		occurredAt: input.occurredAt ?? new Date(),
+	};
+
+	await collection.insertOne(payload);
+};

--- a/src/utils/auditLogV2.ts
+++ b/src/utils/auditLogV2.ts
@@ -12,6 +12,7 @@ import {
 import type { User } from '../models/user';
 import { getDb } from './db';
 import { buildAuditEventSummary } from './auditEventCatalog';
+import { logError } from './logger';
 
 let hasEnsuredAuditLogV2Indexes = false;
 const actorEmailCache = new Map<string, string | null>();
@@ -175,6 +176,7 @@ const ensureAuditLogV2Indexes = async () => {
 
 	await Promise.all([
 		collection.createIndex({ workspaceId: 1, 'scope.type': 1, 'scope.id': 1, occurredAt: -1 }),
+		collection.createIndex({ 'scope.type': 1, 'scope.id': 1, action: 1, occurredAt: -1 }),
 		collection.createIndex({ workspaceId: 1, action: 1, occurredAt: -1 }),
 		collection.createIndex({ workspaceId: 1, visibility: 1, occurredAt: -1 }),
 		collection.createIndex({ 'entity.type': 1, 'entity.id': 1, occurredAt: -1 }),
@@ -185,54 +187,64 @@ const ensureAuditLogV2Indexes = async () => {
 };
 
 export const recordAuditEvent = async (input: RecordAuditEventInput) => {
-	await ensureAuditLogV2Indexes();
+	try {
+		await ensureAuditLogV2Indexes();
 
-	const db = await getDb();
-	const collection = db.collection<AuditLogV2>(AUDIT_LOG_V2_COLLECTION);
+		const db = await getDb();
+		const collection = db.collection<AuditLogV2>(AUDIT_LOG_V2_COLLECTION);
 
-	const groups = parseGroups(input.auth['cognito:groups']);
-	const actorRole: 'admin' | 'user' = groups.includes('admin') ? 'admin' : 'user';
-	const usernameClaim = getClaimString(input.auth, ['username', 'cognito:username']);
-	const actorEmail = await resolveActorEmail({
-		db,
-		workspaceId: input.workspaceId,
-		auth: input.auth,
-	});
-	const actorName = getClaimString(input.auth, ['name']) ?? actorEmail ?? usernameClaim ?? 'Unknown User';
+		const groups = parseGroups(input.auth['cognito:groups']);
+		const actorRole: 'admin' | 'user' = groups.includes('admin') ? 'admin' : 'user';
+		const usernameClaim = getClaimString(input.auth, ['username', 'cognito:username']);
+		const actorEmail = await resolveActorEmail({
+			db,
+			workspaceId: input.workspaceId,
+			auth: input.auth,
+		});
+		const actorName = getClaimString(input.auth, ['name']) ?? actorEmail ?? usernameClaim ?? 'Unknown User';
 
-	const computedChanges = input.changes ?? buildChangesFromPaths({
-		before: input.before,
-		after: input.after,
-		paths: input.changedPaths,
-	});
+		const computedChanges = input.changes ?? buildChangesFromPaths({
+			before: input.before,
+			after: input.after,
+			paths: input.changedPaths,
+		});
 
-	const summary = buildAuditEventSummary({
-		eventKey: input.eventKey,
-		action: input.action,
-		changes: computedChanges,
-		meta: input.meta,
-		actorName,
-	});
+		const summary = buildAuditEventSummary({
+			eventKey: input.eventKey,
+			action: input.action,
+			changes: computedChanges,
+			meta: input.meta,
+			actorName,
+		});
 
-	const payload: AuditLogV2 = {
-		schemaVersion: 2,
-		workspaceId: new ObjectId(input.workspaceId),
-		scope: input.scope,
-		entity: input.entity,
-		action: input.action,
-		eventKey: input.eventKey,
-		summary,
-		actor: {
-			userId: input.auth.sub,
-			name: actorName,
-			email: actorEmail,
-			role: actorRole,
-		},
-		where: input.where,
-		changes: computedChanges,
-		visibility: input.visibility,
-		occurredAt: input.occurredAt ?? new Date(),
-	};
+		const payload: AuditLogV2 = {
+			schemaVersion: 2,
+			workspaceId: new ObjectId(input.workspaceId),
+			scope: input.scope,
+			entity: input.entity,
+			action: input.action,
+			eventKey: input.eventKey,
+			summary,
+			actor: {
+				userId: input.auth.sub,
+				name: actorName,
+				email: actorEmail,
+				role: actorRole,
+			},
+			where: input.where,
+			changes: computedChanges,
+			visibility: input.visibility,
+			occurredAt: input.occurredAt ?? new Date(),
+		};
 
-	await collection.insertOne(payload);
+		await collection.insertOne(payload);
+	} catch (error) {
+		const actor = getClaimString(input.auth, ['sub', 'email', 'username', 'cognito:username', 'name']) ?? 'unknown';
+		logError('Failed to record audit event', error, {
+			eventKey: input.eventKey,
+			workspaceId: input.workspaceId,
+			action: input.action,
+			actor,
+		});
+	}
 };

--- a/src/utils/auditLogV2Aggregation.ts
+++ b/src/utils/auditLogV2Aggregation.ts
@@ -1,0 +1,106 @@
+import {
+	AUDIT_LOG_V2_COLLECTION,
+	type AuditAction,
+	type AuditScopeType,
+} from '../models/auditLogV2';
+
+type LegacyAuditMode = 'activity' | 'archive';
+
+type BuildLegacyAuditLookupStageInput = {
+	scopeType: Extract<AuditScopeType, 'product' | 'project' | 'department'>;
+	mode?: LegacyAuditMode;
+	updateActions?: AuditAction[];
+};
+
+
+export const buildLegacyAuditLookupStage = ({
+	scopeType,
+	mode = 'activity',
+	updateActions = ['update'],
+}: BuildLegacyAuditLookupStageInput): Record<string, unknown> => {
+	if (mode === 'archive') {
+		return {
+			$lookup: {
+				from: AUDIT_LOG_V2_COLLECTION,
+				let: { entityIdString: { $toString: '$_id' } },
+				pipeline: [
+					{
+						$match: {
+							$expr: {
+								$and: [
+									{ $eq: ['$scope.type', scopeType] },
+									{ $eq: ['$scope.id', '$$entityIdString'] },
+									{ $eq: ['$action', 'archive'] },
+								],
+							},
+						},
+					},
+					{ $sort: { occurredAt: -1 } },
+					{ $limit: 1 },
+					{
+						$project: {
+							_id: 1,
+							entity: '$scope.type',
+							entityId: '$scope.id',
+							action: '$action',
+							actionBy: '$actor.name',
+							actionAt: '$occurredAt',
+							active: { $literal: true },
+						},
+					},
+				],
+				as: 'auditLogs',
+			},
+		};
+	}
+
+	const actionFilters = Array.from(new Set(['create', ...updateActions]));
+
+	return {
+		$lookup: {
+			from: AUDIT_LOG_V2_COLLECTION,
+			let: { entityIdString: { $toString: '$_id' } },
+			pipeline: [
+				{
+					$match: {
+						$expr: {
+							$and: [
+								{ $eq: ['$scope.type', scopeType] },
+								{ $eq: ['$scope.id', '$$entityIdString'] },
+								{ $in: ['$action', actionFilters] },
+							],
+						},
+					},
+				},
+				{
+					$addFields: {
+						legacyAction: {
+							$cond: [{ $eq: ['$action', 'create'] }, 'create', 'update'],
+						},
+					},
+				},
+				{ $sort: { occurredAt: -1 } },
+				{
+					$group: {
+						_id: '$legacyAction',
+						log: { $first: '$$ROOT' },
+					},
+				},
+				{ $replaceRoot: { newRoot: '$log' } },
+				{
+					$project: {
+						_id: 1,
+						entity: '$scope.type',
+						entityId: '$scope.id',
+						action: '$legacyAction',
+						actionBy: '$actor.name',
+						actionAt: '$occurredAt',
+						active: { $literal: true },
+					},
+				},
+				{ $sort: { actionAt: -1 } },
+			],
+			as: 'auditLogs',
+		},
+	};
+};

--- a/template.yaml
+++ b/template.yaml
@@ -619,6 +619,27 @@ Resources:
         EntryPoints: [controllers/products/exportProductPDF.ts]
 
   # ──────────────────────────────────────────────────────────────────────────
+  # AUDIT LOGS V2
+  # ──────────────────────────────────────────────────────────────────────────
+
+  GetAuditLogsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/auditLogs/getAuditLogs.lambdaHandler
+      Events:
+        GetAuditLogs:
+          Type: Api
+          Properties:
+            Path: /audit-logs
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/auditLogs/getAuditLogs.ts]
+
+  # ──────────────────────────────────────────────────────────────────────────
   # BOOKMARKS
   # ──────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
- Added a full `auditLogV2` system: new model, shared `recordAuditEvent` utility, event catalog/summaries, and index support.
- Wired v2 audit event writes across core backend flows (products, projects, departments, source files, and product data updates).
- Added new `GET /audit-logs` API with pagination, filters (scope/action/date/search), and visibility rules based on user role.
- Updated read-side aggregation to fetch from v2 but map output to legacy v1 shape so existing UI behavior does not break.
- Removed leftover v1 audit logging code (`updateAuditLog`/`AuditLogAction` paths) and cleaned related controller/helper plumbing, plus added backfill support for legacy audit records.