### PR TITLE
feat: implement scoped upload paths and asset management

### DIFF
--- a/src/controllers/onboarding/adminOnboardingCreateWorkspace.ts
+++ b/src/controllers/onboarding/adminOnboardingCreateWorkspace.ts
@@ -9,7 +9,7 @@ import { validateMissingFields } from "../../utils/validationUtils";
 import { authenticateWithRole } from "../../utils/authUtils";
 import { User } from "../../models/user";
 import { AdminAddUserToGroupCommand, AdminUpdateUserAttributesCommand, CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
-import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { movePendingWorkspaceAssetToWorkspace, normalizePersistedAssetReference } from '../../utils/s3-storage';
 
 const cognito = new CognitoIdentityProviderClient();
 
@@ -50,12 +50,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const db = await getDb();
 		const adminName = resolveAdminName(input.name, normalizedEmail);
+		const normalizedLogo = normalizePersistedAssetReference(input.logo, '');
 
 		const workspace = await db.collection<Workspace>('workspaces').insertOne({
 			workspaceName: input.workspaceName,
 			companyName: input.companyName,
 			description: input.description || '',
-			logo: normalizePersistedAssetReference(input.logo, ''),
+			logo: normalizedLogo,
 			plan: input.plan || '',
 			planName: input.planName || '',
 			planId: input.planId || '',
@@ -66,6 +67,17 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		});
 
 		const workspaceId = workspace.insertedId
+
+		const workspaceLogo = normalizedLogo
+			? await movePendingWorkspaceAssetToWorkspace(normalizedLogo, workspaceId.toString())
+			: '';
+
+		if (workspaceLogo !== normalizedLogo) {
+			await db.collection<Workspace>('workspaces').updateOne(
+				{ _id: workspaceId },
+				{ $set: { logo: workspaceLogo } },
+			);
+		}
 
 		await updateAuditLog({
 			entity: 'workspace',

--- a/src/controllers/s3Storage/presignUpload.ts
+++ b/src/controllers/s3Storage/presignUpload.ts
@@ -1,8 +1,13 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ObjectId } from "mongodb";
 import { authenticateRequest } from "../../utils/authUtils";
+import { getAuthenticatedUserContext } from "../../utils/authenticatedUser";
+import { getDb } from "../../utils/db";
+import { logError } from "../../utils/logger";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { validateMissingFields } from "../../utils/validationUtils";
-import { createPresignedUrl } from "../../utils/s3-storage";
+import { createPresignedUrl, type UploadScope } from "../../utils/s3-storage";
+import type { Product } from "../../models/product";
 
 const PRODUCT_ASSET_CONTENT_TYPES = new Set([
 	"image/png",
@@ -33,6 +38,11 @@ const isAllowedContentType = (contentType: string, uploadScope: string): boolean
 	return false;
 };
 
+const resolveUploadScope = (value: unknown): UploadScope => {
+	if (value === "product-assets" || value === "source-files") return value;
+	return "workspace-assets";
+};
+
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
 		const auth = await authenticateRequest(event);
@@ -49,16 +59,51 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (missingFieldsResult) return missingFieldsResult;
 
 		const contentType = input.contentType!.trim().toLowerCase();
-		const uploadScope = input.uploadScope === "source-files" ? "source-files" : "product-assets";
+		const uploadScope = resolveUploadScope(input.uploadScope);
 
 		if (!isAllowedContentType(contentType, uploadScope)) {
 			return ResponseWrapper.badRequest(`Unsupported contentType: ${input.contentType}`);
 		}
 
-		const { uploadUrl, key } = await createPresignedUrl(input.fileName!, contentType);
+		const userContext = await getAuthenticatedUserContext(auth.payload.sub);
+
+		if (!userContext) {
+			if (uploadScope !== "workspace-assets") {
+				return ResponseWrapper.forbidden('Valid Workspace is required for this upload.');
+			}
+
+			const { uploadUrl, key } = await createPresignedUrl(input.fileName!, contentType, {
+				uploadScope,
+				pendingOwnerId: auth.payload.sub,
+			});
+
+			return ResponseWrapper.created({ message: "Presigned URL generated successfully.", uploadUrl, key, expiresIn: 3600 });
+		}
+
+		let productId: string | undefined;
+		if (uploadScope === "product-assets") {
+			productId = typeof input.productId === "string" ? input.productId.trim() : "";
+			if (!productId) return ResponseWrapper.badRequest('productId is required for product uploads.');
+			if (!ObjectId.isValid(productId)) return ResponseWrapper.badRequest('Invalid productId.');
+
+			const db = await getDb();
+			const product = await db.collection<Product>('products').findOne({
+				_id: new ObjectId(productId),
+				workspace_id: userContext.workspaceId,
+			}, { projection: { _id: 1 } });
+
+			if (!product) return ResponseWrapper.forbidden('You are not authorized to upload files for this product.');
+		}
+
+		const { uploadUrl, key } = await createPresignedUrl(input.fileName!, contentType, {
+			uploadScope,
+			workspaceId: userContext.workspaceId.toString(),
+			productId,
+		});
 
 		return ResponseWrapper.created({ message: "Presigned URL generated successfully.", uploadUrl, key, expiresIn: 3600 });
 	} catch (error) {
+		logError('Failed to generate presigned upload URL', error);
 		return ResponseWrapper.internalServerError('Failed to generate presigned URL.');
 	}
 }

--- a/src/utils/s3-storage.ts
+++ b/src/utils/s3-storage.ts
@@ -1,4 +1,4 @@
-import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { CopyObjectCommand, DeleteObjectCommand, GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import crypto from "node:crypto";
 
@@ -22,9 +22,53 @@ const SIGNING_CONCURRENCY = parsePositiveInteger(process.env.S3_SIGNING_CONCURRE
 
 export const client = new S3Client({ region });
 
-export const createPresignedUrl = async (filename: string, contentType: string) => {
-	const safeFilename = filename.replace(/[^a-zA-Z0-9._-]/g, "_");
-	const key = `uploads/${crypto.randomUUID()}-${safeFilename}`;
+export type UploadScope = "workspace-assets" | "product-assets" | "source-files";
+
+type CreatePresignedUploadOptions = {
+	workspaceId?: string;
+	productId?: string;
+	uploadScope?: UploadScope;
+	pendingOwnerId?: string;
+};
+
+const sanitizeFilename = (filename: string): string => filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+
+const buildUniqueFilename = (filename: string): string => `${crypto.randomUUID()}-${sanitizeFilename(filename)}`;
+
+export const buildUploadKey = ({
+	filename,
+	workspaceId,
+	productId,
+	uploadScope = "workspace-assets",
+	pendingOwnerId,
+}: CreatePresignedUploadOptions & { filename: string }): string => {
+	const uniqueFilename = buildUniqueFilename(filename);
+
+	if (uploadScope === "source-files" && workspaceId) {
+		return `uploads/${workspaceId}/source-files/${uniqueFilename}`;
+	}
+
+	if (uploadScope === "product-assets" && workspaceId && productId) {
+		return `uploads/${workspaceId}/product/${productId}/${uniqueFilename}`;
+	}
+
+	if (uploadScope === "workspace-assets" && workspaceId) {
+		return `uploads/${workspaceId}/workspace/${uniqueFilename}`;
+	}
+
+	if (uploadScope === "workspace-assets" && pendingOwnerId) {
+		return `uploads/pending/${pendingOwnerId}/${uniqueFilename}`;
+	}
+
+	return `uploads/${uniqueFilename}`;
+};
+
+export const createPresignedUrl = async (
+	filename: string,
+	contentType: string,
+	options: CreatePresignedUploadOptions = {},
+) => {
+	const key = buildUploadKey({ filename, ...options });
 
 	const command = new PutObjectCommand({
 		Bucket: uploadsBucket,
@@ -57,6 +101,36 @@ export const deleteObjectByKey = async (key: string) => {
 			Key: key,
 		}),
 	);
+};
+
+const buildCopySource = (bucket: string, key: string): string => {
+	const encodedKey = key.split('/').map(encodeURIComponent).join('/');
+	return `${bucket}/${encodedKey}`;
+};
+
+export const movePendingWorkspaceAssetToWorkspace = async (
+	key: string,
+	workspaceId: string,
+): Promise<string> => {
+	const normalizedKey = normalizeKey(key);
+	if (!normalizedKey || !normalizedKey.startsWith("uploads/pending/")) return key;
+
+	const fileName = normalizedKey.split('/').pop();
+	if (!fileName) return key;
+
+	const targetKey = `uploads/${workspaceId}/workspace/${fileName}`;
+
+	await client.send(
+		new CopyObjectCommand({
+			Bucket: uploadsBucket,
+			CopySource: buildCopySource(uploadsBucket, normalizedKey),
+			Key: targetKey,
+		}),
+	);
+
+	await deleteObjectByKey(normalizedKey);
+
+	return targetKey;
 };
 
 type UploadObjectInput = {

--- a/template.yaml
+++ b/template.yaml
@@ -212,6 +212,12 @@ Resources:
                 - cognito-idp:AdminUpdateUserAttributes
                 - cognito-idp:AdminAddUserToGroup
               Resource: !Sub "arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${UserPoolId}"
+            - Effect: Allow
+              Action:
+                - s3:GetObject
+                - s3:PutObject
+                - s3:DeleteObject
+              Resource: !Sub "arn:aws:s3:::${UploadsBucket}/uploads/*"
       Events:
         AdminOnboardingCreateWorkspace:
           Type: Api


### PR DESCRIPTION
Introduce a structured S3 key hierarchy to support different upload scopes:
- `workspace-assets`: Files associated with a specific workspace.
- `product-assets`: Files associated with a specific product within a workspace.
- `source-files`: Files associated with workspace source files.
- `pending`: Temporary storage for assets uploaded before workspace creation.

Key changes:
- Refactored `createPresignedUrl` to use `buildUploadKey` for scoped path generation.
- Added `movePendingWorkspaceAssetToWorkspace` to migrate assets from pending to workspace storage during onboarding.
- Updated `presignUpload` controller to validate user context and authorization for different upload scopes.
- Updated `adminOnboardingCreateWorkspace` to handle logo asset migration upon workspace creation.
- Added necessary S3 permissions to `template.yaml`.

Closes #96