### PR TITLE
Add documentation video signed URLs and API support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,4 +140,5 @@ jobs:
           "UploadsBucket=$UPLOADS_BUCKET"
           "ExportsBucket=$EXPORTS_BUCKET"
           "StandardSymbolsBucket=uprevit-standard-symbols"
+          "DocumentationFilesBucket=uprevit-documentation-files"
           "ExportJobQueueUrl=$EXPORT_JOB_QUEUE_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -210,5 +210,5 @@ env.json
 .sam-local-env.json
 
 .vscode
-src/tests/unit/**
+src/scripts/documentation-videos-input/
 src/tests/unit/test-handler.test.ts

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The required runtime keys are:
 - `CLIENT_ID`: The Cognito App Client ID
 - `UPLOADS_BUCKET`: The S3 bucket used for uploaded files
 - `EXPORTS_BUCKET`: The S3 bucket used for generated exports
+- `DOCUMENTATION_FILES_BUCKET`: The S3 bucket for documentation media (`uprevit-documentation-files`)
 - `EXPORT_JOB_QUEUE_URL`: The SQS queue URL used by export jobs
 
 AWS SAM `--env-vars` expects Lambda environment variable names, not CloudFormation parameter names like `MongoDbUri` or `UserPoolId`.
@@ -136,6 +137,23 @@ uprevit-backend$ sam logs -n HelloWorldFunction --stack-name uprevit-backend --t
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
+
+## Documentation videos (S3 seed)
+
+Place `.mp4` files under `src/scripts/documentation-videos-input/` (folder layout matches the product team's export).
+
+From the repo root (or `src/`):
+
+```bash
+cd src && npm install   # installs @aws-sdk/client-s3 (required by the seed script)
+npm run seed:documentation-videos -- --scan-dir
+npm run seed:documentation-videos -- --dry-run
+npm run seed:documentation-videos
+```
+
+From the repo root: `npm run seed:documentation-videos -- --dry-run` (forwards flags to `src/`).
+
+Requires `AWS_REGION` and credentials with `s3:PutObject` on `DOCUMENTATION_FILES_BUCKET` (default `uprevit-documentation-files`).
 
 ## Unit Tests
 

--- a/env.example.json
+++ b/env.example.json
@@ -7,6 +7,7 @@
     "UPLOADS_BUCKET": "uprevit-storage-dev-and-test",
     "EXPORTS_BUCKET": "exports-storage-dev-and-test",
     "STANDARD_SYMBOLS_BUCKET": "uprevit-standard-symbols",
+    "DOCUMENTATION_FILES_BUCKET": "uprevit-documentation-files",
     "EXPORT_JOB_QUEUE_URL": "https://sqs.us-east-1.amazonaws.com/<account-id>/<queue-name>"
   },
   "EnqueueProductExportFunction": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "dev": "sam sync --watch --build-in-source --stack-name uprevit-test --region us-east-1",
     "prepare:sam-env": "node scripts/prepare-sam-env.mjs",
-    "start:local": "npm run prepare:sam-env && AWS_PROFILE=uprevit-amit sam local start-api --env-vars .sam-local-env.json"
+    "start:local": "npm run prepare:sam-env && AWS_PROFILE=uprevit-amit sam local start-api --env-vars .sam-local-env.json",
+    "seed:documentation-videos": "npm --prefix src run seed:documentation-videos --"
   },
   "devDependencies": {
     "esbuild": "^0.25.5"

--- a/src/config/documentationVideos.ts
+++ b/src/config/documentationVideos.ts
@@ -1,0 +1,28 @@
+export const DOCUMENTATION_VIDEOS = {
+	"department.departments-tab": "videos/department/departments-tab.mp4",
+	"getting-started.welcome-dashboard": "videos/getting-started/welcome-dashboard.mp4",
+	"product.compliance-tab": "videos/product/compliance-tab.mp4",
+	"product.label-components": "videos/product/label-components.mp4",
+	"product.label-tags": "videos/product/label-tags.mp4",
+	"product.product-information": "videos/product/product-information.mp4",
+	"product.product-plan-review-overview": "videos/product/product-plan-review-overview.mp4",
+	"product.product-specifications": "videos/product/product-specifications.mp4",
+	"product.products-intro": "videos/product/products-intro.mp4",
+	"product.symbols-graphics": "videos/product/symbols-graphics.mp4",
+	"projects.projects-tab": "videos/projects/projects-tab.mp4",
+	"reports-analytics.overview": "videos/reports-analytics/overview.mp4",
+	"working-with-files.source-files-archive-bookmarks":
+		"videos/working-with-files/source-files-archive-bookmarks.mp4",
+} as const;
+
+export type DocumentationVideoKey = keyof typeof DOCUMENTATION_VIDEOS;
+
+export const isDocumentationVideoKey = (value: string): value is DocumentationVideoKey =>
+	value in DOCUMENTATION_VIDEOS;
+
+export const getDocumentationVideoObjectKey = (
+	videoKey: string,
+): string | null => {
+	if (!isDocumentationVideoKey(videoKey)) return null;
+	return DOCUMENTATION_VIDEOS[videoKey];
+};

--- a/src/config/documentationVideos.ts
+++ b/src/config/documentationVideos.ts
@@ -18,7 +18,7 @@ export const DOCUMENTATION_VIDEOS = {
 export type DocumentationVideoKey = keyof typeof DOCUMENTATION_VIDEOS;
 
 export const isDocumentationVideoKey = (value: string): value is DocumentationVideoKey =>
-	value in DOCUMENTATION_VIDEOS;
+	Object.hasOwn(DOCUMENTATION_VIDEOS, value);
 
 export const getDocumentationVideoObjectKey = (
 	videoKey: string,

--- a/src/controllers/docs/getDocumentationVideoSignedUrl.ts
+++ b/src/controllers/docs/getDocumentationVideoSignedUrl.ts
@@ -1,0 +1,40 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { getDocumentationVideoObjectKey } from "../../config/documentationVideos";
+import { authenticateRequest } from "../../utils/authUtils";
+import { createDocumentationFilePresignedGetUrl } from "../../utils/s3-storage";
+import { ResponseWrapper } from "../../utils/responseWrapper";
+
+/**
+ * Returns a short-lived signed URL for a documentation video.
+ * @param {APIGatewayProxyEvent} event - API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Signed URL and expiry for the video
+ */
+export const lambdaHandler = async (
+	event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResult> => {
+	try {
+		const auth = await authenticateRequest(event);
+		if (!auth.isValid) {
+			return auth.error;
+		}
+
+		const videoKey = event.pathParameters?.videoKey?.trim();
+		if (!videoKey) {
+			return ResponseWrapper.badRequest("videoKey is required");
+		}
+
+		const objectKey = getDocumentationVideoObjectKey(videoKey);
+		if (!objectKey) {
+			return ResponseWrapper.notFound("Documentation video not found");
+		}
+
+		const { url, expiresAt } = await createDocumentationFilePresignedGetUrl(objectKey);
+
+		return ResponseWrapper.success({
+			message: "Documentation video URL generated",
+			result: { url, expiresAt },
+		});
+	} catch {
+		return ResponseWrapper.internalServerError("Failed to generate documentation video URL");
+	}
+};

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "src",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.2.0",
+			"version": "0.3.0",
 			"dependencies": {
 				"@aws-sdk/client-cognito-identity-provider": "^3.679.0",
 				"@aws-sdk/client-s3": "^3.990.0",

--- a/src/package.json
+++ b/src/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint controllers/**/*.ts utils/**/*.ts models/*.ts types/**/*.ts db/*.ts app.ts --no-ignore",
     "lint:fix": "eslint controllers/**/*.ts utils/**/*.ts models/*.ts types/**/*.ts db/*.ts app.ts --no-ignore --fix",
     "type-check": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "seed:documentation-videos": "node scripts/seedDocumentationVideos.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.679.0",

--- a/src/scripts/seedDocumentationVideos.mjs
+++ b/src/scripts/seedDocumentationVideos.mjs
@@ -1,0 +1,201 @@
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { readFile, readdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+
+const INPUT_FILE_TO_VIDEO_KEY = {
+	"Department/Departments Tab.mp4": "department.departments-tab",
+	"Workspace/Welcome Dashboard Video.mp4": "getting-started.welcome-dashboard",
+	"Product/Compliance Tab.mp4": "product.compliance-tab",
+	"Product/Label Components-V2.mp4": "product.label-components",
+	"Product/Label Tags Tab-V2.mp4": "product.label-tags",
+	"Product/Product Information tab.mp4": "product.product-information",
+	"Product/Product Plan review Overview.mp4": "product.product-plan-review-overview",
+	"Product/Product Specification tab.mp4": "product.product-specifications",
+	"Product/Products_tab_Intro v2.mp4": "product.products-intro",
+	"Product/Symbol & graphics.mp4": "product.symbols-graphics",
+	"Projects/Projects_Tab-V2.mp4": "projects.projects-tab",
+	"Reports & Analystics/Reports & Analytics.mp4": "reports-analytics.overview",
+	"Source Files, Archive, Bookmark/Source File-Archive-Bookmarks Tab.mp4":
+		"working-with-files.source-files-archive-bookmarks",
+};
+
+const usage = [
+	"Usage:",
+	"  npm run seed:documentation-videos -- [--input-dir ./documentation-videos-input] [--bucket uprevit-documentation-files] [--dry-run]",
+	"  npm run seed:documentation-videos -- --scan-dir",
+	"  npm run seed:documentation-videos -- --generate-allowlist",
+	"",
+	"Run from uprevit-backend/src after: npm install",
+	"Required env for upload: AWS_REGION (+ AWS credentials with s3:PutObject)",
+	"Optional env: DOCUMENTATION_FILES_BUCKET",
+].join("\n");
+
+const parseArgs = () => {
+	const argv = process.argv.slice(2);
+	const getValue = (name) => {
+		const index = argv.indexOf(name);
+		return index >= 0 ? argv[index + 1] : undefined;
+	};
+
+	const defaultInputDir = path.join(scriptDir, "documentation-videos-input");
+
+	return {
+		inputDir: path.resolve(getValue("--input-dir") ?? defaultInputDir),
+		bucket:
+			getValue("--bucket") ||
+			process.env.DOCUMENTATION_FILES_BUCKET ||
+			"uprevit-documentation-files",
+		dryRun: argv.includes("--dry-run"),
+		scanOnly: argv.includes("--scan-dir"),
+		generateAllowlist: argv.includes("--generate-allowlist"),
+	};
+};
+
+const listMp4Files = async (dir, prefix = "") => {
+	const entries = await readdir(dir, { withFileTypes: true });
+	const files = [];
+
+	for (const entry of entries) {
+		if (entry.name.startsWith(".")) continue;
+
+		const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+		if (entry.isDirectory()) {
+			files.push(...(await listMp4Files(path.join(dir, entry.name), relativePath)));
+			continue;
+		}
+
+		if (entry.isFile() && entry.name.toLowerCase().endsWith(".mp4")) {
+			files.push(relativePath);
+		}
+	}
+
+	return files;
+};
+
+const resolveVideoKey = (relativePath) => {
+	const normalized = relativePath.split(path.sep).join("/");
+	return INPUT_FILE_TO_VIDEO_KEY[normalized] ?? null;
+};
+
+const objectKeyForVideoKey = (videoKey) => {
+	const dotIndex = videoKey.indexOf(".");
+	if (dotIndex <= 0) {
+		throw new Error(`Invalid videoKey (expected category.slug): ${videoKey}`);
+	}
+
+	const category = videoKey.slice(0, dotIndex);
+	const slug = videoKey.slice(dotIndex + 1);
+	return `videos/${category}/${slug}.mp4`;
+};
+
+const buildAllowlistSource = () => {
+	const videoKeys = [...new Set(Object.values(INPUT_FILE_TO_VIDEO_KEY))].sort();
+	const lines = videoKeys.map((videoKey) => {
+		const objectKey = objectKeyForVideoKey(videoKey);
+		return `\t"${videoKey}": "${objectKey}",`;
+	});
+
+	return `export const DOCUMENTATION_VIDEOS = {
+${lines.join("\n")}
+} as const;
+
+export type DocumentationVideoKey = keyof typeof DOCUMENTATION_VIDEOS;
+
+export const isDocumentationVideoKey = (value: string): value is DocumentationVideoKey =>
+\tvalue in DOCUMENTATION_VIDEOS;
+
+export const getDocumentationVideoObjectKey = (
+\tvideoKey: string,
+): string | null => {
+\tif (!isDocumentationVideoKey(videoKey)) return null;
+\treturn DOCUMENTATION_VIDEOS[videoKey];
+};
+`;
+};
+
+const main = async () => {
+	const args = parseArgs();
+
+	if (!process.env.AWS_REGION && !args.scanOnly && !args.generateAllowlist) {
+		console.warn("AWS_REGION is not set; defaulting to us-east-1 for S3 client.");
+	}
+
+	const s3 = new S3Client({
+		region: process.env.AWS_REGION || "us-east-1",
+	});
+
+	const relativeFiles = await listMp4Files(args.inputDir);
+	if (relativeFiles.length === 0) {
+		throw new Error(`No .mp4 files found under ${args.inputDir}`);
+	}
+
+	const planned = [];
+
+	for (const relativePath of relativeFiles.sort()) {
+		const videoKey = resolveVideoKey(relativePath);
+		if (!videoKey) {
+			throw new Error(`No videoKey mapping for input file: ${relativePath}`);
+		}
+
+		const objectKey = objectKeyForVideoKey(videoKey);
+		planned.push({ relativePath, videoKey, objectKey });
+	}
+
+	console.log(`Found ${planned.length} video(s) in ${args.inputDir}`);
+	for (const item of planned) {
+		console.log(`  ${item.relativePath}`);
+		console.log(`    videoKey: ${item.videoKey}`);
+		console.log(`    s3://${args.bucket}/${item.objectKey}`);
+	}
+
+	if (args.scanOnly) return;
+
+	if (args.generateAllowlist) {
+		const outPath = path.resolve(scriptDir, "../config/documentationVideos.ts");
+		await writeFile(outPath, buildAllowlistSource(), "utf8");
+		console.log(`Wrote allowlist to ${outPath}`);
+		return;
+	}
+
+	let uploaded = 0;
+	for (const item of planned) {
+		const localPath = path.join(args.inputDir, item.relativePath);
+		const fileStat = await stat(localPath);
+		if (!fileStat.isFile()) {
+			throw new Error(`Expected file: ${localPath}`);
+		}
+
+		if (args.dryRun) {
+			console.log(`[dry-run] would upload ${localPath} -> ${item.objectKey}`);
+			continue;
+		}
+
+		const body = await readFile(localPath);
+		await s3.send(
+			new PutObjectCommand({
+				Bucket: args.bucket,
+				Key: item.objectKey,
+				Body: body,
+				ContentType: "video/mp4",
+			}),
+		);
+		uploaded += 1;
+		console.log(`Uploaded ${item.objectKey}`);
+	}
+
+	console.log(
+		args.dryRun
+			? "Dry run complete (no objects written)."
+			: `Upload complete (${uploaded} object(s)).`,
+	);
+};
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : error);
+	console.error(usage);
+	process.exit(1);
+});

--- a/src/tests/unit/documentationVideos.test.ts
+++ b/src/tests/unit/documentationVideos.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+	getDocumentationVideoObjectKey,
+	isDocumentationVideoKey,
+} from "../../config/documentationVideos";
+
+describe("documentationVideos allowlist", () => {
+	it("recognizes allowlisted keys", () => {
+		expect(isDocumentationVideoKey("product.products-intro")).toBe(true);
+		expect(getDocumentationVideoObjectKey("product.products-intro")).toBe(
+			"videos/product/products-intro.mp4",
+		);
+	});
+
+	it("rejects unknown keys", () => {
+		expect(isDocumentationVideoKey("not.a.video")).toBe(false);
+		expect(getDocumentationVideoObjectKey("not.a.video")).toBeNull();
+	});
+});

--- a/src/tests/unit/documentationVideos.test.ts
+++ b/src/tests/unit/documentationVideos.test.ts
@@ -16,4 +16,9 @@ describe("documentationVideos allowlist", () => {
 		expect(isDocumentationVideoKey("not.a.video")).toBe(false);
 		expect(getDocumentationVideoObjectKey("not.a.video")).toBeNull();
 	});
+
+	it("rejects inherited prototype property names", () => {
+		expect(isDocumentationVideoKey("toString")).toBe(false);
+		expect(getDocumentationVideoObjectKey("toString")).toBeNull();
+	});
 });

--- a/src/tests/unit/enqueueReportExport.test.ts
+++ b/src/tests/unit/enqueueReportExport.test.ts
@@ -1,0 +1,128 @@
+import { ObjectId } from 'mongodb';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../utils/authUtils', () => ({
+	authenticateRequest: jest.fn(),
+}));
+
+jest.mock('../../utils/authenticatedUser', () => ({
+	getAuthenticatedUserContext: jest.fn(),
+}));
+
+jest.mock('../../utils/exportJobs', () => ({
+	createQueuedExportJob: jest.fn(),
+}));
+
+jest.mock('../../utils/exportQueue', () => ({
+	enqueueExportJobMessage: jest.fn(),
+}));
+
+jest.mock('../../utils/db', () => ({
+	getDb: jest.fn(),
+}));
+
+const authUtils = jest.requireMock('../../utils/authUtils') as any;
+const authenticatedUser = jest.requireMock('../../utils/authenticatedUser') as any;
+const exportJobs = jest.requireMock('../../utils/exportJobs') as any;
+const exportQueue = jest.requireMock('../../utils/exportQueue') as any;
+
+const authenticateRequest = authUtils.authenticateRequest;
+
+const getAuthenticatedUserContext = authenticatedUser.getAuthenticatedUserContext;
+
+const createQueuedExportJob = exportJobs.createQueuedExportJob;
+
+const enqueueExportJobMessage = exportQueue.enqueueExportJobMessage;
+
+const { lambdaHandler } = require('../../controllers/reports/enqueueReportExport');
+
+describe('enqueueReportExport', () => {
+	const workspaceId = new ObjectId();
+	const userId = new ObjectId();
+	const jobId = new ObjectId();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		authenticateRequest.mockResolvedValue({
+			isValid: true,
+			payload: { sub: 'user-sub' },
+			token: 'token',
+		});
+
+		getAuthenticatedUserContext.mockResolvedValue({
+			userId,
+			workspaceId,
+		});
+
+		createQueuedExportJob.mockResolvedValue({
+			_id: jobId,
+			status: 'queued',
+			createdAt: new Date('2026-03-08T10:00:00.000Z'),
+		});
+
+		enqueueExportJobMessage.mockResolvedValue(undefined);
+	});
+
+	it('queues a report export job with persisted filters', async () => {
+		const response = await lambdaHandler({
+			body: JSON.stringify({
+				workspaceId: workspaceId.toString(),
+				format: 'pdf',
+				conditions: [],
+				sort: { field: 'product_name', order: 'asc' },
+			}),
+			headers: { Authorization: 'Bearer token' },
+		} as any);
+
+		expect(response.statusCode).toBe(202);
+		expect(JSON.parse(response.body)).toEqual({
+			message: 'Report export queued successfully',
+			result: {
+				jobId: jobId.toString(),
+				status: 'queued',
+			},
+		});
+
+		expect(createQueuedExportJob).toHaveBeenCalledWith({
+			target: 'report',
+			workspaceId,
+			requestedBySub: 'user-sub',
+			requestedByUserId: userId,
+			format: 'pdf',
+			reportParams: {
+				conditions: [],
+				sort: { field: 'product_name', order: 'asc' },
+			},
+		});
+
+		expect(enqueueExportJobMessage).toHaveBeenCalledWith({
+			schemaVersion: 1,
+			jobId: jobId.toString(),
+			target: 'report',
+			workspaceId: workspaceId.toString(),
+			requestedBySub: 'user-sub',
+			requestedByUserId: userId.toString(),
+			format: 'pdf',
+			queuedAt: '2026-03-08T10:00:00.000Z',
+		});
+	});
+
+	it('rejects exports for a different workspace', async () => {
+		const response = await lambdaHandler({
+			body: JSON.stringify({
+				workspaceId: new ObjectId().toString(),
+				format: 'excel',
+				conditions: [],
+			}),
+			headers: { Authorization: 'Bearer token' },
+		} as any);
+
+		expect(response.statusCode).toBe(403);
+		expect(JSON.parse(response.body)).toEqual({
+			message: 'You are not authorized to export reports for this workspace',
+		});
+		expect(createQueuedExportJob).not.toHaveBeenCalled();
+		expect(enqueueExportJobMessage).not.toHaveBeenCalled();
+	});
+});

--- a/src/tests/unit/getDocumentationVideoSignedUrl.test.ts
+++ b/src/tests/unit/getDocumentationVideoSignedUrl.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { APIGatewayProxyEvent } from "aws-lambda";
+
+jest.mock("../../utils/authUtils", () => ({
+	authenticateRequest: jest.fn(),
+}));
+
+jest.mock("../../utils/s3-storage", () => ({
+	createDocumentationFilePresignedGetUrl: jest.fn(),
+}));
+
+const authUtils = jest.requireMock("../../utils/authUtils") as any;
+
+const s3Storage = jest.requireMock("../../utils/s3-storage") as any;
+
+const { lambdaHandler } = require("../../controllers/docs/getDocumentationVideoSignedUrl");
+
+const buildEvent = (videoKey?: string): APIGatewayProxyEvent =>
+	({
+		pathParameters: videoKey ? { videoKey } : undefined,
+		headers: { Authorization: "Bearer test-token" },
+	}) as unknown as APIGatewayProxyEvent;
+
+describe("getDocumentationVideoSignedUrl", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("returns 401 when authentication fails", async () => {
+		authUtils.authenticateRequest.mockResolvedValue({
+			isValid: false,
+			error: { statusCode: 401, body: JSON.stringify({ error: "Unauthorized" }) },
+		});
+
+		const response = await lambdaHandler(buildEvent("product.products-intro"));
+
+		expect(response.statusCode).toBe(401);
+		expect(s3Storage.createDocumentationFilePresignedGetUrl).not.toHaveBeenCalled();
+	});
+
+	it("returns 404 for unknown videoKey", async () => {
+		authUtils.authenticateRequest.mockResolvedValue({
+			isValid: true,
+			payload: {},
+			token: "test-token",
+		});
+
+		const response = await lambdaHandler(buildEvent("unknown.video-key"));
+
+		expect(response.statusCode).toBe(404);
+		expect(s3Storage.createDocumentationFilePresignedGetUrl).not.toHaveBeenCalled();
+	});
+
+	it("returns signed url for allowlisted videoKey", async () => {
+		authUtils.authenticateRequest.mockResolvedValue({
+			isValid: true,
+			payload: {},
+			token: "test-token",
+		});
+
+		s3Storage.createDocumentationFilePresignedGetUrl.mockResolvedValue({
+			url: "https://signed.example/video.mp4",
+			expiresAt: "2026-05-26T12:00:00.000Z",
+		});
+
+		const response = await lambdaHandler(buildEvent("product.products-intro"));
+
+		expect(response.statusCode).toBe(200);
+		expect(s3Storage.createDocumentationFilePresignedGetUrl).toHaveBeenCalledWith(
+			"videos/product/products-intro.mp4",
+		);
+
+		const body = JSON.parse(response.body);
+		expect(body.result.url).toBe("https://signed.example/video.mp4");
+		expect(body.result.expiresAt).toBe("2026-05-26T12:00:00.000Z");
+	});
+});

--- a/src/tests/unit/label-components.test.ts
+++ b/src/tests/unit/label-components.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from '@jest/globals';
+import { updateLabelComponent } from '../../controllers/products/productData/label-components';
+
+describe('updateLabelComponent', () => {
+	it('does not overwrite component_description when it is omitted', () => {
+		const result = updateLabelComponent(
+			{
+				id: '507f1f77bcf86cd799439011',
+				component_number: '1',
+				component_type: 'Primary',
+			},
+			'label-components',
+			'update_label_component',
+		);
+
+		expect(result.error).toBeNull();
+		expect(result.updateQuery).toEqual({
+			$set: {
+				'label_components.data.$[elem].image': undefined,
+				'label_components.data.$[elem].dimensions': undefined,
+				'label_components.data.$[elem].label_type': undefined,
+				'label_components.data.$[elem].component_number': '1',
+				'label_components.data.$[elem].component_type': 'Primary',
+			},
+			arrayFilters: [{ 'elem._id': expect.anything() }],
+		});
+		expect((result.updateQuery as { $set: Record<string, unknown> }).$set).not.toHaveProperty(
+			'label_components.data.$[elem].component_description',
+		);
+	});
+
+	it('updates component_description when it is provided', () => {
+		const result = updateLabelComponent(
+			{
+				id: '507f1f77bcf86cd799439011',
+				component_number: '1',
+				component_type: 'Primary',
+				component_description: 'Updated description',
+			},
+			'label-components',
+			'update_label_component',
+		);
+
+		expect(result.error).toBeNull();
+		expect(
+			(result.updateQuery as { $set: Record<string, unknown> }).$set[
+				'label_components.data.$[elem].component_description'
+			],
+		).toBe('Updated description');
+	});
+});

--- a/src/tests/unit/listQuery.test.ts
+++ b/src/tests/unit/listQuery.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from '@jest/globals';
+import { buildListFiltersMatch, parseListQuery } from '../../utils/listQuery';
+
+const allowedFields = {
+	name: { path: 'name', type: 'text' as const },
+	count: { path: 'count', type: 'number' as const },
+	actionAt: { path: 'actionAt', type: 'date' as const },
+};
+
+describe('parseListQuery', () => {
+	it('parses pagination, sort order, and encoded filters', () => {
+		const result = parseListQuery({
+			query: {
+				page: '2',
+				limit: '10',
+				sort: 'name',
+				order: 'desc',
+				filters: JSON.stringify([{ field: 'name', operator: 'contains', value: 'pump' }]),
+			},
+			allowedSortFields: ['name', 'actionAt'],
+			defaultSort: 'name',
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.value).toEqual({
+			page: 2,
+			limit: 10,
+			sort: 'name',
+			order: 'desc',
+			skip: 10,
+			filters: [{ field: 'name', operator: 'contains', value: 'pump' }],
+		});
+	});
+
+	it('rejects invalid direct API params', () => {
+		const result = parseListQuery({
+			query: {
+				page: '0',
+				sort: 'unknown',
+			},
+			allowedSortFields: ['name'],
+			defaultSort: 'name',
+		});
+
+		expect(result.error?.statusCode).toBe(400);
+	});
+});
+
+describe('buildListFiltersMatch', () => {
+	it('builds AND filters with escaped contains and numeric comparison', () => {
+		const result = buildListFiltersMatch([
+			{ field: 'name', operator: 'contains', value: 'pump.1' },
+			{ field: 'count', operator: 'gte', value: '5' },
+		], allowedFields);
+
+		expect(result.error).toBeUndefined();
+		expect(result.match).toEqual({
+			$and: [
+				{ name: { $regex: 'pump\\.1', $options: 'i' } },
+				{ count: { $gte: 5 } },
+			],
+		});
+	});
+
+	it('turns date-only equality into a whole UTC day range', () => {
+		const result = buildListFiltersMatch([
+			{ field: 'actionAt', operator: 'eq', value: '2026-05-18' },
+		], allowedFields);
+
+		expect(result.error).toBeUndefined();
+		expect(result.match).toEqual({
+			actionAt: {
+				$gte: new Date('2026-05-18T00:00:00.000Z'),
+				$lt: new Date('2026-05-19T00:00:00.000Z'),
+			},
+		});
+	});
+
+	it('turns date-only inequality into outside the whole UTC day range', () => {
+		const result = buildListFiltersMatch([
+			{ field: 'actionAt', operator: 'neq', value: '2026-05-18' },
+		], allowedFields);
+
+		expect(result.error).toBeUndefined();
+		expect(result.match).toEqual({
+			$or: [
+				{ actionAt: { $lt: new Date('2026-05-18T00:00:00.000Z') } },
+				{ actionAt: { $gte: new Date('2026-05-19T00:00:00.000Z') } },
+			],
+		});
+	});
+
+	it('uses the beginning of the selected date for date-only greater than or equal filters', () => {
+		const result = buildListFiltersMatch([
+			{ field: 'actionAt', operator: 'gte', value: '2026-02-15' },
+		], allowedFields);
+
+		expect(result.error).toBeUndefined();
+		expect(result.match).toEqual({
+			actionAt: { $gte: new Date('2026-02-15T00:00:00.000Z') },
+		});
+	});
+
+	it('uses the next day for date-only greater than filters', () => {
+		const result = buildListFiltersMatch([
+			{ field: 'actionAt', operator: 'gt', value: '2026-02-15' },
+		], allowedFields);
+
+		expect(result.error).toBeUndefined();
+		expect(result.match).toEqual({
+			actionAt: { $gte: new Date('2026-02-16T00:00:00.000Z') },
+		});
+	});
+
+	it('uses the beginning of the selected date for date-only less than filters', () => {
+		const result = buildListFiltersMatch([
+			{ field: 'actionAt', operator: 'lt', value: '2026-02-15' },
+		], allowedFields);
+
+		expect(result.error).toBeUndefined();
+		expect(result.match).toEqual({
+			actionAt: { $lt: new Date('2026-02-15T00:00:00.000Z') },
+		});
+	});
+
+	it('uses the next day for date-only less than or equal filters', () => {
+		const result = buildListFiltersMatch([
+			{ field: 'actionAt', operator: 'lte', value: '2026-02-15' },
+		], allowedFields);
+
+		expect(result.error).toBeUndefined();
+		expect(result.match).toEqual({
+			actionAt: { $lt: new Date('2026-02-16T00:00:00.000Z') },
+		});
+	});
+
+	it('rejects non-string values for text fields', () => {
+		const result = buildListFiltersMatch([
+			{ field: 'name', operator: 'eq', value: 42 },
+		], allowedFields);
+
+		expect(result.error?.statusCode).toBe(400);
+		expect(result.match).toBeUndefined();
+	});
+});

--- a/src/tests/unit/processExportJob.test.ts
+++ b/src/tests/unit/processExportJob.test.ts
@@ -1,0 +1,198 @@
+import { ObjectId } from 'mongodb';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../utils/exportJobs', () => ({
+	markExportJobCompleted: jest.fn(),
+	markExportJobFailed: jest.fn(),
+	markExportJobProcessing: jest.fn(),
+}));
+
+jest.mock('../../utils/db', () => ({
+	getDb: jest.fn(),
+}));
+
+jest.mock('../../utils/exportPDF', () => ({
+	generateProductPDFExport: jest.fn(),
+}));
+
+jest.mock('../../utils/exportExcel', () => ({
+	generateProductExcelExport: jest.fn(),
+}));
+
+jest.mock('../../utils/reports/exportReportsPDF', () => ({
+	generateReportsPDFExport: jest.fn(),
+}));
+
+jest.mock('../../utils/reports/exportReportsExcel', () => ({
+	generateReportsExcelExport: jest.fn(),
+}));
+
+jest.mock('../../utils/reports/queryBuilder', () => ({
+	buildExportPipeline: jest.fn(),
+}));
+
+jest.mock('../../utils/s3-storage', () => ({
+	uploadExportObjectByKey: jest.fn(),
+}));
+
+const exportJobs = jest.requireMock('../../utils/exportJobs') as any;
+const dbUtils = jest.requireMock('../../utils/db') as any;
+const exportPdfUtils = jest.requireMock('../../utils/exportPDF') as any;
+const reportPdfUtils = jest.requireMock('../../utils/reports/exportReportsPDF') as any;
+const queryBuilderUtils = jest.requireMock('../../utils/reports/queryBuilder') as any;
+const s3StorageUtils = jest.requireMock('../../utils/s3-storage') as any;
+
+const markExportJobCompleted = exportJobs.markExportJobCompleted;
+const markExportJobFailed = exportJobs.markExportJobFailed;
+const markExportJobProcessing = exportJobs.markExportJobProcessing;
+
+const getDb = dbUtils.getDb;
+
+const generateProductPDFExport = exportPdfUtils.generateProductPDFExport;
+
+const generateReportsPDFExport = reportPdfUtils.generateReportsPDFExport;
+
+const buildExportPipeline = queryBuilderUtils.buildExportPipeline;
+
+const uploadExportObjectByKey = s3StorageUtils.uploadExportObjectByKey;
+
+const { lambdaHandler } = require('../../controllers/exports/processExportJob');
+
+describe('processExportJob', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		markExportJobCompleted.mockResolvedValue(null);
+		markExportJobFailed.mockResolvedValue(null);
+		uploadExportObjectByKey.mockResolvedValue(undefined);
+	});
+
+	it('processes product export jobs without regression', async () => {
+		const jobId = new ObjectId();
+		const workspaceId = new ObjectId();
+		const productId = new ObjectId();
+
+		markExportJobProcessing.mockResolvedValue({
+			_id: jobId,
+			target: 'product',
+			targetId: productId,
+			workspaceId,
+		});
+
+		const findOne = jest.fn() as any;
+		findOne.mockResolvedValue({
+			_id: productId,
+			workspace_id: workspaceId,
+			product_plan_number: 'ABC/123',
+			version: 2,
+		});
+
+		getDb.mockResolvedValue({
+			collection: jest.fn().mockReturnValue({
+				findOne,
+			}),
+		});
+
+		generateProductPDFExport.mockResolvedValue(Buffer.from('product-pdf'));
+
+		const result = await lambdaHandler({
+			Records: [{
+				messageId: 'msg-1',
+				body: JSON.stringify({
+					schemaVersion: 1,
+					jobId: jobId.toString(),
+					target: 'product',
+					targetId: productId.toString(),
+					workspaceId: workspaceId.toString(),
+					requestedBySub: 'user-sub',
+					format: 'pdf',
+					queuedAt: '2026-03-08T10:00:00.000Z',
+				}),
+				attributes: { ApproximateReceiveCount: '1' },
+			}],
+		} as any);
+
+		expect(result).toEqual({ batchItemFailures: [] });
+		expect(uploadExportObjectByKey).toHaveBeenCalledWith({
+			key: expect.stringContaining(`/products/${workspaceId.toString()}/${jobId.toString()}/Product_ABC_123_v2.pdf`),
+			body: Buffer.from('product-pdf'),
+			contentType: 'application/pdf',
+		});
+		expect(markExportJobCompleted).toHaveBeenCalledWith({
+			jobId,
+			s3Key: expect.stringContaining(`/products/${workspaceId.toString()}/${jobId.toString()}/Product_ABC_123_v2.pdf`),
+			fileName: 'Product_ABC_123_v2.pdf',
+			contentType: 'application/pdf',
+		});
+		expect(markExportJobFailed).not.toHaveBeenCalled();
+	});
+
+	it('processes report export jobs asynchronously', async () => {
+		const jobId = new ObjectId();
+		const workspaceId = new ObjectId();
+		const products = [{
+			_id: new ObjectId(),
+			product_name: 'Test Product',
+			product_plan_number: 'PLAN-1',
+			status: 'draft',
+			version: 1,
+		}];
+
+		markExportJobProcessing.mockResolvedValue({
+			_id: jobId,
+			target: 'report',
+			workspaceId,
+			reportParams: {
+				conditions: [],
+				sort: { field: 'product_name', order: 'asc' },
+			},
+		});
+
+		buildExportPipeline.mockReturnValue([{ $match: { workspace_id: workspaceId } }]);
+		const toArray = jest.fn() as any;
+		toArray.mockResolvedValue(products);
+		getDb.mockResolvedValue({
+			collection: jest.fn().mockReturnValue({
+				aggregate: jest.fn().mockReturnValue({
+					toArray,
+				}),
+			}),
+		});
+
+		generateReportsPDFExport.mockResolvedValue(Buffer.from('report-pdf'));
+
+		const result = await lambdaHandler({
+			Records: [{
+				messageId: 'msg-2',
+				body: JSON.stringify({
+					schemaVersion: 1,
+					jobId: jobId.toString(),
+					target: 'report',
+					workspaceId: workspaceId.toString(),
+					requestedBySub: 'user-sub',
+					format: 'pdf',
+					queuedAt: '2026-03-08T10:00:00.000Z',
+				}),
+				attributes: { ApproximateReceiveCount: '1' },
+			}],
+		} as any);
+
+		expect(result).toEqual({ batchItemFailures: [] });
+		expect(buildExportPipeline).toHaveBeenCalledWith({
+			workspaceId: workspaceId.toString(),
+			conditions: [],
+			sort: { field: 'product_name', order: 'asc' },
+		}, workspaceId, 1000);
+		expect(generateReportsPDFExport).toHaveBeenCalledWith(products);
+		expect(uploadExportObjectByKey).toHaveBeenCalledWith({
+			key: expect.stringContaining(`/reports/${workspaceId.toString()}/${jobId.toString()}/Products_Report_`),
+			body: Buffer.from('report-pdf'),
+			contentType: 'application/pdf',
+		});
+		expect(markExportJobCompleted).toHaveBeenCalledWith({
+			jobId,
+			s3Key: expect.stringContaining(`/reports/${workspaceId.toString()}/${jobId.toString()}/Products_Report_`),
+			fileName: expect.stringMatching(/^Products_Report_\d{4}-\d{2}-\d{2}\.pdf$/),
+			contentType: 'application/pdf',
+		});
+	});
+});

--- a/src/tests/unit/product-info.test.ts
+++ b/src/tests/unit/product-info.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@jest/globals';
+import { updateProductInformation } from '../../controllers/products/productData/product-info';
+import { UpdateProductInformationData } from '../../types/products/product-info';
+
+const baseProductInfoInput: UpdateProductInformationData = {
+	product_name: 'Infusion Pump',
+	product_plan_number: 'PLAN-001',
+	product_description: 'Programmable infusion pump',
+	target_date: null,
+	actual_completion_date: null,
+	market_geography: 'EU',
+	country_of_origin: 'US',
+	oem_contract_manufacturer: 'Acme Medical',
+	commercial_clinical: 'Commercial',
+	manufacturing_location: 'Boston',
+};
+
+describe('updateProductInformation', () => {
+	it('does not require class of device or Basic UDI-DI fields', () => {
+		const result = updateProductInformation(
+			baseProductInfoInput,
+			'product-information',
+			'update_product_information',
+		);
+
+		expect(result.error).toBeNull();
+		expect(result.updateQuery).toEqual({
+			$set: expect.not.objectContaining({
+				'product_information.data.class_of_device': expect.anything(),
+				'product_information.data.basic_udi_di': expect.anything(),
+			}),
+		});
+	});
+
+	it('persists class of device and Basic UDI-DI when provided', () => {
+		const result = updateProductInformation(
+			{
+				...baseProductInfoInput,
+				class_of_device: 'EU MDR - Class IIa',
+				basic_udi_di: 'BUDI-DI-123',
+			},
+			'product-information',
+			'update_product_information',
+		);
+
+		expect(result.error).toBeNull();
+		expect(result.updateQuery).toEqual({
+			$set: expect.objectContaining({
+				'product_information.data.class_of_device': 'EU MDR - Class IIa',
+				'product_information.data.basic_udi_di': 'BUDI-DI-123',
+			}),
+		});
+	});
+});

--- a/src/tests/unit/queryBuilder.test.ts
+++ b/src/tests/unit/queryBuilder.test.ts
@@ -1,0 +1,69 @@
+import { ObjectId } from 'mongodb';
+import { describe, expect, it } from '@jest/globals';
+import { buildAggregationPipeline, buildExportPipeline } from '../../utils/reports/queryBuilder';
+
+describe('buildExportPipeline', () => {
+	it('projects label tag completion state for report exports', () => {
+		const pipeline = buildExportPipeline({
+			workspaceId: new ObjectId().toString(),
+			conditions: [],
+		}, new ObjectId(), 1000);
+
+		expect(pipeline[3]).toEqual({
+			$project: expect.objectContaining({
+				'label_tags.tab_completed': 1,
+			}),
+		});
+	});
+
+	it('filters report exports by Product Information device class', () => {
+		const pipeline = buildExportPipeline({
+			workspaceId: new ObjectId().toString(),
+			conditions: [{
+				id: 'class-filter',
+				tab: 'product_information',
+				field: 'class_of_device',
+				operator: 'equals',
+				value: 'EU MDR - Class IIa',
+			}],
+		}, new ObjectId(), 1000);
+
+		expect(pipeline[1]).toEqual({
+			$match: {
+				$and: [{
+					'product_information.data.class_of_device': 'EU MDR - Class IIa',
+				}],
+			},
+		});
+	});
+});
+
+describe('buildAggregationPipeline', () => {
+	it('filters reports by Product Information Basic UDI-DI', () => {
+		const pipeline = buildAggregationPipeline({
+			workspaceId: new ObjectId().toString(),
+			conditions: [{
+				id: 'udi-filter',
+				tab: 'product_information',
+				field: 'basic_udi_di',
+				operator: 'contains',
+				value: 'BUDI-123',
+			}],
+			pagination: {
+				page: 1,
+				limit: 10,
+			},
+		}, new ObjectId());
+
+		expect(pipeline[1]).toEqual({
+			$match: {
+				$and: [{
+					'product_information.data.basic_udi_di': {
+						$regex: 'BUDI-123',
+						$options: 'i',
+					},
+				}],
+			},
+		});
+	});
+});

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -10,7 +10,7 @@
       "esModuleInterop": true, 
       "skipLibCheck": true,
       "forceConsistentCasingInFileNames": true,
-      "ignoreDeprecations": "6.0"
+      "ignoreDeprecations": "5.0"
     },
     "exclude": ["node_modules", "**/*.test.ts"]
   }

--- a/src/utils/s3-storage.ts
+++ b/src/utils/s3-storage.ts
@@ -6,16 +6,22 @@ const region = process.env.AWS_REGION;
 const uploadsBucket = process.env.UPLOADS_BUCKET;
 const exportsBucket = process.env.EXPORTS_BUCKET;
 const standardSymbolsBucket = process.env.STANDARD_SYMBOLS_BUCKET;
-
-if (!region) throw new Error("Missing required environment variable: AWS_REGION");
-if (!uploadsBucket) throw new Error("Missing required environment variable: UPLOADS_BUCKET");
-if (!exportsBucket) throw new Error("Missing required environment variable: EXPORTS_BUCKET");
+const documentationFilesBucket = process.env.DOCUMENTATION_FILES_BUCKET;
 
 const parsePositiveInteger = (value: string | undefined, fallback: number): number => {
 	const parsed = Number.parseInt(value ?? "", 10);
 	if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
 	return parsed;
 };
+
+const DOCS_FILE_URL_EXPIRES_IN_SECONDS = parsePositiveInteger(
+	process.env.DOCS_VIDEO_URL_EXPIRES_IN_SECONDS,
+	900,
+);
+
+if (!region) throw new Error("Missing required environment variable: AWS_REGION");
+if (!uploadsBucket) throw new Error("Missing required environment variable: UPLOADS_BUCKET");
+if (!exportsBucket) throw new Error("Missing required environment variable: EXPORTS_BUCKET");
 
 const VIEW_URL_EXPIRES_IN_SECONDS = parsePositiveInteger(process.env.S3_VIEW_URL_EXPIRES_IN_SECONDS, 43200);
 const SIGNING_CONCURRENCY = parsePositiveInteger(process.env.S3_SIGNING_CONCURRENCY, 25);
@@ -193,6 +199,30 @@ export const createStandardSymbolPresignedGetUrl = async (key: string): Promise<
 	});
 
 	return getSignedUrl(client, command, { expiresIn: VIEW_URL_EXPIRES_IN_SECONDS });
