### PR TITLE
fix: resolve cloud failures in product export worker

### DIFF
--- a/samconfig.toml
+++ b/samconfig.toml
@@ -7,6 +7,6 @@ s3_prefix = "uprevit-test"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "MongoDbUri=\"mongodb+srv://uprevit-testing:sat272011-uprevit@uprevit-test.bh21hmu.mongodb.net/?retryWrites=true&w=majority&appName=Uprevit-test\" DbName=\"uprevit-test\" UserPoolId=\"us-east-1_mpuQjaoL2\" ClientId=\"7vvr577cmdnbbo1qjv8e0m40nd\""
+parameter_overrides = "MongoDbUri=\"mongodb+srv://uprevit-testing:sat272011-uprevit@uprevit-test.bh21hmu.mongodb.net/?retryWrites=true&w=majority&appName=Uprevit-test\" DbName=\"uprevit-test\" UserPoolId=\"us-east-1_mpuQjaoL2\" ClientId=\"7vvr577cmdnbbo1qjv8e0m40nd\" UploadsBucket=\"uprevit-storage-dev-and-test\" ExportsBucket=\"exports-storage-dev-and-test\""
 image_repositories = []
 disable_rollback = false

--- a/src/controllers/exports/processExportJob.ts
+++ b/src/controllers/exports/processExportJob.ts
@@ -27,6 +27,13 @@ const MAX_RECEIVE_COUNT = Number.isFinite(parsedMaxReceiveCount)
  */
 class NonRetryableExportJobError extends Error {}
 
+const NON_RETRYABLE_AWS_ERROR_NAMES = new Set([
+	'NoSuchBucket',
+	'AccessDenied',
+	'InvalidAccessKeyId',
+	'SignatureDoesNotMatch',
+]);
+
 type ExportArtifact = {
 	buffer: Buffer;
 	fileName: string;
@@ -44,6 +51,17 @@ const getReceiveCount = (record: SQSRecord): number => {
 const toFailureMessage = (error: unknown): string => {
 	if (error instanceof Error && error.message) return error.message;
 	return 'Export job failed';
+};
+
+const isNonRetryableError = (error: unknown): boolean => {
+	if (error instanceof NonRetryableExportJobError) return true;
+
+	if (!error || typeof error !== 'object') return false;
+
+	const errorName = (error as { name?: unknown }).name;
+	if (typeof errorName !== 'string') return false;
+
+	return NON_RETRYABLE_AWS_ERROR_NAMES.has(errorName);
 };
 
 const parseQueueMessage = (record: SQSRecord): ProcessableExportQueueMessage => {
@@ -187,7 +205,7 @@ export const lambdaHandler = async (event: SQSEvent): Promise<SQSBatchResponse> 
 				receiveCount,
 			});
 		} catch (error) {
-			const isNonRetryable = error instanceof NonRetryableExportJobError;
+			const isNonRetryable = isNonRetryableError(error);
 			const shouldStopRetry = isNonRetryable || receiveCount >= MAX_RECEIVE_COUNT;
 
 			if (parsedMessage?.jobId && shouldStopRetry && ObjectId.isValid(parsedMessage.jobId)) {

--- a/src/utils/exportExcelStyling.ts
+++ b/src/utils/exportExcelStyling.ts
@@ -50,7 +50,9 @@ export const applyStandardStyling = (worksheet: any) => {
 		});
 	});
 
-	worksheet.columns.forEach((column: any) => {
+	const columns = Array.isArray(worksheet.columns) ? worksheet.columns : [];
+
+	columns.forEach((column: any) => {
 		let maxLength = 0;
 		if (column.header) {
 			maxLength = column.header.toString().length;

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Parameters:
   ExportsBucket:
     Type: String
     Description: "S3 bucket name for generated export files"
-    Default: "uprevit-exports-dev-and-test"
+    Default: "exports-storage-dev-and-test"
   ExportJobQueueUrl:
     Type: String
     Description: "Optional explicit SQS queue URL override for local/dev"


### PR DESCRIPTION
## Summary
- Align deploy/runtime export bucket configuration to `exports-storage-dev-and-test` so worker uploads target an existing bucket.
- Guard Excel worksheet styling when columns are missing and mark non-retryable S3 configuration errors to stop unnecessary SQS retries.