### PR TITLE
Add server-side pagination, sorting, and filters to workspace list APIs

### DIFF
--- a/src/controllers/departments/getAllDepartments.ts
+++ b/src/controllers/departments/getAllDepartments.ts
@@ -116,15 +116,14 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (filtersMatch.error) return filtersMatch.error;
 		if (filtersMatch.match) pipeline.push({ $match: filtersMatch.match });
 
-		const departments = await db
-			.collection<Department>('departments')
-			.aggregate<DepartmentWithUsers>(pipeline.concat([{ $sort: sortObj }, { $skip: skip }, { $limit: limit }]))
-			.toArray();
-
-		const countResult = await db
-			.collection<Department>('departments')
-			.aggregate<{ total: number }>(pipeline.concat({ $count: 'total' }))
-			.toArray();
+		const [departments, countResult] = await Promise.all([
+			db.collection<Department>('departments')
+				.aggregate<DepartmentWithUsers>(pipeline.concat([{ $sort: sortObj }, { $skip: skip }, { $limit: limit }]))
+				.toArray(),
+			db.collection<Department>('departments')
+				.aggregate<{ total: number }>(pipeline.concat({ $count: 'total' }))
+				.toArray(),
+		]);
 		const totalCount = countResult.length > 0 ? countResult[0].total : 0;
 
 		const departmentsWithSignedAvatars = await Promise.all(

--- a/src/controllers/departments/getAllDepartments.ts
+++ b/src/controllers/departments/getAllDepartments.ts
@@ -7,6 +7,21 @@ import { logError } from '../../utils/logger';
 import { authenticateRequest } from '../../utils/authUtils';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 import { enrichDepartmentsWithImageUrls, enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
+import { buildListFiltersMatch, ListFilterField, parseListQuery } from '../../utils/listQuery';
+
+const ALLOWED_SORT_FIELDS = ['department_name', 'department_description', 'manager', 'actionAt', '_id'];
+
+const DEPARTMENT_FILTER_FIELDS: Record<string, ListFilterField> = {
+	department_name: { path: 'department_name', type: 'text' },
+	department_description: { path: 'department_description', type: 'text' },
+	manager: { path: 'manager', type: 'text' },
+	actionBy: { path: 'actionBy', type: 'text' },
+	actionAt: { path: 'actionAt', type: 'date' },
+	lastChangedBy: { path: 'actionBy', type: 'text' },
+	lastChangedOn: { path: 'actionAt', type: 'date' },
+	archivedBy: { path: 'actionBy', type: 'text' },
+	archivedOn: { path: 'actionAt', type: 'date' },
+};
 
 type DepartmentUser = {
 	_id: ObjectId;
@@ -36,74 +51,81 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const db = await getDb();
 
-		const limit = parseInt(event.queryStringParameters?.limit || '10');
-		const page = parseInt(event.queryStringParameters?.page || '1');
-		const sort = event.queryStringParameters?.sort || 'department_name';
+		const listQueryResult = parseListQuery({
+			query: event.queryStringParameters,
+			allowedSortFields: ALLOWED_SORT_FIELDS,
+			defaultSort: 'department_name',
+		});
+		if (listQueryResult.error) return listQueryResult.error;
+
+		const { limit, page, skip, sort, order, filters } = listQueryResult.value!;
 		const workspaceId = event.queryStringParameters?.workspaceId;
 
 		if (!workspaceId) return ResponseWrapper.badRequest('Workspace ID is required.');
+		if (!ObjectId.isValid(workspaceId)) return ResponseWrapper.badRequest('Invalid workspaceId');
 
 		const isArchiveParam = event.queryStringParameters?.isArchive;
 		let isArchive = false;
 
 		if (isArchiveParam !== undefined) {
+			if (isArchiveParam !== 'true' && isArchiveParam !== 'false') {
+				return ResponseWrapper.badRequest('isArchive parameter must be true or false');
+			}
 			isArchive = isArchiveParam.toLowerCase() === 'true';
 		}
 
-		if (limit < 1 || limit > 100) {
-			return ResponseWrapper.badRequest('Limit must be between 1 and 100');
-		}
-
-		if (page < 1) {
-			return ResponseWrapper.badRequest('Page must be greater than 0');
-		}
-
-		const allowedSortFields = ['department_name', 'department_description', 'manager', '_id'];
-		if (!allowedSortFields.includes(sort)) {
-			return ResponseWrapper.badRequest(`Invalid sort field. Allowed fields: ${allowedSortFields.join(', ')}`);
-		}
-
-		const skip = (page - 1) * limit;
-
 		const sortObj: { [key: string]: 1 | -1 } = {};
-		sortObj[sort] = 1;
+		sortObj[sort] = order === 'desc' ? -1 : 1;
 
 		const filter = isArchive
 			? { isArchived: true, workspace_id: new ObjectId(workspaceId) }
 			: { isArchived: { $ne: true }, workspace_id: new ObjectId(workspaceId) };
 
-		const totalCount = await db.collection<Department>('departments').countDocuments(filter);
+		const pipeline = [
+			{ $match: filter },
+			{
+				$lookup: {
+					from: 'users',
+					localField: 'users',
+					foreignField: '_id',
+					pipeline: [
+						{
+							$project: {
+								_id: 1,
+								name: 1,
+								email: 1,
+								profileAvatar: 1,
+							},
+						},
+					],
+					as: 'users',
+				},
+			},
+			isArchive
+				? buildLegacyAuditLookupStage({ scopeType: 'department', mode: 'archive' })
+				: buildLegacyAuditLookupStage({ scopeType: 'department', updateActions: ['update', 'restore'] }),
+			{
+				$addFields: {
+					actionBy: { $arrayElemAt: ['$auditLogs.actionBy', 0] },
+					actionAt: { $arrayElemAt: ['$auditLogs.actionAt', 0] },
+				},
+			},
+		];
+
+		const filtersMatch = buildListFiltersMatch(filters, DEPARTMENT_FILTER_FIELDS);
+		if (filtersMatch.error) return filtersMatch.error;
+		if (filtersMatch.match) pipeline.push({ $match: filtersMatch.match });
 
 		const departments = await db
 			.collection<Department>('departments')
-			.aggregate<DepartmentWithUsers>([
-				{ $match: filter },
-				{ $sort: sortObj },
-				{ $skip: skip },
-				{ $limit: limit },
-				{
-					$lookup: {
-						from: 'users',
-						localField: 'users',
-						foreignField: '_id',
-						pipeline: [
-							{
-								$project: {
-									_id: 1,
-									name: 1,
-									email: 1,
-									profileAvatar: 1,
-								},
-							},
-						],
-						as: 'users',
-					},
-				},
-				isArchive
-					? buildLegacyAuditLookupStage({ scopeType: 'department', mode: 'archive' })
-					: buildLegacyAuditLookupStage({ scopeType: 'department', updateActions: ['update', 'restore'] }),
-			])
+			.aggregate<DepartmentWithUsers>(pipeline.concat([{ $sort: sortObj }, { $skip: skip }, { $limit: limit }]))
 			.toArray();
+
+		const countResult = await db
+			.collection<Department>('departments')
+			.aggregate<{ total: number }>(pipeline.concat({ $count: 'total' }))
+			.toArray();
+		const totalCount = countResult.length > 0 ? countResult[0].total : 0;
 
 		const departmentsWithSignedAvatars = await Promise.all(
 			departments.map(async (department) => {

--- a/src/controllers/products/getAllProducts.ts
+++ b/src/controllers/products/getAllProducts.ts
@@ -6,6 +6,54 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { authenticateRequest } from '../../utils/authUtils';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
+import { buildListFiltersMatch, ListFilterField, parseListQuery } from '../../utils/listQuery';
+
+const ALLOWED_SORT_FIELDS = [
+	'product_name',
+	'product_plan_number',
+	'product_description',
+	'project_name',
+	'department_name',
+	'version',
+	'status',
+	'target_date',
+	'complete_count',
+	'createdBy',
+	'createdOn',
+	'modifiedBy',
+	'modifiedOn',
+	'archivedBy',
+	'archivedOn',
+	'actionAt',
+	'_id',
+];
+
+const ACTIVE_FILTER_FIELDS: Record<string, ListFilterField> = {
+	product_name: { path: 'product_name', type: 'text' },
+	product_plan_number: { path: 'product_plan_number', type: 'text' },
+	project_name: { path: 'project_name', type: 'text' },
+	department_name: { path: 'department_name', type: 'text' },
+	status: { path: 'status', type: 'text' },
+	version: { path: 'version', type: 'number' },
+	complete_count: { path: 'complete_count', type: 'number' },
+	progress: { path: 'complete_count', type: 'number' },
+	createdBy: { path: 'createdBy', type: 'text' },
+	createdOn: { path: 'createdOn', type: 'date' },
+	modifiedBy: { path: 'modifiedBy', type: 'text' },
+	modifiedOn: { path: 'modifiedOn', type: 'date' },
+};
+
+const ARCHIVE_FILTER_FIELDS: Record<string, ListFilterField> = {
+	product_name: { path: 'product_name', type: 'text' },
+	product_plan_number: { path: 'product_plan_number', type: 'text' },
+	project_name: { path: 'project_name', type: 'text' },
+	department_name: { path: 'department_name', type: 'text' },
+	version: { path: 'version', type: 'number' },
+	complete_count: { path: 'complete_count', type: 'number' },
+	progress: { path: 'complete_count', type: 'number' },
+	archivedBy: { path: 'archivedBy', type: 'text' },
+	archivedOn: { path: 'archivedOn', type: 'date' },
+};
 
 /**
  * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
@@ -26,46 +74,39 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const db = await getDb();
 
-		// Extract query parameters for pagination and filtering
-		const limit = parseInt(event.queryStringParameters?.limit || '10');
-		const page = parseInt(event.queryStringParameters?.page || '1');
-		const sort = event.queryStringParameters?.sort || 'product_name';
+		const listQueryResult = parseListQuery({
+			query: event.queryStringParameters,
+			allowedSortFields: ALLOWED_SORT_FIELDS,
+			defaultSort: 'product_name',
+		});
+		if (listQueryResult.error) return listQueryResult.error;
+
+		const { limit, page, skip, sort, order, filters } = listQueryResult.value!;
 		const isLatest = event.queryStringParameters?.isLatest || 'true';
 		const statusFilter = event.queryStringParameters?.status;
 		const filterParam = event.queryStringParameters?.filter;
 		const workspaceId = event.queryStringParameters?.workspaceId;
-
-		// Validate pagination parameters
-		if (limit < 1 || limit > 100) {
-			return ResponseWrapper.badRequest('Limit must be between 1 and 100');
-		}
-
-		if (page < 1) {
-			return ResponseWrapper.badRequest('Page must be greater than 0');
-		}
-
-		// Validate sort field
-		const allowedSortFields = [
-			'product_name',
-			'product_plan_number',
-			'product_description',
-			'version',
-			'status',
-			'target_date',
-			'actionAt',
-			'_id',
-		];
-		if (!allowedSortFields.includes(sort)) {
-			return ResponseWrapper.badRequest(`Invalid sort field. Allowed fields: ${allowedSortFields.join(', ')}`);
-		}
-
-		const skip = (page - 1) * limit;
+		const projectId = event.queryStringParameters?.projectId;
+		const departmentId = event.queryStringParameters?.departmentId;
 
 		// Build filter object
 		const filter: any = {};
 		let statusValues: string[] | null = null;
 
-		if (workspaceId) filter.workspace_id = new ObjectId(workspaceId);
+		if (workspaceId) {
+			if (!ObjectId.isValid(workspaceId)) return ResponseWrapper.badRequest('Invalid workspaceId');
+			filter.workspace_id = new ObjectId(workspaceId);
+		}
+
+		if (projectId) {
+			if (!ObjectId.isValid(projectId)) return ResponseWrapper.badRequest('Invalid projectId');
+			filter.project_id = new ObjectId(projectId);
+		}
+
+		if (departmentId) {
+			if (!ObjectId.isValid(departmentId)) return ResponseWrapper.badRequest('Invalid departmentId');
+			filter.department_id = new ObjectId(departmentId);
+		}
 		
 
 		if (statusFilter) {
@@ -73,7 +114,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				const statusArray = JSON.parse(statusFilter);
 				if (Array.isArray(statusArray) && statusArray.length > 0) {
 					filter.status = { $in: statusArray };
-					statusValues = statusArray;
+					statusValues = statusArray.filter((status): status is string => typeof status === 'string');
 				}
 			} catch (e) {
 				// If parsing fails, treat as single status
@@ -140,23 +181,52 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			}
 		];
 
-		// Add sorting based on the sort parameter
-		if (sort === 'actionAt') {
-			// Sort by the first audit log's actionAt
-			pipeline.push({ $sort: { 'auditLogs.0.actionAt': -1 } });
-		} else {
-			// Sort by the specified field
-			const sortObj: { [key: string]: 1 | -1 } = {};
-			sortObj[sort] = 1;
-			pipeline.push({ $sort: sortObj });
-		}
+		pipeline.push({
+			$addFields: {
+				project_name: { $arrayElemAt: ['$project.project_name', 0] },
+				department_name: { $arrayElemAt: ['$department.department_name', 0] },
+				actionBy: { $arrayElemAt: ['$auditLogs.actionBy', 0] },
+				actionAt: { $arrayElemAt: ['$auditLogs.actionAt', 0] },
+				createdAudit: {
+					$first: {
+						$filter: { input: '$auditLogs', as: 'auditLog', cond: { $eq: ['$$auditLog.action', 'create'] } },
+					},
+				},
+				modifiedAudit: {
+					$first: {
+						$filter: { input: '$auditLogs', as: 'auditLog', cond: { $eq: ['$$auditLog.action', 'update'] } },
+					},
+				},
+			},
+		});
+		pipeline.push({
+			$addFields: {
+				createdBy: '$createdAudit.actionBy',
+				createdOn: '$createdAudit.actionAt',
+				modifiedBy: '$modifiedAudit.actionBy',
+				modifiedOn: '$modifiedAudit.actionAt',
+				archivedBy: '$actionBy',
+				archivedOn: '$actionAt',
+			},
+		});
+
+		const filtersMatch = buildListFiltersMatch(
+			filters,
+			isArchiveOnlyStatus ? ARCHIVE_FILTER_FIELDS : ACTIVE_FILTER_FIELDS,
+		);
+		if (filtersMatch.error) return filtersMatch.error;
+		if (filtersMatch.match) pipeline.push({ $match: filtersMatch.match });
+
+		const sortObj: { [key: string]: 1 | -1 } = {};
+		sortObj[sort] = order === 'desc' ? -1 : 1;
+		pipeline.push({ $sort: sortObj });
 
 		// Add pagination
 		pipeline.push({ $skip: skip });
 		pipeline.push({ $limit: limit });
 
 		// Get total count for pagination
-		const countPipeline = [{ $match: filter }, { $count: 'total' }];
+		const countPipeline = pipeline.slice(0, -3).concat({ $count: 'total' });
 
 		const [products, countResult] = await Promise.all([
 			db.collection<Product>('products').aggregate(pipeline).toArray(),

--- a/src/controllers/projects/getAllProjects.ts
+++ b/src/controllers/projects/getAllProjects.ts
@@ -7,6 +7,21 @@ import { logError } from '../../utils/logger';
 import { authenticateRequest } from '../../utils/authUtils';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 import { enrichProjectsWithImageUrls, enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
+import { buildListFiltersMatch, ListFilterField, parseListQuery } from '../../utils/listQuery';
+
+const ALLOWED_SORT_FIELDS = ['project_name', 'project_description', 'project_manager', '_id', 'actionAt'];
+
+const PROJECT_FILTER_FIELDS: Record<string, ListFilterField> = {
+	project_name: { path: 'project_name', type: 'text' },
+	project_description: { path: 'project_description', type: 'text' },
+	project_manager: { path: 'project_manager', type: 'text' },
+	actionBy: { path: 'actionBy', type: 'text' },
+	actionAt: { path: 'actionAt', type: 'date' },
+	lastChangedBy: { path: 'actionBy', type: 'text' },
+	lastChangedOn: { path: 'actionAt', type: 'date' },
+	archivedBy: { path: 'actionBy', type: 'text' },
+	archivedOn: { path: 'actionAt', type: 'date' },
+};
 
 type ProjectUser = {
 	_id: ObjectId;
@@ -37,15 +52,22 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const db = await getDb();
 
-		// Extract query parameters for pagination
-		const limit = parseInt(event.queryStringParameters?.limit || '10');
-		const page = parseInt(event.queryStringParameters?.page || '1');
-		const sort = event.queryStringParameters?.sort || 'actionAt';
+		const listQueryResult = parseListQuery({
+			query: event.queryStringParameters,
+			allowedSortFields: ALLOWED_SORT_FIELDS,
+			defaultSort: 'actionAt',
+			defaultOrder: 'desc',
+		});
+		if (listQueryResult.error) return listQueryResult.error;
+
+		const { limit, page, skip, sort, order, filters } = listQueryResult.value!;
 		const workspaceId = event.queryStringParameters?.workspaceId;
 		const isArchiveParam = event.queryStringParameters?.isArchive || 'false';
+		const departmentId = event.queryStringParameters?.departmentId;
 
 		if (!workspaceId) return ResponseWrapper.badRequest('Workspace ID is required.');
-
+		if (!ObjectId.isValid(workspaceId)) return ResponseWrapper.badRequest('Invalid workspaceId');
+		if (departmentId && !ObjectId.isValid(departmentId)) return ResponseWrapper.badRequest('Invalid departmentId');
 
 		// Validate isArchive parameter
 		if (isArchiveParam !== 'true' && isArchiveParam !== 'false') {
@@ -55,140 +77,89 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		// Convert to boolean
 		const isArchive = isArchiveParam === 'true';
 
-		// Validate pagination parameters
-		if (limit < 1 || limit > 100) {
-			return ResponseWrapper.badRequest('Limit must be between 1 and 100');
-		}
-
-		if (page < 1) {
-			return ResponseWrapper.badRequest('Page must be greater than 0');
-		}
-
-		// Validate sort field
-		const allowedSortFields = [
-			'project_name',
-			'project_number',
-			'project_description',
-			'project_manager',
-			'_id',
-			'actionAt',
-		];
-		if (!allowedSortFields.includes(sort)) {
-			return ResponseWrapper.badRequest(`Invalid sort field. Allowed fields: ${allowedSortFields.join(', ')}`);
-		}
-
-		const skip = (page - 1) * limit;
-
 		// filter based on isArchive parameter
-		const filter = isArchive
+		const filter: Record<string, unknown> = isArchive
 			? { isArchived: true, workspace_id: new ObjectId(workspaceId) }
 			: { isArchived: { $ne: true }, workspace_id: new ObjectId(workspaceId) };
 
-		// If sorting by actionAt, use aggregation to join with audit_logs
-		if (sort === 'actionAt') {
-			const projectAuditLookupStage = isArchive
-				? buildLegacyAuditLookupStage({ scopeType: 'project', mode: 'archive' })
-				: buildLegacyAuditLookupStage({ scopeType: 'project', updateActions: ['update', 'restore'] });
+		if (departmentId) filter.department_id = new ObjectId(departmentId);
 
-			// aggregation pipeline
-			const pipeline = [
-				{ $match: filter },
-				{
-					$lookup: {
-						from: 'users',
-						localField: 'users',
-						foreignField: '_id',
-						pipeline: [
-							{
-								$project: {
-									_id: 1,
-									name: 1,
-									email: 1,
-									profileAvatar: 1,
-								},
+		const sortObj: { [key: string]: 1 | -1 } = {};
+		sortObj[sort] = order === 'desc' ? -1 : 1;
+
+		const pipeline = [
+			{ $match: filter },
+			{
+				$lookup: {
+					from: 'users',
+					localField: 'users',
+					foreignField: '_id',
+					pipeline: [
+						{
+							$project: {
+								_id: 1,
+								name: 1,
+								email: 1,
+								profileAvatar: 1,
 							},
-						],
-						as: 'users',
-					},
+						},
+					],
+					as: 'users',
 				},
-				projectAuditLookupStage,
-			];
-
-			// Get total count for pagination
-			const countPipeline = [{ $match: filter }, { $count: 'total' }];
-
-			const [projects, countResult] = await Promise.all([
-				db.collection<Project>('projects').aggregate<ProjectWithUsers>(pipeline).toArray(),
-				db.collection<Project>('projects').aggregate(countPipeline).toArray(),
-			]);
-
-			const projectsWithSignedAvatars = await Promise.all(
-				projects.map(async (project) => {
-					if (!project.users?.length) return project;
-
-					const usersWithSignedAvatars = await enrichUsersWithProfileAvatarUrls(project.users);
-
-					return {
-						...project,
-						users: usersWithSignedAvatars,
-					};
-				}),
-			);
-
-			const projectsWithSignedUrls = await enrichProjectsWithImageUrls(projectsWithSignedAvatars);
-
-			const totalCount = countResult.length > 0 ? countResult[0].total : 0;
-			const totalPages = Math.ceil(totalCount / limit);
-
-			return ResponseWrapper.success({message: 'Projects fetched successfully',
-				result: {
-					projects: projectsWithSignedUrls,
-					pagination: {
-						currentPage: page,
-						totalPages,
-						totalCount,
-						limit,
-						hasNextPage: page < totalPages,
-						hasPrevPage: page > 1,
-					},
+			},
+			isArchive
+				? buildLegacyAuditLookupStage({ scopeType: 'project', mode: 'archive' })
+				: buildLegacyAuditLookupStage({ scopeType: 'project', updateActions: ['update', 'restore'] }),
+			{
+				$addFields: {
+					actionBy: { $arrayElemAt: ['$auditLogs.actionBy', 0] },
+					actionAt: { $arrayElemAt: ['$auditLogs.actionAt', 0] },
 				},
-			});
-		} else {
-			// For other sort fields, use regular find with sort
-			const sortObj: { [key: string]: 1 | -1 } = {};
-			sortObj[sort] = 1;
+			},
+		];
 
-			// Get total count based on archived filter
-			const totalCount = await db.collection<Project>('projects').countDocuments(filter);
+		const filtersMatch = buildListFiltersMatch(filters, PROJECT_FILTER_FIELDS);
+		if (filtersMatch.error) return filtersMatch.error;
+		if (filtersMatch.match) pipeline.push({ $match: filtersMatch.match });
 
-			// Get paginated projects based on archived filter
-			const projects = await db
-				.collection<Project>('projects')
-				.find(filter)
-				.sort(sortObj)
-				.skip(skip)
-				.limit(limit)
-				.toArray();
+		const [projects, countResult] = await Promise.all([
+			db.collection<Project>('projects')
+				.aggregate<ProjectWithUsers>(pipeline.concat([{ $sort: sortObj }, { $skip: skip }, { $limit: limit }]))
+				.toArray(),
+			db.collection<Project>('projects').aggregate<{ total: number }>(pipeline.concat({ $count: 'total' })).toArray(),
+		]);
 
-			const projectsWithSignedUrls = await enrichProjectsWithImageUrls(projects);
+		const projectsWithSignedAvatars = await Promise.all(
+			projects.map(async (project) => {
+				if (!project.users?.length) return project;
 
-			const totalPages = Math.ceil(totalCount / limit);
+				const usersWithSignedAvatars = await enrichUsersWithProfileAvatarUrls(project.users);
 
+				return {
+					...project,
+					users: usersWithSignedAvatars,
+				};
+			}),
+		);
 
-			return ResponseWrapper.success({message: 'Projects fetched successfully',
-				result: {
-					projects: projectsWithSignedUrls,
-					pagination: {
-						currentPage: page,
-						totalPages,
-						totalCount,
-						limit,
-						hasNextPage: page < totalPages,
-						hasPrevPage: page > 1,
-					},
+		const projectsWithSignedUrls = await enrichProjectsWithImageUrls(projectsWithSignedAvatars);
+
+		const totalCount = countResult.length > 0 ? countResult[0].total : 0;
+		const totalPages = Math.ceil(totalCount / limit);
+
+		return ResponseWrapper.success({message: 'Projects fetched successfully',
+			result: {
+				projects: projectsWithSignedUrls,
+				pagination: {
+					currentPage: page,
+					totalPages,
+					totalCount,
+					limit,
+					hasNextPage: page < totalPages,
+					hasPrevPage: page > 1,
 				},
-			});
-		}
+			},
+		});
 	} catch (err) {
 		logError('Get all projects handler failed', err);
 		return ResponseWrapper.internalServerError('Failed to get projects');

--- a/src/controllers/users/getAllUsersByWorkspace.ts
+++ b/src/controllers/users/getAllUsersByWorkspace.ts
@@ -6,36 +6,80 @@ import { logError } from '../../utils/logger';
 import { authenticateRequest } from '../../utils/authUtils';
 import { ObjectId } from 'mongodb';
 import { enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
+import { buildListFiltersMatch, ListFilterField, parseListQuery } from '../../utils/listQuery';
 
-/**
- * Get all users by workspace
- * @param {APIGatewayProxyEvent} event - API Gateway Lambda Proxy Input Format
- * @return {Promise<APIGatewayProxyResult>} API Gateway Lambda Proxy Output Format
- */
+const ALLOWED_SORT_FIELDS = ['name', 'email', 'designation', 'location', 'status', 'userType'];
+
+const USER_FILTER_FIELDS: Record<string, ListFilterField> = {
+	name: { path: 'name', type: 'text' },
+	email: { path: 'email', type: 'text' },
+	designation: { path: 'designation', type: 'text' },
+	location: { path: 'location', type: 'text' },
+	phone: { path: 'phone', type: 'text' },
+	status: { path: 'status', type: 'text' },
+	userType: { path: 'userType', type: 'text' },
+};
+
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
 		const auth = await authenticateRequest(event);
-		
-		if(!auth.isValid) {
+
+		if (!auth.isValid) {
 			return auth.error;
 		}
 
-		if (!event.queryStringParameters?.workspaceId) {
-			return ResponseWrapper.badRequest('Missing required fields: workspaceId is required');
-		}
-		const workspaceId = event.queryStringParameters.workspaceId;
+		const listQueryResult = parseListQuery({
+			query: event.queryStringParameters,
+			allowedSortFields: ALLOWED_SORT_FIELDS,
+			defaultSort: 'name',
+		});
+		if (listQueryResult.error) return listQueryResult.error;
+
+		const { limit, page, skip, sort, order, filters } = listQueryResult.value!;
+		const workspaceId = event.queryStringParameters?.workspaceId;
+
+		if (!workspaceId) return ResponseWrapper.badRequest('Valid workspace is required.');
+		if (!ObjectId.isValid(workspaceId)) return ResponseWrapper.badRequest('Invalid workspace');
+
+		const sortObj: { [key: string]: 1 | -1 } = {};
+		sortObj[sort] = order === 'desc' ? -1 : 1;
+
+		const baseMatch = { workspaceId: new ObjectId(workspaceId) };
+
+		const filtersMatch = buildListFiltersMatch(filters, USER_FILTER_FIELDS);
+		if (filtersMatch.error) return filtersMatch.error;
+
+		const queryFilter =
+			filtersMatch.match != null
+				? { $and: [baseMatch, filtersMatch.match] }
+				: baseMatch;
 
 		const db = await getDb();
+		const collection = db.collection<User>('users');
 
-		const users: User[] = await db.collection<User>('users').find({ workspaceId: new ObjectId(workspaceId) }).toArray();
+		const [users, totalCount] = await Promise.all([
+			collection.find(queryFilter).sort(sortObj).skip(skip).limit(limit).toArray(),
+			collection.countDocuments(queryFilter),
+		]);
+
 		const usersWithSignedAvatars = await enrichUsersWithProfileAvatarUrls(users);
+		const totalPages = Math.ceil(totalCount / limit);
 
 		return ResponseWrapper.success({
 			message: 'Users retrieved successfully',
-			data: usersWithSignedAvatars,
+			result: {
+				users: usersWithSignedAvatars,
+				pagination: {
+					currentPage: page,
+					totalPages,
+					totalCount,
+					limit,
+					hasNextPage: page < totalPages,
+					hasPrevPage: page > 1,
+				},
+			},
 		});
-
 	} catch (err) {
 		logError('Get users by workspace handler failed', err);
 		return ResponseWrapper.internalServerError('Failed to get users');

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -10,7 +10,7 @@
       "esModuleInterop": true, 
       "skipLibCheck": true,
       "forceConsistentCasingInFileNames": true,
-      "ignoreDeprecations": "6.0"
+      "ignoreDeprecations": "5.0"
     },
     "exclude": ["node_modules", "**/*.test.ts"]
   }

--- a/src/utils/listQuery.ts
+++ b/src/utils/listQuery.ts
@@ -220,9 +220,14 @@ function normalizeFilterValue(value: unknown, field: string, type: ListFieldType
 	}
 
 	if (type === 'number') {
-		const numberValue = typeof value === 'number' ? value : Number(value);
-		if (Number.isNaN(numberValue)) return `Filter '${field}' must use a numeric value`;
-		return numberValue;
+		if (typeof value === 'number') {
+			if (Number.isNaN(value)) return `Filter '${field}' must use a numeric value`;
+			return value;
+		}
+		if (typeof value === 'string' && /^-?\d+(\.\d+)?$/.test(value)) {
+			return Number(value);
+		}
+		return `Filter '${field}' must use a numeric value`;
 	}
 
 	if (type === 'boolean') {
@@ -293,7 +298,9 @@ function buildFilterQuery(filter: ListFilter, fieldConfig: ListFilterField): Doc
 	}
 
 	const normalizedValue = normalizeFilterValue(value, filter.field, type);
-	if (typeof normalizedValue === 'string' && type !== 'text') return normalizedValue;
+	const isNormalizeError =
+		typeof normalizedValue === 'string' && (type !== 'text' || typeof value !== 'string');
+	if (isNormalizeError) return normalizedValue;
 
 	if (type !== 'text' && ['contains', 'not_contains', 'starts_with', 'ends_with'].includes(operator)) {
 		return `Operator '${operator}' is only supported for text fields`;

--- a/src/utils/listQuery.ts
+++ b/src/utils/listQuery.ts
@@ -1,0 +1,366 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { Document } from 'mongodb';
+import { ResponseWrapper } from './responseWrapper';
+
+export type ListFilterOperator =
+	| 'eq'
+	| 'neq'
+	| 'contains'
+	| 'not_contains'
+	| 'starts_with'
+	| 'ends_with'
+	| 'gt'
+	| 'gte'
+	| 'lt'
+	| 'lte'
+	| 'is_null'
+	| 'is_not_null';
+
+export type ListFilter = {
+	field: string;
+	operator: ListFilterOperator;
+	value?: unknown;
+};
+
+export type ListFieldType = 'text' | 'number' | 'date' | 'boolean';
+
+export type ListFilterField = {
+	path: string;
+	type: ListFieldType;
+};
+
+type ParseListQueryInput = {
+	query?: Record<string, string | undefined> | null;
+	allowedSortFields: string[];
+	defaultSort: string;
+	defaultOrder?: 'asc' | 'desc';
+};
+
+type ParsedListQuery = {
+	page: number;
+	limit: number;
+	sort: string;
+	order: 'asc' | 'desc';
+	skip: number;
+	filters: ListFilter[];
+};
+
+type ParseListQueryResult = {
+	value?: ParsedListQuery;
+	error?: APIGatewayProxyResult;
+};
+
+const FILTER_OPERATORS: ListFilterOperator[] = [
+	'eq',
+	'neq',
+	'contains',
+	'not_contains',
+	'starts_with',
+	'ends_with',
+	'gt',
+	'gte',
+	'lt',
+	'lte',
+	'is_null',
+	'is_not_null',
+];
+
+const NO_VALUE_OPERATORS: ListFilterOperator[] = ['is_null', 'is_not_null'];
+
+/**
+ * Parses positive integer query params with a default fallback.
+ *
+ * @param {string | undefined} value Query string value to parse.
+ * @param {number} fallback Default value when the query value is omitted.
+ * @param {string} name Human-readable field name for validation errors.
+ * @return {number | string} Parsed integer or an error message.
+ */
+function parsePositiveInteger(value: string | undefined, fallback: number, name: string): number | string {
+	if (value === undefined || value === '') return fallback;
+	if (!/^\d+$/.test(value)) return `${name} must be a positive integer`;
+	return Number(value);
+}
+
+/**
+ * Checks whether an unknown value is a supported list filter shape.
+ *
+ * @param {unknown} value Value to inspect.
+ * @return {boolean} True when the value is a valid list filter.
+ */
+function isListFilter(value: unknown): value is ListFilter {
+	if (!value || typeof value !== 'object') return false;
+
+	const filter = value as Partial<ListFilter>;
+	return typeof filter.field === 'string' && FILTER_OPERATORS.includes(filter.operator as ListFilterOperator);
+}
+
+/**
+ * Parses and validates common list pagination, sort, order, and filter params.
+ *
+ * @param {ParseListQueryInput} input Query parsing input.
+ * @return {ParseListQueryResult} Parsed list query values or a response error.
+ */
+export function parseListQuery(input: ParseListQueryInput): ParseListQueryResult {
+	const {
+		query,
+		allowedSortFields,
+		defaultSort,
+		defaultOrder = 'asc',
+	} = input;
+	const limitResult = parsePositiveInteger(query?.limit, 10, 'Limit');
+	if (typeof limitResult === 'string') return { error: ResponseWrapper.badRequest(limitResult) };
+	if (limitResult < 1 || limitResult > 100) {
+		return { error: ResponseWrapper.badRequest('Limit must be between 1 and 100') };
+	}
+
+	const pageResult = parsePositiveInteger(query?.page, 1, 'Page');
+	if (typeof pageResult === 'string') return { error: ResponseWrapper.badRequest(pageResult) };
+	if (pageResult < 1) return { error: ResponseWrapper.badRequest('Page must be greater than 0') };
+
+	const sort = query?.sort || defaultSort;
+	if (!allowedSortFields.includes(sort)) {
+		return { error: ResponseWrapper.badRequest(`Invalid sort field. Allowed fields: ${allowedSortFields.join(', ')}`) };
+	}
+
+	const order = query?.order || defaultOrder;
+	if (order !== 'asc' && order !== 'desc') {
+		return { error: ResponseWrapper.badRequest('Order must be asc or desc') };
+	}
+
+	let filters: ListFilter[] = [];
+	if (query?.filters) {
+		try {
+			const parsedFilters = JSON.parse(query.filters);
+			if (!Array.isArray(parsedFilters)) {
+				return { error: ResponseWrapper.badRequest('filters must be a JSON array') };
+			}
+
+			for (const filter of parsedFilters) {
+				if (!isListFilter(filter)) {
+					return { error: ResponseWrapper.badRequest('Each filter must include a valid field and operator') };
+				}
+				if (!NO_VALUE_OPERATORS.includes(filter.operator) && filter.value === undefined) {
+					return { error: ResponseWrapper.badRequest(`Operator '${filter.operator}' requires a value`) };
+				}
+			}
+
+			filters = parsedFilters;
+		} catch {
+			return { error: ResponseWrapper.badRequest('filters must be valid JSON') };
+		}
+	}
+
+	const page = pageResult;
+	const limit = limitResult;
+
+	return {
+		value: {
+			page,
+			limit,
+			sort,
+			order,
+			skip: (page - 1) * limit,
+			filters,
+		},
+	};
+}
+
+/**
+ * Escapes user text before building a Mongo regex filter.
+ *
+ * @param {string} value Text to escape.
+ * @return {string} Regex-safe text.
+ */
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Parses date filter values into Date instances.
+ *
+ * @param {unknown} value Date value from the filter payload.
+ * @param {string} field Filter field name for validation errors.
+ * @return {Date | string} Parsed date or an error message.
+ */
+function parseDateValue(value: unknown, field: string): Date | string {
+	if (typeof value !== 'string') return `Filter '${field}' must use a date string`;
+
+	const date = /^\d{4}-\d{2}-\d{2}$/.test(value)
+		? new Date(`${value}T00:00:00.000Z`)
+		: new Date(value);
+
+	if (Number.isNaN(date.getTime())) return `Filter '${field}' must use a valid date`;
+	return date;
+}
+
+/**
+ * Returns the UTC day boundary after a parsed date-only value.
+ *
+ * @param {Date} date Start date.
+ * @return {Date} Next UTC day.
+ */
+function getNextUtcDay(date: Date): Date {
+	const next = new Date(date);
+	next.setUTCDate(next.getUTCDate() + 1);
+	return next;
+}
+
+/**
+ * Normalizes filter values to the configured field type.
+ *
+ * @param {unknown} value Raw filter value.
+ * @param {string} field Filter field name for validation errors.
+ * @param {ListFieldType} type Configured field type.
+ * @return {unknown | string} Normalized value or an error message.
+ */
+function normalizeFilterValue(value: unknown, field: string, type: ListFieldType): unknown | string {
+	if (type === 'text') {
+		if (typeof value !== 'string') return `Filter '${field}' must use a string value`;
+		return value;
+	}
+
+	if (type === 'number') {
+		const numberValue = typeof value === 'number' ? value : Number(value);
+		if (Number.isNaN(numberValue)) return `Filter '${field}' must use a numeric value`;
+		return numberValue;
+	}
+
+	if (type === 'boolean') {
+		if (typeof value === 'boolean') return value;
+		if (value === 'true') return true;
+		if (value === 'false') return false;
+		return `Filter '${field}' must use a boolean value`;
+	}
+
+	return parseDateValue(value, field);
+}
+
+/**
+ * Builds a Mongo query for null and not-null filter operators.
+ *
+ * @param {string} path Mongo field path.
+ * @param {boolean} isNull Whether to match null-like values.
+ * @return {Document} Mongo query document.
+ */
+function buildNullQuery(path: string, isNull: boolean): Document {
+	if (isNull) {
+		return { $or: [{ [path]: { $exists: false } }, { [path]: null }, { [path]: '' }] };
+	}
+	return { [path]: { $exists: true, $nin: [null, ''] } };
+}
+
+/**
+ * Builds whole-day Mongo comparisons for date-only filter values.
+ *
+ * @param {string} path Mongo field path.
+ * @param {ListFilterOperator} operator Filter operator.
+ * @param {Date} value Parsed start-of-day date.
+ * @return {Document | string} Mongo query document or an error message.
+ */
+function buildDateOnlyQuery(path: string, operator: ListFilterOperator, value: Date): Document | string {
+	const end = getNextUtcDay(value);
+	switch (operator) {
+	case 'eq':
+		return { [path]: { $gte: value, $lt: end } };
+	case 'neq':
+		return { $or: [{ [path]: { $lt: value } }, { [path]: { $gte: end } }] };
+	case 'gt':
+		return { [path]: { $gte: end } };
+	case 'gte':
+		return { [path]: { $gte: value } };
+	case 'lt':
+		return { [path]: { $lt: value } };
+	case 'lte':
+		return { [path]: { $lt: end } };
+	default:
+		return `Unsupported operator '${operator}'`;
+	}
+}
+
+/**
+ * Builds a Mongo query for one validated list filter.
+ *
+ * @param {ListFilter} filter Filter to convert.
+ * @param {ListFilterField} fieldConfig Allowed field configuration.
+ * @return {Document | string} Mongo query document or an error message.
+ */
+function buildFilterQuery(filter: ListFilter, fieldConfig: ListFilterField): Document | string {
+	const { operator, value } = filter;
+	const { path, type } = fieldConfig;
+
+	if (operator === 'is_null' || operator === 'is_not_null') {
+		return buildNullQuery(path, operator === 'is_null');
+	}
+
+	const normalizedValue = normalizeFilterValue(value, filter.field, type);
+	if (typeof normalizedValue === 'string' && type !== 'text') return normalizedValue;
+
+	if (type !== 'text' && ['contains', 'not_contains', 'starts_with', 'ends_with'].includes(operator)) {
+		return `Operator '${operator}' is only supported for text fields`;
+	}
+
+	if (!['number', 'date'].includes(type) && ['gt', 'gte', 'lt', 'lte'].includes(operator)) {
+		return `Operator '${operator}' is only supported for number and date fields`;
+	}
+
+	if (type === 'date' && normalizedValue instanceof Date && /^\d{4}-\d{2}-\d{2}$/.test(String(value))) {
+		return buildDateOnlyQuery(path, operator, normalizedValue);
+	}
+
+	switch (operator) {
+	case 'eq':
+		return { [path]: normalizedValue };
+	case 'neq':
+		return { [path]: { $ne: normalizedValue } };
+	case 'contains':
+		return { [path]: { $regex: escapeRegex(String(normalizedValue)), $options: 'i' } };
+	case 'not_contains':
+		return { [path]: { $not: { $regex: escapeRegex(String(normalizedValue)), $options: 'i' } } };
+	case 'starts_with':
+		return { [path]: { $regex: `^${escapeRegex(String(normalizedValue))}`, $options: 'i' } };
+	case 'ends_with':
+		return { [path]: { $regex: `${escapeRegex(String(normalizedValue))}$`, $options: 'i' } };
+	case 'gt':
+		return { [path]: { $gt: normalizedValue } };
+	case 'gte':
+		return { [path]: { $gte: normalizedValue } };
+	case 'lt':
+		return { [path]: { $lt: normalizedValue } };
+	case 'lte':
+		return { [path]: { $lte: normalizedValue } };
+	default:
+		return `Unsupported operator '${operator}'`;
+	}
+}
+
+/**
+ * Builds a Mongo match document from an AND-matched list filter set.
+ *
+ * @param {ListFilter[]} filters Filters to convert.
+ * @param {Record<string, ListFilterField>} allowedFields Allowed field map.
+ * @return {Object} Mongo match or response error.
+ */
+export function buildListFiltersMatch(
+	filters: ListFilter[],
+	allowedFields: Record<string, ListFilterField>,
+): { match?: Document; error?: APIGatewayProxyResult } {
+	if (filters.length === 0) return {};
+
+	const conditions: Document[] = [];
+	for (const filter of filters) {
+		const fieldConfig = allowedFields[filter.field];
+		if (!fieldConfig) {
+			return {
+				error: ResponseWrapper.badRequest(
+					`Invalid filter field '${filter.field}'. Allowed fields: ${Object.keys(allowedFields).join(', ')}`,
+				),
+			};
+		}
+
+		const query = buildFilterQuery(filter, fieldConfig);
+		if (typeof query === 'string') return { error: ResponseWrapper.badRequest(query) };
+		conditions.push(query);
+	}
+
+	return { match: conditions.length === 1 ? conditions[0] : { $and: conditions } };
+}


### PR DESCRIPTION
Closes #105

- Add shared list query parsing and MongoDB filter utilities
- Wire pagination, sorting, and filters into departments, projects, and products endpoints
- Extend workspace users endpoint with paginated, sortable, filterable responses