### PR TITLE
fix: cap product export worker Lambda memory at 3008 MB

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -718,7 +718,7 @@ Resources:
       CodeUri: src/
       Handler: controllers/exports/processExportJob.lambdaHandler
       Timeout: 900
-      MemorySize: 3072
+      MemorySize: 3008
       Environment:
         Variables:
           EXPORTS_PREFIX: exports


### PR DESCRIPTION
## Summary
- Reduce `ProcessProductExportJobFunction` memory from `3072` to `3008` in `template.yaml`.
- Prevent CloudFormation failure in accounts currently capped at `3008` MB Lambda memory.