### PR TITLE
Fix documentation video key validation TypeScript compatibility

### DIFF
--- a/src/config/documentationVideos.ts
+++ b/src/config/documentationVideos.ts
@@ -18,7 +18,7 @@ export const DOCUMENTATION_VIDEOS = {
 export type DocumentationVideoKey = keyof typeof DOCUMENTATION_VIDEOS;
 
 export const isDocumentationVideoKey = (value: string): value is DocumentationVideoKey =>
-	Object.hasOwn(DOCUMENTATION_VIDEOS, value);
+	Object.prototype.hasOwnProperty.call(DOCUMENTATION_VIDEOS, value);
 
 export const getDocumentationVideoObjectKey = (
 	videoKey: string,


### PR DESCRIPTION
- Replace the ES2022-only `Object.hasOwn` call with an ES2020-compatible own-property check so the backend deploy type-check can complete.
- Verified with `npm run type-check` from `src`.