### PR TITLE
feat: update workspace model and onboarding logic to handle admin name resolution

### DIFF
--- a/src/controllers/onboarding/adminOnboardingCreateWorkspace.ts
+++ b/src/controllers/onboarding/adminOnboardingCreateWorkspace.ts
@@ -35,20 +35,21 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
 
-		
 		const input = JSON.parse(event.body);
 		if(!input) return ResponseWrapper.badRequest('Invalid JSON in request body');
-		
+
+		const normalizedEmail = typeof input.email === 'string' ? input.email.trim().toLowerCase() : null;
+		if (!normalizedEmail) return ResponseWrapper.badRequest('Email must be a non-empty string');
 
 		const validationResult = validateMissingFields({
 			workspaceName: input.workspaceName,
 			companyName: input.companyName,
-			email: input.email,
+			email: normalizedEmail,
 		});
 		if (validationResult) return validationResult;
 
 		const db = await getDb();
-		const adminName = resolveAdminName(input.name, input.email);
+		const adminName = resolveAdminName(input.name, normalizedEmail);
 
 		const workspace = await db.collection<Workspace>('workspaces').insertOne({
 			workspaceName: input.workspaceName,
@@ -77,7 +78,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const user = await db.collection<User>('users').insertOne({
 			name: adminName,
-			email: input.email,
+			email: normalizedEmail,
 			userType: 'admin',
 			cognitoSub: cognitoSub,
 			workspaceId: workspaceId,
@@ -102,7 +103,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		await cognito.send(new AdminUpdateUserAttributesCommand({
 			UserPoolId: process.env.USER_POOL_ID!,
-			Username: input.email,
+			Username: normalizedEmail,
 			UserAttributes: [
 				{ Name: "custom:userId", Value: userId.toString() },
 				{ Name: "custom:workspaceId", Value: workspaceId.toString() },
@@ -111,8 +112,8 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}));
 
 		await cognito.send(new AdminAddUserToGroupCommand({
-			UserPoolId: process.env.USER_POOL_ID!, 
-			Username: input.email, 
+			UserPoolId: process.env.USER_POOL_ID!,
+			Username: normalizedEmail,
 			GroupName: "admin",
 		}));
 		

--- a/src/controllers/onboarding/adminOnboardingCreateWorkspace.ts
+++ b/src/controllers/onboarding/adminOnboardingCreateWorkspace.ts
@@ -13,6 +13,13 @@ import { normalizePersistedAssetReference } from '../../utils/s3-storage';
 
 const cognito = new CognitoIdentityProviderClient();
 
+const resolveAdminName = (name: unknown, email: string): string => {
+	const trimmedName = typeof name === 'string' ? name.trim() : '';
+	if (trimmedName && trimmedName.toLowerCase() !== 'test') return trimmedName;
+
+	return email.split('@')[0].trim();
+};
+
 /**
  * @param {APIGatewayProxyEvent} event 
  * @return  {Promise<APIGatewayProxyResult>}
@@ -36,18 +43,16 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const validationResult = validateMissingFields({
 			workspaceName: input.workspaceName,
 			companyName: input.companyName,
-			companyId: input.companyId,
-			name: input.name,
 			email: input.email,
 		});
 		if (validationResult) return validationResult;
 
 		const db = await getDb();
+		const adminName = resolveAdminName(input.name, input.email);
 
 		const workspace = await db.collection<Workspace>('workspaces').insertOne({
 			workspaceName: input.workspaceName,
 			companyName: input.companyName,
-			companyId: input.companyId,
 			description: input.description || '',
 			logo: normalizePersistedAssetReference(input.logo, ''),
 			plan: input.plan || '',
@@ -71,7 +76,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		});
 
 		const user = await db.collection<User>('users').insertOne({
-			name: input.name,
+			name: adminName,
 			email: input.email,
 			userType: 'admin',
 			cognitoSub: cognitoSub,

--- a/src/controllers/workspaces/createWorkspace.ts
+++ b/src/controllers/workspaces/createWorkspace.ts
@@ -36,7 +36,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const validationResult = validateMissingFields({
 			'workspaceName': input.workspaceName,
 			'companyName': input.companyName,
-			'companyId': input.companyId,
 		});
 		
 		if (validationResult) {
@@ -48,7 +47,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const workspace = await db.collection<Workspace>('workspaces').insertOne({
 			workspaceName: input.workspaceName,
 			companyName: input.companyName,
-			companyId: input.companyId,
 			description: input.description || '',
 			logo: normalizePersistedAssetReference(input.logo, ''),
 			plan: input.plan || '',

--- a/src/controllers/workspaces/updateWorkspace.ts
+++ b/src/controllers/workspaces/updateWorkspace.ts
@@ -83,7 +83,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				$set: {
 					workspaceName: input.workspaceName,
 					companyName: input.companyName,
-					companyId: input.companyId,
 					description: input.description,
 					logo: normalizePersistedAssetReference(input.logo, workspaceRecord.logo ?? ''),
 					plan: input.plan,

--- a/src/models/workspace.ts
+++ b/src/models/workspace.ts
@@ -4,7 +4,7 @@ export type Workspace = {
 	_id?: ObjectId;
 	workspaceName: string;
 	companyName: string;
-	companyId: string;
+	companyId?: string;
 	description: string;
 	logo: string;
 	plan: string;


### PR DESCRIPTION
- Remove company ID while creating or updating the workspace
- Resolve admin name while creating workspace and admin's profile
- Normalize admin email before using it for profile and Cognito updates

Closes #93