### PR TITLE
Feature/update version comparison logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "dev": "sam sync --watch --stack-name uprevit-test --region us-east-1",
     "prepare:sam-env": "node scripts/prepare-sam-env.mjs",
     "start:local": "npm run prepare:sam-env && AWS_PROFILE=uprevit-amit sam local start-api --env-vars .sam-local-env.json"
   },

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -9,3 +9,4 @@ confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
 image_repositories = []
 disable_rollback = false
+watch = true

--- a/src/controllers/products/productData/label-components.ts
+++ b/src/controllers/products/productData/label-components.ts
@@ -30,6 +30,14 @@ export function addLabelComponent(
 			throw new Error('Data for add_label_component must be an array of label components.');
 		}
 
+		for (const component of newLabelComponentsData) {
+			const missingFieldsValidation = validateMissingFields({
+				component_number: component.component_number as string,
+				component_type: component.component_type as string,
+			});
+			if (missingFieldsValidation) throw new Error(missingFieldsValidation.body);
+		}
+
 		const componentsWithIds = newLabelComponentsData.map(component => ({
 			...component,
 			_id: new ObjectId(),
@@ -74,7 +82,6 @@ export function updateLabelComponent(
 			id: updatedLabelComponent.id,
 			component_number: updatedLabelComponent.component_number as string,
 			component_type: updatedLabelComponent.component_type as string,
-			component_description: updatedLabelComponent.component_description as string,
 		});
 		if (missingFieldsValidation) throw new Error(missingFieldsValidation.body);
 

--- a/src/controllers/products/productData/label-components.ts
+++ b/src/controllers/products/productData/label-components.ts
@@ -97,7 +97,9 @@ export function updateLabelComponent(
 				'label_components.data.$[elem].label_type': updatedLabelComponent.label_type,
 				'label_components.data.$[elem].component_number': updatedLabelComponent.component_number,
 				'label_components.data.$[elem].component_type': updatedLabelComponent.component_type,
-				'label_components.data.$[elem].component_description': updatedLabelComponent.component_description,
+				...(updatedLabelComponent.component_description !== undefined && {
+					'label_components.data.$[elem].component_description': updatedLabelComponent.component_description,
+				}),
 				...(updatedLabelComponent.key !== undefined && {
 					'label_components.data.$[elem].key': updatedLabelComponent.key,
 				}),

--- a/src/controllers/products/productData/product-info.ts
+++ b/src/controllers/products/productData/product-info.ts
@@ -9,6 +9,13 @@ import {
 	UpdateProductInformationCompletionData,
 } from '../../../types/products/product-info';
 
+type ExistingCustomField = {
+	_id: ObjectId;
+	parent_id?: string | null;
+	label: string;
+	value: string;
+};
+
 /**
  * Handles the update of product information fields.
  * @param {UpdateProductInformationData} inputData - The data object containing product information fields.
@@ -118,12 +125,14 @@ export function addCustomField(
  * @param {CustomFieldInput[]} inputData - An array of custom field data objects to update.
  * @param {string} tab - The current tab being updated.
  * @param {string} action - The action being performed.
+ * @param {ExistingCustomField[]} currentCustomFields - An array of existing custom fields to match against.
  * @return {Object} An object containing the update query, updated data, and any validation error.
  */
 export function updateCustomField(
 	inputData: CustomFieldInput[],
 	tab: string,
 	action: string,
+	currentCustomFields: ExistingCustomField[] = [],
 ): {
     updateQuery: Record<string, unknown>;
     updatedData: { customFields: CustomFieldInput[] };
@@ -134,14 +143,38 @@ export function updateCustomField(
 		if (isValidTabUpdateCustomField) throw new Error(isValidTabUpdateCustomField.body);
 	
 		if (!Array.isArray(inputData)) throw new Error('Data for updating custom fields must be an array.');
+
+		const existingFieldsById = new Map(
+			currentCustomFields.map((field) => [field._id.toString(), field]),
+		);
+
+		const normalizedCustomFields = inputData.map((field, index) => {
+			const fieldId = field.id ?? field.field_id;
+			const existingField = fieldId ? existingFieldsById.get(fieldId) : undefined;
+			const fallbackField = !fieldId ? currentCustomFields[index] : undefined;
+			const matchedField = existingField ?? fallbackField;
+
+			if (!matchedField) {
+				throw new Error('Each custom field update must reference an existing field id.');
+			}
+
+			return {
+				_id: matchedField._id,
+				parent_id: matchedField.parent_id ?? null,
+				label: field.label ?? matchedField.label,
+				value: field.value ?? matchedField.value,
+			};
+		});
 	
-		const validatedCustomFields = inputData.map((field) => ({
-			...field,
-			_id: field.id ? new ObjectId(field.id) : new ObjectId(),
-		}));
-	
-		const updateQuery = { $set: { 'product_information.custom_fields': validatedCustomFields } };
-		const updatedData = { customFields: inputData };
+		const updateQuery = { $set: { 'product_information.custom_fields': normalizedCustomFields } };
+		const updatedData = {
+			customFields: normalizedCustomFields.map((field) => ({
+				id: field._id.toString(),
+				parent_id: field.parent_id ?? null,
+				label: field.label,
+				value: field.value,
+			})),
+		};
 	
 		return { updateQuery, updatedData, error: null };
 	} catch (error) {

--- a/src/controllers/products/updateProductData.ts
+++ b/src/controllers/products/updateProductData.ts
@@ -363,7 +363,12 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			break;
 
 		case 'update_custom_field':
-			const updateCustomFieldResult = updateCustomField(input.data, input.tab, input.action);
+			const updateCustomFieldResult = updateCustomField(
+				input.data,
+				input.tab,
+				input.action,
+				product.product_information.custom_fields || [],
+			);
 			if (updateCustomFieldResult.error) return updateCustomFieldResult.error;
 
 			({ updateQuery, updatedData } = updateCustomFieldResult);

--- a/src/models/product.ts
+++ b/src/models/product.ts
@@ -30,12 +30,14 @@ export type ProductInformation = {
 			manufacturing_location: string;
 			custom_fields?: Array<{
 				_id: ObjectId;
+				parent_id?: string | null;
 				label: string;
 				value: string;
 			}>;
 		};
 	custom_fields?: Array<{
 		_id: ObjectId;
+		parent_id?: string | null;
 		label: string;
 		value: string;
 	}>;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -9,7 +9,8 @@
       "moduleResolution":"node",
       "esModuleInterop": true, 
       "skipLibCheck": true,
-      "forceConsistentCasingInFileNames": true,  
+      "forceConsistentCasingInFileNames": true,
+      "ignoreDeprecations": "6.0"
     },
     "exclude": ["node_modules", "**/*.test.ts"]
   }

--- a/src/types/products/product-info.ts
+++ b/src/types/products/product-info.ts
@@ -15,6 +15,8 @@ export interface UpdateProductInformationData {
 
 export interface CustomFieldInput {
     id?: string;
+    field_id?: string;
+    parent_id?: string | null;
     label?: string;
     value?: string;
 }
@@ -43,5 +45,4 @@ export type AddUpdateCustomField = BaseProductRequest<'add_custom_field' | 'upda
 export type DeleteCustomField = BaseProductRequest<'delete_custom_field', DeleteCustomFieldInput>;
 
 export type UpdateProductInfoTabCompletion = BaseProductRequest<'update_product_information_completion', UpdateProductInformationCompletionData>;
-
 


### PR DESCRIPTION
Closes #82
Closes #83
Closes #84

- Preserve existing product custom field IDs and metadata during updates, and reject invalid custom field updates that do not match existing records.
- Tighten label component validation to require the core fields for new entries while avoiding unnecessary validation on optional fields during updates.
- Add a SAM watch-based local dev command and adjust TypeScript config for the current toolchain.