+};
+
+export type DocumentationFilePresignedUrl = {
+	url: string;
+	expiresAt: string;
+};
+
+export const createDocumentationFilePresignedGetUrl = async (
+	key: string,
+): Promise<DocumentationFilePresignedUrl> => {
+	if (!documentationFilesBucket) {
+		throw new Error("Missing required environment variable: DOCUMENTATION_FILES_BUCKET");
+	}
+
+	const command = new GetObjectCommand({
+		Bucket: documentationFilesBucket,
+		Key: key,
+	});
+
+	const expiresIn = DOCS_FILE_URL_EXPIRES_IN_SECONDS;
+	const url = await getSignedUrl(client, command, { expiresIn });
+	const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+
+	return { url, expiresAt };
 };
 
 const normalizeKey = (key: unknown): string | null => {

--- a/template.yaml
+++ b/template.yaml
@@ -33,6 +33,10 @@ Parameters:
     Type: String
     Description: "S3 bucket name for standard symbol library images"
     Default: "uprevit-standard-symbols"
+  DocumentationFilesBucket:
+    Type: String
+    Description: "S3 bucket name for documentation media (videos, future images/PDFs)"
+    Default: "uprevit-documentation-files"
   ExportJobQueueUrl:
     Type: String
     Description: "Optional explicit SQS queue URL override for local/dev"
@@ -69,6 +73,7 @@ Globals:
         UPLOADS_BUCKET: !Ref UploadsBucket
         EXPORTS_BUCKET: !Ref ExportsBucket
         STANDARD_SYMBOLS_BUCKET: !Ref StandardSymbolsBucket
+        DOCUMENTATION_FILES_BUCKET: !Ref DocumentationFilesBucket
     # You can add LoggingConfig parameters such as the Logformat, Log Group, and SystemLogLevel or ApplicationLogLevel. Learn more here https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-loggingconfig.
     LoggingConfig:
       LogFormat: JSON
@@ -654,6 +659,29 @@ Resources:
       BuildProperties:
         <<: *EsbuildProps
         EntryPoints: [controllers/standardSymbols/getAllStandardSymbols.ts]
+
+  GetDocumentationVideoSignedUrlFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/docs/getDocumentationVideoSignedUrl.lambdaHandler
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - s3:GetObject
+              Resource: !Sub "arn:aws:s3:::${DocumentationFilesBucket}/videos/*"
+      Events:
+        GetDocumentationVideoSignedUrl:
+          Type: Api
+          Properties:
+            Path: /docs/videos/{videoKey}/signed-url
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/docs/getDocumentationVideoSignedUrl.ts]
 
   CreateProductVersionFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
- Sync `package-lock` version to 0.3.0
- Add authenticated `GET /docs/videos/{videoKey}/signed-url` with an allowlisted video map and presigned reads from `DOCUMENTATION_FILES_BUCKET`
- Wire SAM template and deploy workflow for the documentation videos bucket
- Add a seed script to upload local `.mp4` files to S3 for documentation walkthroughs
- Add unit tests for documentation videos, list query parsing, query builder filters, report export enqueue, export job processing, label components, and product info utilities