### PR TITLE
Enforce workspace tenant isolation across API handlers and harden S3/export access

### DIFF
--- a/.cursor/rules/Branch-Merging-Strategy.mdc
+++ b/.cursor/rules/Branch-Merging-Strategy.mdc
@@ -1,0 +1,42 @@
+---
+alwaysApply: true
+---
+---
+alwaysApply: false
+---
+
+Gitflow and `demo` branch (uprevit-ui & uprevit-backend)
+
+## Branches
+
+- `develop` — integration (features merge here)
+- `release/x.y.z` — release fixes only
+- `main` — production (deploy prod)
+- `demo` — demo environment; must be the **same commit as `main`**, not `develop`
+
+## Release flow
+
+1. Merge `release/x.y.z` → `main`, tag `vx.y.z` on `main`.
+2. **One PR:** `main` → `develop` (back-merge).
+3. Sync `demo` to `main` with a ref push — **no PR:**
+
+```bash
+git fetch origin
+git push origin origin/main:demo
+If rejected:
+
+git diff origin/main origin/demo --stat   # must be empty
+git push origin origin/main:demo --force-with-lease
+Local: git fetch origin && git checkout demo && git reset --hard origin/demo
+
+Verify:
+git rev-parse origin/main origin/demo    # identical SHA
+git rev-list --left-right --count origin/main...origin/demo   # 0 0
+
+Never
+Do not open a PR main → demo (adds a merge commit; demo looks ahead of main).
+Do not git push origin origin/develop:demo for releases (demo must match main, not develop).
+Expected graph
+main, demo, origin/demo — same commit (release merge).
+develop — one commit ahead of main (back-merge only). That is normal; do not try to align develop with main on the graph.
+```

--- a/src/controllers/auditLogs/getAuditLogs.ts
+++ b/src/controllers/auditLogs/getAuditLogs.ts
@@ -8,10 +8,10 @@ import {
 	type AuditLogV2,
 	type AuditScopeType,
 } from '../../models/auditLogV2';
-import { authenticateRequest } from '../../utils/authUtils';
 import { getDb } from '../../utils/db';
 import { logError, logInfo } from '../../utils/logger';
 import { ResponseWrapper } from '../../utils/responseWrapper';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
 
 const ADMIN_ONLY_SCOPES: AuditScopeType[] = ['department', 'project', 'archive'];
 const MAX_SEARCH_LENGTH = 200;
@@ -50,10 +50,12 @@ const parseActions = (rawActions: string | undefined): AuditAction[] | null => {
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		const workspaceId = event.queryStringParameters?.workspaceId;
+		const { context, auth } = tenantResult;
+
+		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;
 		const scopeTypeRaw = event.queryStringParameters?.scopeType;
 		const scopeId = event.queryStringParameters?.scopeId;
 		const search = event.queryStringParameters?.search?.trim();
@@ -69,8 +71,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			requestId: event.requestContext?.requestId,
 		});
 
-		if (!workspaceId || !ObjectId.isValid(workspaceId)) {
-			return ResponseWrapper.badRequest('workspaceId query parameter must be a valid ObjectId.');
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) {
+				return ResponseWrapper.badRequest('workspaceId query parameter must be a valid ObjectId.');
+			}
+
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
 		}
 
 		if (!scopeTypeRaw || !AUDIT_SCOPE_TYPES.includes(scopeTypeRaw as AuditScopeType)) {
@@ -106,7 +113,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const collection = db.collection<AuditLogV2>(AUDIT_LOG_V2_COLLECTION);
 
 		const query: Record<string, unknown> = {
-			workspaceId: new ObjectId(workspaceId),
+			workspaceId: context.workspaceId,
 		};
 
 		if (!adminUser) {

--- a/src/controllers/bookmarks/addProductToBookmarkFolder.ts
+++ b/src/controllers/bookmarks/addProductToBookmarkFolder.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext, tenantObjectIdFilter } from "../../utils/tenantContext";
 import { validateAllObjectIds, validateMissingFields } from "../../utils/validationUtils";
 import { getDb } from "../../utils/db";
 import { UserBookmarks } from "../../models/bookmarks";
@@ -17,8 +17,10 @@ import { AuditLogAction } from "../../models/auditLog";
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 
 		const folderIdParam = event.pathParameters?.folderId;
 		if (!folderIdParam) return ResponseWrapper.badRequest("Folder ID is missing from path parameters.");
@@ -28,32 +30,33 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const input = JSON.parse(event.body);
 
 		const missingFieldsResult = validateMissingFields({
-			user_id: input.user_id,
 			product_id: input.product_id,
 		});
 		if (missingFieldsResult) return missingFieldsResult;
 
 		const objectIdValidation = validateAllObjectIds({
-			user_id: input.user_id,
 			product_id: input.product_id,
 			folderId: folderIdParam,
 		});
 		if (objectIdValidation) return objectIdValidation;
 
-		const userId = ObjectId.createFromHexString(input.user_id);
+		const userId = context.userId;
 		const productId = ObjectId.createFromHexString(input.product_id);
 		const folderId = ObjectId.createFromHexString(folderIdParam);
 
 		const db = await getDb();
 
-		const productExists = await db.collection<Product>("products").countDocuments({ _id: productId });
-		if (productExists === 0) {
+		const productExists = await db.collection<Product>("products").findOne(
+			tenantObjectIdFilter(productId, context.workspaceId),
+		);
+		if (!productExists) {
 			return ResponseWrapper.notFound("Product not found.");
 		}
 
 		const updateResult = await db.collection<UserBookmarks>("bookmarks").updateOne(
 			{
 				user_id: userId,
+				workspace_id: context.workspaceId,
 				"product_folders._id": folderId,
 			},
 			{

--- a/src/controllers/bookmarks/createProductBookmarkFolder.ts
+++ b/src/controllers/bookmarks/createProductBookmarkFolder.ts
@@ -1,8 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
-import { validateAllObjectIds, validateMissingFields } from "../../utils/validationUtils";
+import { requireTenantContext } from "../../utils/tenantContext";
+import { validateMissingFields } from "../../utils/validationUtils";
 import { getDb } from "../../utils/db";
 import { ProductBookmarkFolder, UserBookmarks } from "../../models/bookmarks";
 import { ObjectId } from "mongodb";
@@ -16,36 +16,30 @@ import { AuditLogAction } from "../../models/auditLog";
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 
 		if(!event.body) return ResponseWrapper.badRequest('Request body is missing.');
 
 		const input = JSON.parse(event.body);
 
 		const missingFieldsResult = validateMissingFields({
-			user_id: input.user_id,
-			workspace_id: input.workspace_id,
 			folder_name: input.folder_name,
 		});
 		if (missingFieldsResult) return missingFieldsResult;
 
-		const objectIdValidation = validateAllObjectIds({
-			'user_id': input.user_id,
-			'workspace_id': input.workspace_id
-		});
-		if (objectIdValidation) return objectIdValidation
-
-
 		const db = await getDb();
 		const bookmarksCollection = db.collection<UserBookmarks>('bookmarks');
-		const userId = ObjectId.createFromHexString(input.user_id);
-		const workspaceId = ObjectId.createFromHexString(input.workspace_id);
+		const userId = context.userId;
+		const workspaceId = context.workspaceId;
 
 		const trimmedFolderName = input.folder_name.trim();
 
 		const existingFolder = await bookmarksCollection.findOne({
 			user_id: userId,
+			workspace_id: workspaceId,
 			'product_folders.folder_name': trimmedFolderName,
 		});
 
@@ -62,6 +56,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		await bookmarksCollection.updateOne(
 			{
 				user_id: userId,
+				workspace_id: workspaceId,
 			},
 			{
 				$push: { product_folders: newProductBookmarkFolder },

--- a/src/controllers/bookmarks/deleteProductBookmarkFolder.ts
+++ b/src/controllers/bookmarks/deleteProductBookmarkFolder.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext } from "../../utils/tenantContext";
 import { validateAllObjectIds } from "../../utils/validationUtils";
 import { getDb } from "../../utils/db";
 import { UserBookmarks } from "../../models/bookmarks";
@@ -16,30 +16,28 @@ import { AuditLogAction } from "../../models/auditLog";
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 
 		const folderId = event.pathParameters?.folderId;
 		if(!folderId) return ResponseWrapper.badRequest('Folder ID is missing from path parameters.');
 
-		// TODO - Get user id from auth token in future 
- 		const userId = event.queryStringParameters?.user_id;
-		if (!userId) return ResponseWrapper.badRequest('Missing required query parameter: user_id');
-
 		const objectIdValidation = validateAllObjectIds({ 
-			userId, 
-			folderId 
+			folderId, 
 		});
-		if (objectIdValidation) return objectIdValidation
+		if (objectIdValidation) return objectIdValidation;
 
 		const db = await getDb();
 		const bookmarksCollection = db.collection<UserBookmarks>('bookmarks');
-		const userIdObj = ObjectId.createFromHexString(userId);
+		const userIdObj = context.userId;
 		const folderIdObj = ObjectId.createFromHexString(folderId);
 
 		const result = await bookmarksCollection.updateOne(
 			{
 				user_id: userIdObj,
+				workspace_id: context.workspaceId,
 				'product_folders._id': folderIdObj
 			},
 			{

--- a/src/controllers/bookmarks/deleteProductFromBookmark.ts
+++ b/src/controllers/bookmarks/deleteProductFromBookmark.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext } from "../../utils/tenantContext";
 import { validateAllObjectIds, validateMissingFields } from "../../utils/validationUtils";
 import { getDb } from "../../utils/db";
 import { UserBookmarks } from "../../models/bookmarks";
@@ -16,8 +16,10 @@ import { AuditLogAction } from "../../models/auditLog";
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 
 		const folderIdParam = event.pathParameters?.folderId;
 		if (!folderIdParam) return ResponseWrapper.badRequest("Folder ID is missing from path parameters.");
@@ -27,19 +29,17 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const input = JSON.parse(event.body);
 
 		const missingFieldsResult = validateMissingFields({
-			user_id: input.user_id,
 			product_id: input.product_id,
 		});
 		if (missingFieldsResult) return missingFieldsResult;
 
 		const objectIdValidation = validateAllObjectIds({
-			user_id: input.user_id,
 			folderId: folderIdParam,
 			productId: input.product_id,
 		});
 		if (objectIdValidation) return objectIdValidation;
 
-		const userId = ObjectId.createFromHexString(input.user_id);
+		const userId = context.userId;
 		const folderId = ObjectId.createFromHexString(folderIdParam);
 		const productId = ObjectId.createFromHexString(input.product_id);
 
@@ -48,6 +48,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const updateResult = await db.collection<UserBookmarks>("bookmarks").findOneAndUpdate(
 			{
 				user_id: userId,
+				workspace_id: context.workspaceId,
 				"product_folders._id": folderId
 			},
 			{

--- a/src/controllers/bookmarks/getAllProductBookmarkFolders.ts
+++ b/src/controllers/bookmarks/getAllProductBookmarkFolders.ts
@@ -1,10 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext } from "../../utils/tenantContext";
 import { getDb } from "../../utils/db";
-import { validateAllObjectIds } from "../../utils/validationUtils";
-import { ObjectId } from "mongodb";
 
 /**
  * @param {APIGatewayProxyEvent} event 
@@ -13,23 +11,17 @@ import { ObjectId } from "mongodb";
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		const userId = event.queryStringParameters?.userId;
-		if (!userId) return ResponseWrapper.badRequest('Missing required query parameter: userId');
-
-		const  validateUserId = validateAllObjectIds({ userId });
-		if (validateUserId) return validateUserId;
-
-		// TODO: Implement this check when we connect auth and users collection
-		// if(auth.payload.sub !== userId) return ResponseWrapper.unauthorized('You are not authorized to access bookmarks of other users.');
+		const { context } = tenantResult;
 
 		const db = await getDb();
 
 		const productBookmarkFolders = await db.collection('bookmarks').findOne({
-			user_id: new ObjectId(userId),
-		})
+			user_id: context.userId,
+			workspace_id: context.workspaceId,
+		});
 
 		if(!productBookmarkFolders) return ResponseWrapper.notFound('No product bookmark folders found for the given user.');
 

--- a/src/controllers/bookmarks/getBookmarkedSourceFileFolders.ts
+++ b/src/controllers/bookmarks/getBookmarkedSourceFileFolders.ts
@@ -1,9 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext } from "../../utils/tenantContext";
 import { getDb } from "../../utils/db";
-import { validateAllObjectIds } from "../../utils/validationUtils";
 import { ObjectId } from "mongodb";
 import { SourceFile } from "../../models/sourceFiles";
 import { UserBookmarks } from "../../models/bookmarks";
@@ -14,23 +13,25 @@ import { UserBookmarks } from "../../models/bookmarks";
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		const userId = event.queryStringParameters?.userId;
-		if (!userId) return ResponseWrapper.badRequest('Missing required query parameter: userId');
-
-		const validationError = validateAllObjectIds({ userId });
-		if (validationError) return validationError;
+		const { context } = tenantResult;
 
 		const db = await getDb();
-		const userIdObj = new ObjectId(userId);
+		const userIdObj = context.userId;
 
-		const bookmarks = await db.collection<UserBookmarks>('bookmarks').findOne({ user_id: userIdObj });
+		const bookmarks = await db.collection<UserBookmarks>('bookmarks').findOne({
+			user_id: userIdObj,
+			workspace_id: context.workspaceId,
+		});
 		const bookmarkedFolderIds = bookmarks ? bookmarks.sourceFile_folders.map(id => id.toString()) : [];
         
 
-		const allBookmarkedFolders = await db.collection<SourceFile>('sourceFiles').find({_id: {$in: bookmarkedFolderIds.map(id => new ObjectId(id))}}).toArray();
+		const allBookmarkedFolders = await db.collection<SourceFile>('sourceFiles').find({
+			_id: { $in: bookmarkedFolderIds.map(id => new ObjectId(id)) },
+			workspace_id: context.workspaceId,
+		}).toArray();
 
 
 		return ResponseWrapper.success({

--- a/src/controllers/bookmarks/getProductsFromBookmark.ts
+++ b/src/controllers/bookmarks/getProductsFromBookmark.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext } from "../../utils/tenantContext";
 import { validateAllObjectIds } from "../../utils/validationUtils";
 import { getDb } from "../../utils/db";
 import { UserBookmarks } from "../../models/bookmarks";
@@ -14,28 +14,28 @@ import { ObjectId } from "mongodb";
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
 
 		const folderIdParam = event.pathParameters?.folderId;
-		const userIdParam = event.queryStringParameters?.userId;
 
 		if (!folderIdParam) return ResponseWrapper.badRequest("Folder ID is missing from path parameters.");
-		if (!userIdParam) return ResponseWrapper.badRequest("User ID is missing from query string parameters.");
 
 		const objectIdValidation = validateAllObjectIds({
 			folderId: folderIdParam,
-			userId: userIdParam,
 		});
 		if (objectIdValidation) return objectIdValidation;
 
 		const folderId = ObjectId.createFromHexString(folderIdParam);
-		const userId = ObjectId.createFromHexString(userIdParam);
+		const userId = context.userId;
+		const workspaceId = context.workspaceId;
 
 		const db = await getDb();
 
 		const pipeline = [
-			{ $match: { user_id: userId } },
+			{ $match: { user_id: userId, workspace_id: workspaceId } },
 			{ $unwind: "$product_folders" },
 			{ $match: { "product_folders._id": folderId } },
 			{
@@ -43,6 +43,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 					from: "products",
 					localField: "product_folders.products",
 					foreignField: "_id",
+					pipeline: [
+						{
+							$match: {
+								workspace_id: workspaceId,
+							},
+						},
+					],
 					as: "bookmarkedProducts",
 				},
 			},

--- a/src/controllers/bookmarks/toggleBookmarkSourceFileFolders.ts
+++ b/src/controllers/bookmarks/toggleBookmarkSourceFileFolders.ts
@@ -1,10 +1,11 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext, tenantObjectIdFilter } from "../../utils/tenantContext";
 import { getDb } from "../../utils/db";
 import { validateAllObjectIds, validateMissingFields } from "../../utils/validationUtils";
 import { ObjectId } from "mongodb";
+import { SourceFile } from "../../models/sourceFiles";
 import { UserBookmarks } from "../../models/bookmarks";
 import { updateAuditLog } from "../../utils/auditLog";
 import { AuditLogAction } from "../../models/auditLog";
@@ -15,34 +16,42 @@ import { AuditLogAction } from "../../models/auditLog";
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 
 		if (!event.body) return ResponseWrapper.badRequest("Request body is missing.");
 
 		const input = JSON.parse(event.body);
 
 		const missingFieldsResult = validateMissingFields({
-			user_id: input.user_id,
-			workspace_id: input.workspace_id,
 			folder_id: input.folder_id,
 		});
 		if (missingFieldsResult) return missingFieldsResult;
 
 		const objectIdValidation = validateAllObjectIds({
-			user_id: input.user_id,
-			workspace_id: input.workspace_id,
 			folder_id: input.folder_id,
 		});
 		if (objectIdValidation) return objectIdValidation;
 
 		const db = await getDb();
 		const bookmarksCollection = db.collection<UserBookmarks>('bookmarks');
-		const userId = ObjectId.createFromHexString(input.user_id);
-		const workspaceId = ObjectId.createFromHexString(input.workspace_id);
+		const userId = context.userId;
+		const workspaceId = context.workspaceId;
 		const folderId = ObjectId.createFromHexString(input.folder_id);
 
-		const userBookmarks = await bookmarksCollection.findOne({ user_id: userId });
+		const sourceFolder = await db.collection<SourceFile>('sourceFiles').findOne(
+			tenantObjectIdFilter(folderId, workspaceId),
+		);
+		if (!sourceFolder || sourceFolder.type !== 'folder') {
+			return ResponseWrapper.notFound('Source file folder not found.');
+		}
+
+		const userBookmarks = await bookmarksCollection.findOne({
+			user_id: userId,
+			workspace_id: workspaceId,
+		});
 
 		let update;
 		let message: string;
@@ -62,7 +71,11 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			message = 'Source file folder added to bookmarks successfully.';
 		}
 
-		const result = await bookmarksCollection.updateOne({ user_id: userId }, update, { upsert: true });
+		const result = await bookmarksCollection.updateOne(
+			{ user_id: userId, workspace_id: workspaceId },
+			update,
+			{ upsert: true },
+		);
 
 		await updateAuditLog({
 			entity: 'sourcefile_bookmark_folder',

--- a/src/controllers/bookmarks/updateProductBookmarkFolder.ts
+++ b/src/controllers/bookmarks/updateProductBookmarkFolder.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext } from "../../utils/tenantContext";
 import { validateAllObjectIds, validateMissingFields } from "../../utils/validationUtils";
 import { getDb } from "../../utils/db";
 import { UserBookmarks } from "../../models/bookmarks";
@@ -16,8 +16,10 @@ import { AuditLogAction } from "../../models/auditLog";
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 
 		const folderId = event.pathParameters?.folderId;
 		if(!folderId) return ResponseWrapper.badRequest('Folder ID is missing from path parameters.');
@@ -27,26 +29,25 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const input = JSON.parse(event.body);
 
 		const missingFieldsResult = validateMissingFields({
-			user_id: input.user_id,
 			folder_name: input.folder_name,
 		});
 		if (missingFieldsResult) return missingFieldsResult;
 
 		const objectIdValidation = validateAllObjectIds({
-			'user_id': input.user_id,
-			'folderId': folderId
+			folderId,
 		});
-		if (objectIdValidation) return objectIdValidation
+		if (objectIdValidation) return objectIdValidation;
 
 		const db = await getDb();
 		const bookmarksCollection = db.collection<UserBookmarks>('bookmarks');
-		const userId = ObjectId.createFromHexString(input.user_id);
+		const userId = context.userId;
 		const productBookmarkFolderId = ObjectId.createFromHexString(folderId);
 
 		const trimmedFolderName = input.folder_name.trim();
 
 		const existingFolderWithSameName = await bookmarksCollection.findOne({
 			user_id: userId,
+			workspace_id: context.workspaceId,
 			product_folders: {
 				$elemMatch: {
 					folder_name: trimmedFolderName,
@@ -62,6 +63,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const result = await bookmarksCollection.updateOne(
 			{
 				user_id: userId,
+				workspace_id: context.workspaceId,
 				'product_folders._id': productBookmarkFolderId
 			},
 			{

--- a/src/controllers/dashboard/getDashboardStats.ts
+++ b/src/controllers/dashboard/getDashboardStats.ts
@@ -3,8 +3,7 @@ import { getDb } from '../../utils/db';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { validateAllObjectIds } from '../../utils/validationUtils';
-import { authenticateRequest } from '../../utils/authUtils';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
 
 /**
  * API endpoint to get dashboard statistics for a workspace
@@ -14,29 +13,23 @@ import { authenticateRequest } from '../../utils/authUtils';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-	    // Extract workspaceId from query parameters
-	    const workspaceId = event.queryStringParameters?.id;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-	    if (!workspaceId) {
-	        return ResponseWrapper.badRequest('Missing required fields: id (workspaceId) is required');
-	    }
+		const { context } = tenantResult;
+		const requestedWorkspaceId = event.queryStringParameters?.id;
 
-		const validationResult = validateAllObjectIds({
-			'_id': workspaceId,
-		});
-			
-		if (validationResult) {
-			return validationResult;
-		}
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) {
+				return ResponseWrapper.badRequest('Invalid workspace id');
+			}
 
-		const auth = await authenticateRequest(event);
-
-		if (!auth.isValid) {
-			return auth.error;
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
 		}
 
 		const db = await getDb();
-		const workspaceObjectId = new ObjectId(workspaceId);
+		const workspaceObjectId = context.workspaceId;
 
 		// Count departments for the workspace
 		const departmentsPromise = db.collection('departments').countDocuments({

--- a/src/controllers/departments/archiveDepartment.ts
+++ b/src/controllers/departments/archiveDepartment.ts
@@ -1,12 +1,11 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import type { Department } from '../../models/department';
-import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateBoolean } from '../../utils/validationUtils';
-import { authenticateWithRole } from '../../utils/authUtils';
 import { recordAuditEvent } from '../../utils/auditLogV2';
+import { isWorkspaceAdmin, requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 
 /**
  * Archive a department
@@ -16,10 +15,13 @@ import { recordAuditEvent } from '../../utils/auditLogV2';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		const auth = await authenticateWithRole(event, 'admin');
-		if(!auth.isValid) {
-			return auth.error;
+		const { context, auth } = tenantResult;
+
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
 		}
 
 		if (!event.pathParameters?.id) {
@@ -48,19 +50,16 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const isBoolean = validateBoolean(isArchived, 'isArchived');
 		if (isBoolean) return isBoolean;
 
+		const departmentFilter = tenantObjectIdFilter(departmentId, context.workspaceId);
 
-		const departmentRecord: Department | null = await db.collection<Department>('departments').findOne({
-			_id: new ObjectId(departmentId),
-		});
+		const departmentRecord: Department | null = await db.collection<Department>('departments').findOne(departmentFilter);
 
 		if (!departmentRecord) {
 			return ResponseWrapper.notFound('Department not found');
 		}
 
 		const department = await db.collection<Department>('departments').updateOne(
-			{
-				_id: new ObjectId(departmentId),
-			},
+			departmentFilter,
 			{
 				$set: {
 					isArchived: isArchived,
@@ -73,7 +72,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		try {
 			await recordAuditEvent({
-				workspaceId: departmentRecord.workspace_id.toString(),
+				workspaceId: context.workspaceId.toString(),
 				scope: { type: 'department', id: departmentId },
 				entity: { type: 'department', id: departmentId },
 				action,
@@ -91,7 +90,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		} catch (auditError) {
 			logError('Department archive audit event failed', auditError, {
 				departmentName: departmentRecord.department_name,
-				workspaceId: departmentRecord.workspace_id.toString(),
+				workspaceId: context.workspaceId.toString(),
 				action,
 				departmentId,
 			});

--- a/src/controllers/departments/createDepartment.ts
+++ b/src/controllers/departments/createDepartment.ts
@@ -5,9 +5,9 @@ import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
-import { authenticateWithRole } from '../../utils/authUtils';
 import { recordAuditEvent } from '../../utils/auditLogV2';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 
 /**
  * Create a department
@@ -17,8 +17,14 @@ import { normalizePersistedAssetReference } from '../../utils/s3-storage';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateWithRole(event, 'admin');
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
+
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
+		}
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
 
@@ -30,14 +36,17 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			'department_name': input.department_name,
 			'department_description': input.department_description,
 			'admin_id': input.admin_id.toString(),
-			'workspace_id': input.workspace_id.toString(),
 		});
 		if (missingFieldsResult) return missingFieldsResult;
+
+		if (input.workspace_id) {
+			const workspaceMismatch = assertWorkspaceMatch(input.workspace_id, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
 
 		
 		const objectIdValidation = validateAllObjectIds({
 			'admin_id': input.admin_id,
-			'workspace_id': input.workspace_id,
 		}, {
 			'users': input.users,
 		});
@@ -47,7 +56,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const db = await getDb();
 		
 		const adminObjectId = new ObjectId(input.admin_id);
-		const workspaceObjectId = new ObjectId(input.workspace_id);
+		const workspaceObjectId = context.workspaceId;
 		const userObjectIds = input.users ? input.users.map((userId: string) => new ObjectId(userId)) : [];
 		const normalizedDepartmentImage = normalizePersistedAssetReference(input.image, '');
 

--- a/src/controllers/departments/getAllDepartments.ts
+++ b/src/controllers/departments/getAllDepartments.ts
@@ -148,7 +148,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			departments.map(async (department) => {
 				if (!department.users?.length) return department;
 
-				const usersWithSignedAvatars = await enrichUsersWithProfileAvatarUrls(department.users);
+				const usersWithSignedAvatars = await enrichUsersWithProfileAvatarUrls(department.users, {
+					workspaceId: context.workspaceId,
+					pendingOwnerId: context.cognitoSub,
+				});
 
 				return {
 					...department,
@@ -157,7 +160,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			}),
 		);
 
-		const departmentsWithSignedUrls = await enrichDepartmentsWithImageUrls(departmentsWithSignedAvatars);
+		const departmentsWithSignedUrls = await enrichDepartmentsWithImageUrls(departmentsWithSignedAvatars, {
+			workspaceId: context.workspaceId,
+			pendingOwnerId: context.cognitoSub,
+		});
 
 		const totalPages = Math.ceil(totalCount / limit);
 

--- a/src/controllers/departments/getAllDepartments.ts
+++ b/src/controllers/departments/getAllDepartments.ts
@@ -4,7 +4,7 @@ import { ObjectId } from 'mongodb';
 import { Department } from '../../models/department';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 import { enrichDepartmentsWithImageUrls, enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
 import { buildListFiltersMatch, ListFilterField, parseListQuery } from '../../utils/listQuery';
@@ -56,10 +56,10 @@ type DepartmentWithUsers = Omit<Department, 'users'> & {
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) {
-			return auth.error;
-		}
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
 
 		const db = await getDb();
 
@@ -71,10 +71,14 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (listQueryResult.error) return listQueryResult.error;
 
 		const { limit, page, skip, sort, order, filters } = listQueryResult.value!;
-		const workspaceId = event.queryStringParameters?.workspaceId;
+		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;
 
-		if (!workspaceId) return ResponseWrapper.badRequest('Workspace ID is required.');
-		if (!ObjectId.isValid(workspaceId)) return ResponseWrapper.badRequest('Invalid workspaceId');
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) return ResponseWrapper.badRequest('Invalid workspaceId');
+
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
 
 		const isArchiveParam = event.queryStringParameters?.isArchive;
 		let isArchive = false;
@@ -91,8 +95,8 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		sortObj[sortField] = order === 'desc' ? -1 : 1;
 
 		const filter = isArchive
-			? { isArchived: true, workspace_id: new ObjectId(workspaceId) }
-			: { isArchived: { $ne: true }, workspace_id: new ObjectId(workspaceId) };
+			? { isArchived: true, workspace_id: context.workspaceId }
+			: { isArchived: { $ne: true }, workspace_id: context.workspaceId };
 
 		const pipeline = [
 			{ $match: filter },

--- a/src/controllers/departments/getDepartment.ts
+++ b/src/controllers/departments/getDepartment.ts
@@ -4,7 +4,7 @@ import type { Department } from '../../models/department';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
+import { requireTenantContext } from '../../utils/tenantContext';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 import { enrichDepartmentsWithImageUrls, enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
 
@@ -30,10 +30,10 @@ type DepartmentWithUsers = Omit<Department, 'users'> & {
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
 
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) {
-			return auth.error;
-		}
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
 
 		if (!event.pathParameters?.id) {
 			return ResponseWrapper.badRequest('Missing required fields: id is required');
@@ -44,8 +44,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			{
 				$match: {
 					_id: new ObjectId(event.pathParameters.id),
-					isArchived: { $ne: true }
-				}
+					workspace_id: context.workspaceId,
+					isArchived: { $ne: true },
+				},
 			},
 			{
 				$lookup: {

--- a/src/controllers/departments/getDepartment.ts
+++ b/src/controllers/departments/getDepartment.ts
@@ -78,8 +78,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.badRequest('Department not found');
 		}
 
+		const signingOptions = {
+			workspaceId: context.workspaceId,
+			pendingOwnerId: context.cognitoSub,
+		};
+
 		const usersWithSignedAvatars = department.users?.length
-			? await enrichUsersWithProfileAvatarUrls(department.users)
+			? await enrichUsersWithProfileAvatarUrls(department.users, signingOptions)
 			: department.users;
 
 		const [departmentWithSignedImage] = await enrichDepartmentsWithImageUrls([
@@ -87,7 +92,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				...department,
 				users: usersWithSignedAvatars,
 			},
-		]);
+		], signingOptions);
 
 		return ResponseWrapper.success({
 			message: 'Department retrieved successfully',

--- a/src/controllers/departments/updateDepartment.ts
+++ b/src/controllers/departments/updateDepartment.ts
@@ -5,9 +5,9 @@ import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
-import { authenticateWithRole } from '../../utils/authUtils';
 import { recordAuditEvent } from '../../utils/auditLogV2';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 
 /**
  * Update a department
@@ -17,10 +17,13 @@ import { normalizePersistedAssetReference } from '../../utils/s3-storage';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		const auth = await authenticateWithRole(event, 'admin');
-		if(!auth.isValid) {
-			return auth.error;
+		const { context, auth } = tenantResult;
+
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
 		}
 
 		if (!event.body) {
@@ -33,7 +36,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			'department_name': input.department_name,
 			'department_description': input.department_description,
 			'admin_id': input.admin_id.toString(),
-			'workspace_id': input.workspace_id.toString(),
 			'_id': input._id!.toString(),
 		});
 
@@ -41,10 +43,14 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return missingFieldsResult;
 		}
 
+		if (input.workspace_id) {
+			const workspaceMismatch = assertWorkspaceMatch(input.workspace_id, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
+
 		const objectIdValidation = validateAllObjectIds({
 			'_id': input._id!,
 			'admin_id': input.admin_id,
-			'workspace_id': input.workspace_id,
 		}, {
 			'users': input.users,
 		});
@@ -54,24 +60,20 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		const db = await getDb();
+		const departmentFilter = tenantObjectIdFilter(input._id!, context.workspaceId);
 
-		const departmentRecord: Department | null = await db.collection<Department>('departments').findOne({
-			_id: new ObjectId(input._id),
-		});
+		const departmentRecord: Department | null = await db.collection<Department>('departments').findOne(departmentFilter);
 
 		if (!departmentRecord) {
 			return ResponseWrapper.badRequest('Department not found');
 		}
 
 		const adminObjectId = new ObjectId(input.admin_id);
-		const workspaceObjectId = new ObjectId(input.workspace_id);
 		const userObjectIds = input.users ? input.users.map((userId) => new ObjectId(userId)) : [];
 		const normalizedDepartmentImage = normalizePersistedAssetReference(input.image, departmentRecord.image ?? '');
 
 		const department = await db.collection<Department>('departments').updateOne(
-			{
-				_id: new ObjectId(departmentRecord._id as ObjectId),
-			},
+			departmentFilter,
 			{
 				$set: {
 					department_name: input.department_name,
@@ -79,14 +81,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 					image: normalizedDepartmentImage,
 					manager: input.manager,
 					admin_id: adminObjectId,
-					workspace_id: workspaceObjectId,
 					users: userObjectIds,
 				},
 			},
 		);
 
 		await recordAuditEvent({
-			workspaceId: workspaceObjectId.toString(),
+			workspaceId: context.workspaceId.toString(),
 			scope: { type: 'department', id: (departmentRecord._id as ObjectId).toString() },
 			entity: { type: 'department', id: (departmentRecord._id as ObjectId).toString() },
 			action: 'update',

--- a/src/controllers/onboarding/InviteNewUserByAdmin.ts
+++ b/src/controllers/onboarding/InviteNewUserByAdmin.ts
@@ -3,11 +3,11 @@ import { CognitoIdentityProviderClient, AdminCreateUserCommand, AdminUpdateUserA
 import { getDb } from "../../utils/db";
 import { User } from "../../models/user";
 import { ObjectId } from "mongodb";
-import { authenticateWithRole } from "../../utils/authUtils";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
 import { validateUserArray } from "../../utils/validationUtils";
 import { Workspace } from "../../models/workspace";
+import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext } from "../../utils/tenantContext";
 
 const cognito = new CognitoIdentityProviderClient({ region: 'us-east-1' });
 
@@ -17,13 +17,24 @@ const cognito = new CognitoIdentityProviderClient({ region: 'us-east-1' });
  */
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateWithRole(event, 'admin');
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
+		const { context } = tenantResult;
+
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
+		}
 
 		const workspaceId = event.pathParameters?.workspaceId;
 		if (!workspaceId) return ResponseWrapper.badRequest("Workspace ID is required in path parameters");
 
+		if (!ObjectId.isValid(workspaceId)) {
+			return ResponseWrapper.badRequest('Invalid workspace ID format. Must be a valid MongoDB ObjectId.');
+		}
+
+		const workspaceMismatch = assertWorkspaceMatch(workspaceId, context.workspaceId);
+		if (workspaceMismatch) return workspaceMismatch;
 
 		if (!event.body) return ResponseWrapper.badRequest("Request body is required.");
 
@@ -32,6 +43,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 		if(validationError) return validationError;
 
 		const db = await getDb();
+		const workspaceObjectId = context.workspaceId;
 		const results = [];
 
 		for (const user of users) {
@@ -56,7 +68,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 					email: email,
 					name: name,
 					cognitoSub: cognitoSub,
-					workspaceId: new ObjectId(workspaceId),
+					workspaceId: workspaceObjectId,
 					userType: "user",
 					status: "invited",
 				};
@@ -64,7 +76,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 				const dbUserId = userResult.insertedId.toString();
 
 				await db.collection<Workspace>("workspaces").updateOne(
-					{ _id: new ObjectId(workspaceId) },
+					{ _id: workspaceObjectId },
 					{ $push: { userIds: new ObjectId(dbUserId) } }
 				);
 		      
@@ -73,7 +85,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 					Username: email,
 					UserAttributes: [
 						{ Name: "custom:userId", Value: dbUserId },
-						{ Name: "custom:workspaceId", Value: workspaceId },
+						{ Name: "custom:workspaceId", Value: workspaceObjectId.toString() },
 						{ Name: "custom:status", Value: "invited" }
 					],
 				}));

--- a/src/controllers/onboarding/adminOnboardingCreateWorkspace.ts
+++ b/src/controllers/onboarding/adminOnboardingCreateWorkspace.ts
@@ -21,8 +21,15 @@ const resolveAdminName = (name: unknown, email: string): string => {
 };
 
 /**
- * @param {APIGatewayProxyEvent} event 
- * @return  {Promise<APIGatewayProxyResult>}
+ * Platform provisioning: onboarding flow that creates a new workspace and binds
+ * the authenticated admin user to it.
+ *
+ * Not tenant-scoped to an existing workspace — creates a new tenant. Same
+ * platform-role caveat as {@link createWorkspace}; do not treat Cognito `admin`
+ * as authorization to mutate arbitrary workspaces.
+ *
+ * @param {APIGatewayProxyEvent} event
+ * @return {Promise<APIGatewayProxyResult>}
  */
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {

--- a/src/controllers/onboarding/onboardAndUpdateInvitedUser.ts
+++ b/src/controllers/onboarding/onboardAndUpdateInvitedUser.ts
@@ -1,7 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { getDb } from "../../utils/db";
-import { ObjectId } from "mongodb";
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext } from "../../utils/tenantContext";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
 import { validateMissingFields } from "../../utils/validationUtils";
@@ -15,24 +14,24 @@ import { normalizePersistedAssetReference } from '../../utils/s3-storage';
  */
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return ResponseWrapper.unauthorized("Invalid authentication payload");
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
+		const { context } = tenantResult;
 
 		if (!event.body) return ResponseWrapper.badRequest("Request body is required.");
 
 
 		const input = JSON.parse(event.body);
 
-		const validationResult = validateMissingFields({ name: input.name, userId: input.user_id });
+		const validationResult = validateMissingFields({ name: input.name });
 		if (validationResult) return validationResult;
 
 
 		const db = await getDb();
 
-		// 2. Update user profile in MongoDB
 		const updateResult = await db.collection("users").updateOne(
-			{ _id: new ObjectId(input.user_id as string) },
+			{ cognitoSub: context.cognitoSub, workspaceId: context.workspaceId },
 			{
 				$set: {
 					name: input.name,
@@ -44,13 +43,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 			}
 		);
 
-		if (updateResult.modifiedCount === 0) {
+		if (updateResult.matchedCount === 0) {
 			return ResponseWrapper.notFound("User not found or no changes were made.");
 		}
         
 		await updateAuditLog({
 			entity: 'user',
-			entityId: input.user_id as string,
+			entityId: context.userId.toString(),
 			action: AuditLogAction.UPDATE,
 			actionBy: input.name,
 			actionAt: new Date(),

--- a/src/controllers/products/createProduct.ts
+++ b/src/controllers/products/createProduct.ts
@@ -4,7 +4,7 @@ import type { Product } from '../../models/product';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { validateEnum, validateMissingFields, validateObjectIds } from '../../utils/validationUtils';
-import { authenticateRequest } from '../../utils/authUtils';
+import { requireTenantContext } from '../../utils/tenantContext';
 import { logError } from '../../utils/logger';
 import { recordAuditEvent } from '../../utils/auditLogV2';
 
@@ -16,20 +16,18 @@ import { recordAuditEvent } from '../../utils/auditLogV2';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	let userId: string | undefined;
-	let workspaceId: string | undefined;
 	
 	try {
-		const auth = await authenticateRequest(event);	
-		if(!auth.isValid) return auth.error;
-		
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 		userId = auth.payload?.sub;
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
 
 		const input = JSON.parse(event.body);
 		if(!input)return ResponseWrapper.badRequest('Invalid JSON in request body');
-		
-		workspaceId = input.workspace_id;
 	
 
 		const missingFieldsResult = validateMissingFields({
@@ -52,7 +50,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const objectIdValidation = validateObjectIds({
 			'project_id': input.project_id,
 			'department_id': input.department_id!,
-			'workspace_id': input.workspace_id,
 		});
 
 		if(objectIdValidation) return objectIdValidation;
@@ -62,7 +59,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const projectObjectId = new ObjectId(input.project_id);
 		const departmentObjectId = new ObjectId(input.department_id);
-		const workspaceObjectId = new ObjectId(input.workspace_id);
+		const workspaceObjectId = context.workspaceId;
 
 		const existingProduct = await db.collection<Product>('products').findOne({
 			product_plan_number: input.product_plan_number,
@@ -162,10 +159,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			product: product,
 		});
 	} catch (err) {
-		logError('Create product handler failed', err, {
-			userId,
-			workspaceId,
-		});
+		logError('Create product handler failed', err, { userId });
 		return ResponseWrapper.internalServerError('Failed to create product');
 	}
 };

--- a/src/controllers/products/createProductVersion.ts
+++ b/src/controllers/products/createProductVersion.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 import { getDb } from "../../utils/db";
 import { ObjectId } from "mongodb";
 import { Product } from "../../models/product";
@@ -17,15 +17,23 @@ import { recordAuditEvent } from "../../utils/auditLogV2";
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);	
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 
 		const productId = event.pathParameters?.productId;
 		if(!productId) return ResponseWrapper.badRequest('Product ID is required');
 
 		const db = await getDb();
 
-		const currentProduct = await db.collection<Product>('products').findOne({ _id: new ObjectId(productId), status: 'submitted', is_latest: true });
+		const productFilter = {
+			...tenantObjectIdFilter(productId, context.workspaceId),
+			status: 'submitted' as const,
+			is_latest: true,
+		};
+
+		const currentProduct = await db.collection<Product>('products').findOne(productFilter);
 
 		if(!currentProduct) return ResponseWrapper.notFound('Product not found or not submitted to create new version');
 
@@ -33,7 +41,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const revisedUpdatedProduct =  {...revisedProduct, is_latest: true, parent_id: currentProduct._id, version: currentProduct.version + 1, status: 'draft' as const, complete_count: 0, target_date: null, actual_completion_date: null, product_information: {...revisedProduct.product_information, tab_completed: false}, compliance_information: {...revisedProduct.compliance_information, tab_completed: false}, languages_information: revisedProduct.languages_information || { data: [] }, label_components: {...revisedProduct.label_components, tab_completed: false}, symbols_graphics: {...revisedProduct.symbols_graphics, tab_completed: false}, product_data: {...revisedProduct.product_data, tab_completed: false}, operational_parameters: {...revisedProduct.operational_parameters, tab_completed: false}, label_tags: {...revisedProduct.label_tags, tab_completed: false}};
 
-		await db.collection<Product>('products').findOneAndUpdate({ _id: currentProduct._id }, { $set: { is_latest: false } });
+		await db.collection<Product>('products').findOneAndUpdate(
+			tenantObjectIdFilter(currentProduct._id!, context.workspaceId),
+			{ $set: { is_latest: false } },
+		);
        
 		const insertedProduct = await db.collection<Product>('products').insertOne(revisedUpdatedProduct);
 		

--- a/src/controllers/products/downloadProductExportJob.ts
+++ b/src/controllers/products/downloadProductExportJob.ts
@@ -38,11 +38,12 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const job = await getProductExportJobByIdForUser({
 			jobId: new ObjectId(jobId),
+			workspaceId: userContext.workspaceId,
 			requestedBySub: cognitoSub,
 			target: 'product',
 		});
 
-		if (!job || job.workspaceId.toString() !== userContext.workspaceId.toString()) {
+		if (!job) {
 			return ResponseWrapper.notFound('Product export job not found');
 		}
 

--- a/src/controllers/products/getAllProductVersions.ts
+++ b/src/controllers/products/getAllProductVersions.ts
@@ -1,10 +1,9 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
-import { ObjectId } from 'mongodb';
 import { Product } from '../../models/product';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
+import { assertWorkspaceMatch, requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 import { validateAllObjectIds } from '../../utils/validationUtils';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 
@@ -16,8 +15,10 @@ import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
 
 		const productId = event.queryStringParameters?.id;
 		const workspaceId = event.queryStringParameters?.workspaceId;
@@ -28,8 +29,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.badRequest("Product id - 'id' is required in query parameters");
 		}
 
-		if (!workspaceId) {
-			return ResponseWrapper.badRequest("Workspace id - 'workspaceId' is required in query parameters");
+		if (workspaceId) {
+			const workspaceMismatch = assertWorkspaceMatch(workspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
 		}
 
 		if (limit < 1 || limit > 100) {
@@ -40,24 +42,24 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.badRequest('Page must be greater than 0');
 		}
 
-		const validationResult = validateAllObjectIds({ '_id': productId, 'workspaceId': workspaceId });
+		const validationResult = validateAllObjectIds({ '_id': productId });
 		if (validationResult) return validationResult;
 
 		const db = await getDb();
-		const productObjectId = new ObjectId(productId);
-		const workspaceObjectId = new ObjectId(workspaceId);
 		const skip = (page - 1) * limit;
 
 		// First, find the product to get its product_plan_number
-		const product = await db.collection<Product>('products').findOne({ _id: productObjectId });
+		const product = await db.collection<Product>('products').findOne(
+			tenantObjectIdFilter(productId, context.workspaceId),
+		);
 
 		if (!product) {
 			return ResponseWrapper.notFound('Product not found');
 		}
 
-		const matchFilter = { 
+		const matchFilter = {
 			product_plan_number: product.product_plan_number,
-			workspace_id: workspaceObjectId 
+			workspace_id: context.workspaceId,
 		};
 
 		// Find all versions with the same product_plan_number, sorted by version descending

--- a/src/controllers/products/getAllProducts.ts
+++ b/src/controllers/products/getAllProducts.ts
@@ -4,7 +4,7 @@ import { ObjectId } from 'mongodb';
 import { Product } from '../../models/product';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 import { buildListFiltersMatch, ListFilterField, parseListQuery } from '../../utils/listQuery';
 
@@ -67,11 +67,10 @@ const ARCHIVE_FILTER_FIELDS: Record<string, ListFilterField> = {
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-	   
-		const auth = await authenticateRequest(event);
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		if(!auth.isValid) return auth.error;
-
+		const { context } = tenantResult;
 
 		const db = await getDb();
 
@@ -86,18 +85,24 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const isLatest = event.queryStringParameters?.isLatest || 'true';
 		const statusFilter = event.queryStringParameters?.status;
 		const filterParam = event.queryStringParameters?.filter;
-		const workspaceId = event.queryStringParameters?.workspaceId;
+		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;
 		const projectId = event.queryStringParameters?.projectId;
 		const departmentId = event.queryStringParameters?.departmentId;
 
-		// Build filter object
-		const filter: any = {};
-		let statusValues: string[] | null = null;
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) {
+				return ResponseWrapper.badRequest('Invalid workspaceId');
+			}
 
-		if (workspaceId) {
-			if (!ObjectId.isValid(workspaceId)) return ResponseWrapper.badRequest('Invalid workspaceId');
-			filter.workspace_id = new ObjectId(workspaceId);
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
 		}
+
+		// Build filter object
+		const filter: Record<string, unknown> = {
+			workspace_id: context.workspaceId,
+		};
+		let statusValues: string[] | null = null;
 
 		if (projectId) {
 			if (!ObjectId.isValid(projectId)) return ResponseWrapper.badRequest('Invalid projectId');

--- a/src/controllers/products/getProductData.ts
+++ b/src/controllers/products/getProductData.ts
@@ -7,13 +7,20 @@ import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateEnum } from '../../utils/validationUtils';
 import { requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
-import { createPresignedGetUrlMap, createStandardSymbolPresignedGetUrlMap, enrichItemsWithSignedUrls } from '../../utils/s3-storage';
+import {
+	createPresignedGetUrlMap,
+	createStandardSymbolPresignedGetUrlMap,
+	enrichItemsWithSignedUrls,
+	type TenantUploadSigningOptions,
+} from '../../utils/s3-storage';
 
 const enrichLabelComponentsWithSignedUrls = async (
 	labelComponents: LabelComponents['data'],
+	signingOptions: TenantUploadSigningOptions,
 ): Promise<LabelComponents['data']> => {
 	return enrichItemsWithSignedUrls({
 		items: labelComponents,
+		signingOptions,
 		getKey: (item) => item.key,
 		setSignedUrl: (item, signedUrl) => ({
 			...item,
@@ -24,6 +31,7 @@ const enrichLabelComponentsWithSignedUrls = async (
 
 const enrichSymbolsGraphicsWithSignedUrls = async (
 	symbolsGraphics: SymbolsGraphics['data'],
+	signingOptions: TenantUploadSigningOptions,
 ): Promise<SymbolsGraphics['data']> => {
 	if (!symbolsGraphics.length) return symbolsGraphics;
 
@@ -39,7 +47,7 @@ const enrichSymbolsGraphicsWithSignedUrls = async (
 		.filter((key): key is string => Boolean(key));
 
 	const [uploadUrlMap, standardSymbolUrlMap] = await Promise.all([
-		createPresignedGetUrlMap(uploadKeys),
+		createPresignedGetUrlMap(uploadKeys, signingOptions),
 		createStandardSymbolPresignedGetUrlMap(standardSymbolKeys),
 	]);
 
@@ -62,9 +70,11 @@ const enrichSymbolsGraphicsWithSignedUrls = async (
 
 const enrichLabelTagsWithSignedUrls = async (
 	labelTags: LabelTags['data'],
+	signingOptions: TenantUploadSigningOptions,
 ): Promise<LabelTags['data']> => {
 	const withImageUrls = await enrichItemsWithSignedUrls({
 		items: labelTags,
+		signingOptions,
 		getKey: (item) => item.key,
 		setSignedUrl: (item, signedUrl) => ({
 			...item,
@@ -74,6 +84,7 @@ const enrichLabelTagsWithSignedUrls = async (
 
 	return enrichItemsWithSignedUrls({
 		items: withImageUrls,
+		signingOptions,
 		getKey: (item) => item.tagged_image_key,
 		setSignedUrl: (item, signedUrl) => ({
 			...item,
@@ -151,15 +162,19 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const shouldEnrichLabelComponents = tab === 'all-tabs' || tab === 'label-components';
 		const shouldEnrichSymbolsGraphics = tab === 'all-tabs' || tab === 'symbols-graphics';
 		const shouldEnrichLabelTags = tab === 'all-tabs' || tab === 'label-tags';
+		const signingOptions: TenantUploadSigningOptions = {
+			workspaceId: context.workspaceId,
+			pendingOwnerId: context.cognitoSub,
+		};
 
 		const labelComponentsData = shouldEnrichLabelComponents
-			? await enrichLabelComponentsWithSignedUrls(product.label_components.data)
+			? await enrichLabelComponentsWithSignedUrls(product.label_components.data, signingOptions)
 			: product.label_components.data;
 		const symbolsGraphicsData = shouldEnrichSymbolsGraphics
-			? await enrichSymbolsGraphicsWithSignedUrls(product.symbols_graphics.data)
+			? await enrichSymbolsGraphicsWithSignedUrls(product.symbols_graphics.data, signingOptions)
 			: product.symbols_graphics.data;
 		const labelTagsData = shouldEnrichLabelTags
-			? await enrichLabelTagsWithSignedUrls(product.label_tags.data)
+			? await enrichLabelTagsWithSignedUrls(product.label_tags.data, signingOptions)
 			: product.label_tags.data;
 
 		// Create product_data object once - reused across all tabs

--- a/src/controllers/products/getProductData.ts
+++ b/src/controllers/products/getProductData.ts
@@ -5,7 +5,7 @@ import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateEnum } from '../../utils/validationUtils';
-import { authenticateRequest } from '../../utils/authUtils';
+import { requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 import { createPresignedGetUrlMap, createStandardSymbolPresignedGetUrlMap, enrichItemsWithSignedUrls } from '../../utils/s3-storage';
 
@@ -90,11 +90,10 @@ const enrichLabelTagsWithSignedUrls = async (
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		if(!auth.isValid) {
-			return auth.error;
-		}
+		const { context } = tenantResult;
 
 		const productId = event.queryStringParameters?.id;
 		const tab = event.queryStringParameters?.tab;
@@ -132,10 +131,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		const db = await getDb();
-		const productObjectId = new ObjectId(productId);
 
 		const pipeline = [
-			{ $match: { _id: productObjectId } },
+			{ $match: tenantObjectIdFilter(productId, context.workspaceId) },
 			buildLegacyAuditLookupStage({
 				scopeType: 'product',
 				updateActions: ['update', 'submit', 'delete', 'move', 'link', 'unlink', 'restore'],

--- a/src/controllers/products/getProductExportJob.ts
+++ b/src/controllers/products/getProductExportJob.ts
@@ -38,11 +38,12 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const job = await getProductExportJobByIdForUser({
 			jobId: new ObjectId(jobId),
+			workspaceId: userContext.workspaceId,
 			requestedBySub: cognitoSub,
 			target: 'product',
 		});
 
-		if (!job || job.workspaceId.toString() !== userContext.workspaceId.toString()) {
+		if (!job) {
 			return ResponseWrapper.notFound('Product export job not found');
 		}
 

--- a/src/controllers/products/updateProduct.ts
+++ b/src/controllers/products/updateProduct.ts
@@ -4,7 +4,8 @@ import type { Product } from '../../models/product';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateRequest, authenticateWithRole } from '../../utils/authUtils';
+import { authenticateWithRole } from '../../utils/authUtils';
+import { requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 import { recordAuditEvent } from '../../utils/auditLogV2';
 
 /**
@@ -14,9 +15,10 @@ import { recordAuditEvent } from '../../utils/auditLogV2';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
+		const { context, auth } = tenantResult;
 
 		if (!event.body) {
 			return ResponseWrapper.badRequest('Request body is required');
@@ -39,12 +41,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 
 		const db = await getDb();
-		const productObjectId = new ObjectId(productId);
+		const productFilter = tenantObjectIdFilter(productId, context.workspaceId);
 
 
-		const existingProduct = await db.collection<Product>('products').findOne({
-			_id: productObjectId,
-		});
+		const existingProduct = await db.collection<Product>('products').findOne(productFilter);
 
 		if (!existingProduct) return ResponseWrapper.notFound('Product not found');
 
@@ -97,15 +97,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const result = await db
 			.collection<Product>('products')
-			.updateOne({ _id: productObjectId }, { $set: updateData });
+			.updateOne(productFilter, { $set: updateData });
 
 		if (result.matchedCount === 0) {
 			return ResponseWrapper.notFound('Product not found');
 		}
 
-		const updatedProduct = await db.collection<Product>('products').findOne({
-			_id: productObjectId,
-		});
+		const updatedProduct = await db.collection<Product>('products').findOne(productFilter);
 
 		let eventKey = 'product.updated';
 		let auditAction: 'update' | 'submit' | 'archive' | 'restore' = 'update';

--- a/src/controllers/products/updateProductData.ts
+++ b/src/controllers/products/updateProductData.ts
@@ -4,7 +4,7 @@ import { validateAllObjectIds, validateMissingFields } from '../../utils/validat
 import { getDb } from '../../utils/db';
 import { Product } from '../../models/product';
 import { ObjectId } from 'mongodb';
-import { authenticateRequest } from '../../utils/authUtils';
+import { requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 import {
 	addCustomField,
 	deleteCustomField,
@@ -228,9 +228,10 @@ const PRODUCT_DATA_ACTION_AUDIT_META: Record<string, ProductDataAuditMeta> = {
  */
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-	const auth = await authenticateRequest(event);
+	const tenantResult = await requireTenantContext(event);
+	if (!tenantResult.ok) return tenantResult.response;
 
-	if (!auth.isValid) return auth.error;
+	const { context, auth } = tenantResult;
 
 	try {
 		if (!event.body) return ResponseWrapper.badRequest('Request body is required to update product data');
@@ -255,8 +256,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.badRequest(`Invalid tab parameter. Must be one of: ${validTabs.join(', ')}`);
 
 		const db = await getDb();
+		const productTenantFilter = tenantObjectIdFilter(input.id!, context.workspaceId);
 
-		const product = await db.collection<Product>('products').findOne({ _id: new ObjectId(input.id) });
+		const product = await db.collection<Product>('products').findOne(productTenantFilter);
 
 		if (!product) return ResponseWrapper.notFound('Product not found, please check the provided product id.');
 
@@ -356,7 +358,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			if (addLabelComponentResult.error) return addLabelComponentResult.error;
 
 			const isDuplicateAddLabelComponent = await db.collection<Product>('products').findOne({
-				_id: new ObjectId(input.id),
+				...productTenantFilter,
 				'label_components.data.component_number': input.data[0].component_number,
 			});
 			if (isDuplicateAddLabelComponent) return ResponseWrapper.conflict('Component number already exists, please use a different component number.');
@@ -370,7 +372,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			if (updateLabelComponentResult.error) return updateLabelComponentResult.error;
 
 			const isDuplicateUpdateLabelComponent = await db.collection<Product>('products').findOne({
-				_id: new ObjectId(input.id),
+				...productTenantFilter,
 				'label_components.data': {
 					$elemMatch: {
 						_id: {$ne: new ObjectId(input.data.id)},
@@ -406,7 +408,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const entity = input.data[0].entity?.toLowerCase();
 			if(entity === 'barcodes') {
 				const isDuplicateBarcode = await db.collection<Product>('products').findOne({
-					_id: new ObjectId(input.id),
+					...productTenantFilter,
 					'symbols_graphics.data': {
 						$elemMatch: {
 							entity: 'Barcodes',
@@ -418,7 +420,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				if (isDuplicateBarcode) return ResponseWrapper.conflict('Barcode description already exists, please use a different barcode description.');
 			} else if (entity !== 'other components') {
 				const isDuplicategraphics = await db.collection<Product>('products').findOne({
-					_id: new ObjectId(input.id),
+					...productTenantFilter,
 					'symbols_graphics.data': {
 						$elemMatch:{
 							entity: input.data[0].entity,
@@ -460,7 +462,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			const entity = input.data.entity?.toLowerCase();
 			if(entity === 'barcodes') {
 				const isDuplicateBarcode = await db.collection<Product>('products').findOne({
-					_id: new ObjectId(input.id),
+					...productTenantFilter,
 					'symbols_graphics.data': {
 						$elemMatch: {
 							_id: {$ne: new ObjectId(input.data.id)},
@@ -473,7 +475,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				if (isDuplicateBarcode) return ResponseWrapper.conflict('Barcode description already exists, please use a different barcode description.');
 			} else if (entity !== 'other components') {
 				const isDuplicategraphics = await db.collection<Product>('products').findOne({
-					_id: new ObjectId(input.id),
+					...productTenantFilter,
 					'symbols_graphics.data': {
 						$elemMatch:{
 							_id: {$ne: new ObjectId(input.data.id)},
@@ -639,14 +641,14 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const updateResult = await db
 			.collection<Product>('products')
-			.updateOne({ _id: new ObjectId(input.id) }, updateQuery, options);
+			.updateOne(productTenantFilter, updateQuery, options);
 		if (updateResult.modifiedCount === 0) {
 			return ResponseWrapper.notFound(
 				'Product data not modified successfully, please check the data and try again.',
 			);
 		}
 
-		const updatedProduct = await db.collection<Product>('products').findOne({ _id: new ObjectId(input.id) });
+		const updatedProduct = await db.collection<Product>('products').findOne(productTenantFilter);
 		const auditMeta = PRODUCT_DATA_ACTION_AUDIT_META[input.action];
 
 		if (updatedProduct && auditMeta) {

--- a/src/controllers/projects/archiveProject.ts
+++ b/src/controllers/projects/archiveProject.ts
@@ -4,9 +4,9 @@ import type { Project } from '../../models/project';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateWithRole } from '../../utils/authUtils';
 import { validateBoolean } from '../../utils/validationUtils';
 import { recordAuditEvent } from '../../utils/auditLogV2';
+import { isWorkspaceAdmin, requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 
 /**
  * Archive a project
@@ -16,10 +16,13 @@ import { recordAuditEvent } from '../../utils/auditLogV2';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateWithRole(event, 'admin');
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		if(!auth.isValid) {
-			return auth.error;
+		const { context, auth } = tenantResult;
+
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
 		}
 
 		if (!event.pathParameters?.id) {
@@ -42,18 +45,16 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const isBoolean = validateBoolean(isArchived, 'isArchived');
 		if (isBoolean) return isBoolean;
 
-		const projectRecord: Project | null = await db.collection<Project>('projects').findOne({
-			_id: new ObjectId(event.pathParameters.id),
-		});
+		const projectFilter = tenantObjectIdFilter(event.pathParameters.id, context.workspaceId);
+
+		const projectRecord: Project | null = await db.collection<Project>('projects').findOne(projectFilter);
 
 		if (!projectRecord) {
 			return ResponseWrapper.notFound('Project not found');
 		}
 
 		const project = await db.collection<Project>('projects').updateOne(
-			{
-				_id: new ObjectId(event.pathParameters.id),
-			},
+			projectFilter,
 			{
 				$set: {
 					isArchived: isArchived,
@@ -62,7 +63,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		);
 
 		await recordAuditEvent({
-			workspaceId: projectRecord.workspace_id.toString(),
+			workspaceId: context.workspaceId.toString(),
 			scope: { type: 'project', id: event.pathParameters.id },
 			entity: { type: 'project', id: event.pathParameters.id },
 			action: isArchived ? 'archive' : 'restore',

--- a/src/controllers/projects/createProject.ts
+++ b/src/controllers/projects/createProject.ts
@@ -5,9 +5,9 @@ import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
-import { authenticateWithRole } from '../../utils/authUtils';
 import { recordAuditEvent } from '../../utils/auditLogV2';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 
 /**
  * Create a project
@@ -17,10 +17,14 @@ import { normalizePersistedAssetReference } from '../../utils/s3-storage';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateWithRole(event, 'admin');
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		if(!auth.isValid) return auth.error;
+		const { context, auth } = tenantResult;
 
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
+		}
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
 	
@@ -29,7 +33,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 	
 
 		const missingFieldsResult = validateMissingFields({
-			'workspace_id': input.workspace_id.toString(),
 			'department_id': input.department_id.toString(),
 			'project_name': input.project_name,
 			'project_number': input.project_number,
@@ -41,8 +44,12 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return missingFieldsResult;
 		}
 
+		if (input.workspace_id) {
+			const workspaceMismatch = assertWorkspaceMatch(input.workspace_id, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
+
 		const objectIdValidation = validateAllObjectIds({
-			'workspace_id': input.workspace_id,
 			'department_id': input.department_id,
 			'admin_id': input.admin_id,
 		}, {
@@ -55,16 +62,25 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const db = await getDb();
 		
-		const workspaceObjectId = new ObjectId(input.workspace_id);
+		const workspaceObjectId = context.workspaceId;
 		const departmentObjectId = new ObjectId(input.department_id);
 		const adminObjectId = new ObjectId(input.admin_id);
 		const userObjectIds = input.users ? input.users.map((userId: string) => new ObjectId(userId)) : [];
 		const normalizedProjectImage = normalizePersistedAssetReference(input.image, '');
 
-		// Check if project_number already exists
+		const departmentInWorkspace = await db.collection('departments').findOne({
+			_id: departmentObjectId,
+			workspace_id: workspaceObjectId,
+		});
+
+		if (!departmentInWorkspace) {
+			return ResponseWrapper.badRequest('Department not found in this workspace');
+		}
+
 		const existingProject = await db.collection<Project>('projects').findOne({
 			project_number: input.project_number,
-			isArchived: { $ne: true }
+			workspace_id: workspaceObjectId,
+			isArchived: { $ne: true },
 		});
 
 		if (existingProject) {

--- a/src/controllers/projects/getAllProjects.ts
+++ b/src/controllers/projects/getAllProjects.ts
@@ -178,7 +178,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			projects.map(async (project) => {
 				if (!project.users?.length) return project;
 
-				const usersWithSignedAvatars = await enrichUsersWithProfileAvatarUrls(project.users);
+				const usersWithSignedAvatars = await enrichUsersWithProfileAvatarUrls(project.users, {
+					workspaceId: context.workspaceId,
+					pendingOwnerId: context.cognitoSub,
+				});
 
 				return {
 					...project,
@@ -187,7 +190,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			}),
 		);
 
-		const projectsWithSignedUrls = await enrichProjectsWithImageUrls(projectsWithSignedAvatars);
+		const projectsWithSignedUrls = await enrichProjectsWithImageUrls(projectsWithSignedAvatars, {
+			workspaceId: context.workspaceId,
+			pendingOwnerId: context.cognitoSub,
+		});
 
 		const totalCount = countResult.length > 0 ? countResult[0].total : 0;
 		const totalPages = Math.ceil(totalCount / limit);

--- a/src/controllers/projects/getAllProjects.ts
+++ b/src/controllers/projects/getAllProjects.ts
@@ -4,7 +4,7 @@ import { ObjectId } from 'mongodb';
 import { Project } from '../../models/project';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 import { enrichProjectsWithImageUrls, enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
 import { buildListFiltersMatch, ListFilterField, parseListQuery } from '../../utils/listQuery';
@@ -59,11 +59,10 @@ type ProjectWithUsers = Omit<Project, 'users'> & {
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		
-		if(!auth.isValid) {
-			return auth.error;
-		}
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
 
 		const db = await getDb();
 
@@ -77,12 +76,17 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const { limit, page, skip, sort, order, filters } = listQueryResult.value!;
 		const sortField = PROJECT_SORT_FIELD_MAP[sort] ?? sort;
-		const workspaceId = event.queryStringParameters?.workspaceId;
+		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;
 		const isArchiveParam = event.queryStringParameters?.isArchive || 'false';
 		const departmentId = event.queryStringParameters?.departmentId;
 
-		if (!workspaceId) return ResponseWrapper.badRequest('Workspace ID is required.');
-		if (!ObjectId.isValid(workspaceId)) return ResponseWrapper.badRequest('Invalid workspaceId');
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) return ResponseWrapper.badRequest('Invalid workspaceId');
+
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
+
 		if (departmentId && !ObjectId.isValid(departmentId)) return ResponseWrapper.badRequest('Invalid departmentId');
 
 		// Validate isArchive parameter
@@ -95,8 +99,8 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		// filter based on isArchive parameter
 		const filter: Record<string, unknown> = isArchive
-			? { isArchived: true, workspace_id: new ObjectId(workspaceId) }
-			: { isArchived: { $ne: true }, workspace_id: new ObjectId(workspaceId) };
+			? { isArchived: true, workspace_id: context.workspaceId }
+			: { isArchived: { $ne: true }, workspace_id: context.workspaceId };
 
 		if (departmentId) filter.department_id = new ObjectId(departmentId);
 

--- a/src/controllers/projects/getProject.ts
+++ b/src/controllers/projects/getProject.ts
@@ -78,8 +78,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.notFound('Project not found');
 		}
 
+		const signingOptions = {
+			workspaceId: context.workspaceId,
+			pendingOwnerId: context.cognitoSub,
+		};
+
 		const usersWithSignedAvatars = project.users?.length
-			? await enrichUsersWithProfileAvatarUrls(project.users)
+			? await enrichUsersWithProfileAvatarUrls(project.users, signingOptions)
 			: project.users;
 
 		const [projectWithSignedImage] = await enrichProjectsWithImageUrls([
@@ -87,7 +92,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				...project,
 				users: usersWithSignedAvatars,
 			},
-		]);
+		], signingOptions);
 
 		return ResponseWrapper.success({
 			message: 'Project retrieved successfully',

--- a/src/controllers/projects/getProject.ts
+++ b/src/controllers/projects/getProject.ts
@@ -4,7 +4,7 @@ import type { Project } from '../../models/project';
 import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
+import { requireTenantContext } from '../../utils/tenantContext';
 import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
 import { enrichProjectsWithImageUrls, enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
 
@@ -29,11 +29,10 @@ type ProjectWithUsers = Omit<Project, 'users'> & {
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		
-		if(!auth.isValid) {
-			return auth.error;
-		}
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
 
 		if (!event.pathParameters?.id) {
 			return ResponseWrapper.badRequest('Missing required fields: id is required');
@@ -45,8 +44,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			{
 				$match: {
 					_id: new ObjectId(event.pathParameters.id),
-					isArchived: { $ne: true }
-				}
+					workspace_id: context.workspaceId,
+					isArchived: { $ne: true },
+				},
 			},
 			{
 				$lookup: {

--- a/src/controllers/projects/updateProject.ts
+++ b/src/controllers/projects/updateProject.ts
@@ -5,9 +5,9 @@ import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
-import { authenticateWithRole } from '../../utils/authUtils';
 import { recordAuditEvent } from '../../utils/auditLogV2';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 
 /**
  * Update a project
@@ -17,10 +17,13 @@ import { normalizePersistedAssetReference } from '../../utils/s3-storage';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateWithRole(event, 'admin');
-		
-		if(!auth.isValid) {
-			return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
+
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
 		}
 
 		if (!event.body) {
@@ -36,7 +39,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		const missingFieldsResult = validateMissingFields({
-			'workspace_id': input.workspace_id.toString(),
 			'department_id': input.department_id.toString(),
 			'project_name': input.project_name,
 			'project_number': input.project_number,
@@ -49,9 +51,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return missingFieldsResult;
 		}
 
+		if (input.workspace_id) {
+			const workspaceMismatch = assertWorkspaceMatch(input.workspace_id, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
+
 		const objectIdValidation = validateAllObjectIds({
 			'_id': input._id!,
-			'workspace_id': input.workspace_id,
 			'department_id': input.department_id,
 			'admin_id': input.admin_id,
 		}, {
@@ -63,39 +69,44 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		const db = await getDb();
+		const projectFilter = tenantObjectIdFilter(input._id!, context.workspaceId);
+		const departmentObjectId = new ObjectId(input.department_id);
 
-		// Check if project exists and is not archived
+		const departmentInWorkspace = await db.collection('departments').findOne({
+			_id: departmentObjectId,
+			workspace_id: context.workspaceId,
+		});
+
+		if (!departmentInWorkspace) {
+			return ResponseWrapper.badRequest('Department not found in this workspace');
+		}
+
 		const projectRecord: Project | null = await db.collection<Project>('projects').findOne({
-			_id: new ObjectId(input._id),
-			isArchived: { $ne: true }
+			...projectFilter,
+			isArchived: { $ne: true },
 		});
 		
 		if (!projectRecord) {
 			return ResponseWrapper.notFound('Project not found or archived');
 		}
 
-		// Check if project_number already exists (excluding current project)
 		const existingProject = await db.collection<Project>('projects').findOne({
 			project_number: input.project_number,
+			workspace_id: context.workspaceId,
 			_id: { $ne: new ObjectId(input._id) },
-			isArchived: { $ne: true }
+			isArchived: { $ne: true },
 		});
 
 		if (existingProject) {
 			return ResponseWrapper.conflict('Project number already exists');
 		}
 		
-		const workspaceObjectId = new ObjectId(input.workspace_id);
-		const departmentObjectId = new ObjectId(input.department_id);
 		const adminObjectId = new ObjectId(input.admin_id);
 		const userObjectIds = input.users ? (input.users as unknown as string[]).map((userId: string) => new ObjectId(userId)) : [];
 		const normalizedProjectImage = normalizePersistedAssetReference(input.image, projectRecord.image ?? '');
 
-		const project = await db.collection<Project>('projects').updateOne({
-			_id: new ObjectId(input._id),
-		}, {
+		const project = await db.collection<Project>('projects').updateOne(projectFilter, {
 			$set: {
-				workspace_id: workspaceObjectId,
 				department_id: departmentObjectId,
 				project_name: input.project_name,
 				project_number: input.project_number,
@@ -104,11 +115,11 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				admin_id: adminObjectId,
 				users: userObjectIds,
 				image: normalizedProjectImage,
-			}
+			},
 		});
 
 		await recordAuditEvent({
-			workspaceId: workspaceObjectId.toString(),
+			workspaceId: context.workspaceId.toString(),
 			scope: { type: 'project', id: input._id!.toString() },
 			entity: { type: 'project', id: input._id!.toString() },
 			action: 'update',

--- a/src/controllers/reports/downloadReportExportJob.ts
+++ b/src/controllers/reports/downloadReportExportJob.ts
@@ -38,11 +38,12 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const job = await getExportJobByIdForUser({
 			jobId: new ObjectId(jobId),
+			workspaceId: userContext.workspaceId,
 			requestedBySub: cognitoSub,
 			target: 'report',
 		});
 
-		if (!job || job.workspaceId.toString() !== userContext.workspaceId.toString()) {
+		if (!job) {
 			return ResponseWrapper.notFound('Report export job not found');
 		}
 

--- a/src/controllers/reports/getReportExportJob.ts
+++ b/src/controllers/reports/getReportExportJob.ts
@@ -38,11 +38,12 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const job = await getExportJobByIdForUser({
 			jobId: new ObjectId(jobId),
+			workspaceId: userContext.workspaceId,
 			requestedBySub: cognitoSub,
 			target: 'report',
 		});
 
-		if (!job || job.workspaceId.toString() !== userContext.workspaceId.toString()) {
+		if (!job) {
 			return ResponseWrapper.notFound('Report export job not found');
 		}
 

--- a/src/controllers/reports/reportsExportExcel.ts
+++ b/src/controllers/reports/reportsExportExcel.ts
@@ -1,11 +1,10 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
-import { ObjectId } from 'mongodb';
 import { Product } from '../../models/product';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { StatusCodes } from '../../utils/statusCodes';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
 import { validateMissingFields, validateObjectIds } from '../../utils/validationUtils';
 import { EXPORT_LIMITS } from '../../types/reports';
 import { validateConditions, buildExportPipeline } from '../../utils/reports/queryBuilder';
@@ -17,8 +16,10 @@ import { generateReportsExcelExport } from '../../utils/reports/exportReportsExc
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
 
@@ -37,6 +38,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const objectIdValidation = validateObjectIds({ workspaceId: input.workspaceId });
 		if (objectIdValidation) return objectIdValidation;
 
+		const workspaceMismatch = assertWorkspaceMatch(
+			input.workspaceId,
+			context.workspaceId,
+			'You are not authorized to export reports for this workspace',
+		);
+		if (workspaceMismatch) return workspaceMismatch;
+
 		if (input.conditionLogic && !['AND', 'OR'].includes(input.conditionLogic)) {
 			return ResponseWrapper.badRequest('conditionLogic must be either "AND" or "OR"');
 		}
@@ -46,8 +54,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			if (conditionError) return conditionError;
 		}
 
-		const workspaceId = ObjectId.createFromHexString(input.workspaceId);
-		const pipeline = buildExportPipeline(input, workspaceId, EXPORT_LIMITS.EXCEL);
+		const pipeline = buildExportPipeline(input, context.workspaceId, EXPORT_LIMITS.EXCEL);
 
 		const db = await getDb();
 		const products = (await db.collection<Product>('products').aggregate(pipeline).toArray()) as any[];

--- a/src/controllers/reports/reportsExportPDF.ts
+++ b/src/controllers/reports/reportsExportPDF.ts
@@ -1,11 +1,10 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
-import { ObjectId } from 'mongodb';
 import { Product } from '../../models/product';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { StatusCodes } from '../../utils/statusCodes';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
 import { validateMissingFields, validateObjectIds } from '../../utils/validationUtils';
 import { EXPORT_LIMITS } from '../../types/reports';
 import { validateConditions, buildExportPipeline } from '../../utils/reports/queryBuilder';
@@ -17,8 +16,10 @@ import { generateReportsPDFExport } from '../../utils/reports/exportReportsPDF';
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
 
@@ -37,6 +38,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const objectIdValidation = validateObjectIds({ workspaceId: input.workspaceId });
 		if (objectIdValidation) return objectIdValidation;
 
+		const workspaceMismatch = assertWorkspaceMatch(
+			input.workspaceId,
+			context.workspaceId,
+			'You are not authorized to export reports for this workspace',
+		);
+		if (workspaceMismatch) return workspaceMismatch;
+
 		if (input.conditionLogic && !['AND', 'OR'].includes(input.conditionLogic)) {
 			return ResponseWrapper.badRequest('conditionLogic must be either "AND" or "OR"');
 		}
@@ -46,8 +54,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			if (conditionError) return conditionError;
 		}
 
-		const workspaceId = ObjectId.createFromHexString(input.workspaceId);
-		const pipeline = buildExportPipeline(input, workspaceId, EXPORT_LIMITS.PDF);
+		const pipeline = buildExportPipeline(input, context.workspaceId, EXPORT_LIMITS.PDF);
 
 		const db = await getDb();
 		const products = (await db.collection<Product>('products').aggregate(pipeline).toArray()) as any[];

--- a/src/controllers/reports/reportsQuery.ts
+++ b/src/controllers/reports/reportsQuery.ts
@@ -6,7 +6,7 @@ import { Department } from '../../models/department';
 import { Project } from '../../models/project';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
 import { validateMissingFields, validateObjectIds } from '../../utils/validationUtils';
 import { validateConditions, buildAggregationPipeline } from '../../utils/reports/queryBuilder';
 
@@ -16,8 +16,10 @@ import { validateConditions, buildAggregationPipeline } from '../../utils/report
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
 
@@ -36,6 +38,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const objectIdValidation = validateObjectIds({ workspaceId: input.workspaceId });
 		if (objectIdValidation) return objectIdValidation;
 
+		const workspaceMismatch = assertWorkspaceMatch(
+			input.workspaceId,
+			context.workspaceId,
+			'You are not authorized to query reports for this workspace',
+		);
+		if (workspaceMismatch) return workspaceMismatch;
+
 		const page = input.pagination?.page || 1;
 		const limit = Math.min(input.pagination?.limit || 10, 100);
 
@@ -48,8 +57,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			if (conditionError) return conditionError;
 		}
 
-		const workspaceId = ObjectId.createFromHexString(input.workspaceId);
-		const pipeline = buildAggregationPipeline(input, workspaceId);
+		const pipeline = buildAggregationPipeline(input, context.workspaceId);
 
 		const db = await getDb();
 		const result = await db.collection<Product>('products').aggregate(pipeline).toArray();

--- a/src/controllers/sourceFiles/createSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/createSourceFileAndFolder.ts
@@ -1,10 +1,11 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext, tenantObjectIdFilter } from "../../utils/tenantContext";
 import { validateAllObjectIds, validateEnum, validateMissingFields } from "../../utils/validationUtils";
 import { getDb } from "../../utils/db";
 import { SourceFile } from "../../models/sourceFiles";
+import type { Product } from "../../models/product";
 import { ObjectId } from "mongodb";
 import { recordAuditEvent } from "../../utils/auditLogV2";
 
@@ -14,15 +15,16 @@ import { recordAuditEvent } from "../../utils/auditLogV2";
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if (!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is missing.');
 
 		const input = JSON.parse(event.body);
 
 		const missingFieldsResult = validateMissingFields({
-			workspace_id: input.workspace_id,
 			name: input.name,
 			type: input.type,
 		});
@@ -36,7 +38,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if(isValidEnum) return isValidEnum
 
 		const objectIdValidation = validateAllObjectIds({
-			workspace_id: input.workspace_id,
 			...(input.parentId && { 'parentId': input.parentId }),
 			...(input.product_id && { 'product_id': input.product_id })
 		});
@@ -44,7 +45,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const db = await getDb();
 		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
-		const workspaceId = ObjectId.createFromHexString(input.workspace_id);
+		const workspaceId = context.workspaceId;
 		const parentId = input.parentId ? ObjectId.createFromHexString(input.parentId) : null;
 		const productId = typeof input.product_id === 'string' ? ObjectId.createFromHexString(input.product_id) : null;
 
@@ -54,6 +55,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		if (productId && parentId) {
 			return ResponseWrapper.badRequest('product_id can only be set on top-level folders.');
+		}
+
+		if (productId) {
+			const product = await db.collection<Product>('products').findOne(
+				tenantObjectIdFilter(productId, workspaceId),
+			);
+			if (!product) return ResponseWrapper.notFound('Product not found.');
 		}
 
 		const trimmedName = input.name.trim();

--- a/src/controllers/sourceFiles/deleteSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/deleteSourceFileAndFolder.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 import { getDb } from "../../utils/db";
 import { validateAllObjectIds } from "../../utils/validationUtils";
 import { Collection, ObjectId } from "mongodb";
@@ -15,12 +15,16 @@ import { deleteObjectByKey } from "../../utils/s3-storage";
  * @param {ObjectId} parentId The ID of the parent folder.
  * @return {Promise<ObjectId[]>} A promise that resolves to an array of descendant IDs.
  */
-async function findDescendantIds(collection: Collection<SourceFile>, parentId: ObjectId): Promise<ObjectId[]> {
+async function findDescendantIds(
+	collection: Collection<SourceFile>,
+	parentId: ObjectId,
+	workspaceId: ObjectId,
+): Promise<ObjectId[]> {
 	let idsToDelete = [parentId];
-	const children = await collection.find({ parentId: parentId }).toArray();
+	const children = await collection.find({ parentId, workspace_id: workspaceId }).toArray();
 	for (const child of children) {
 		if (child.type === 'folder') {
-			const descendantIds = await findDescendantIds(collection, child._id);
+			const descendantIds = await findDescendantIds(collection, child._id, workspaceId);
 			idsToDelete = idsToDelete.concat(descendantIds);
 		} else {
 			idsToDelete.push(child._id);
@@ -35,8 +39,10 @@ async function findDescendantIds(collection: Collection<SourceFile>, parentId: O
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 
 		const id = event.pathParameters?.id;
 		if (!id) return ResponseWrapper.badRequest('Missing required path parameter: id');
@@ -48,7 +54,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
 		const fileObjectId = new ObjectId(id);
 
-		const fileOrFolder = await sourceFilesCollection.findOne({ _id: fileObjectId });
+		const fileOrFolder = await sourceFilesCollection.findOne(
+			tenantObjectIdFilter(id, context.workspaceId),
+		);
 		if (!fileOrFolder) {
 			return ResponseWrapper.notFound('File or folder not found.');
 		}
@@ -56,13 +64,13 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		let idsToDelete: ObjectId[];
 
 		if (fileOrFolder.type === 'folder') {
-			idsToDelete = await findDescendantIds(sourceFilesCollection, fileObjectId);
+			idsToDelete = await findDescendantIds(sourceFilesCollection, fileObjectId, context.workspaceId);
 		} else {
 			idsToDelete = [fileObjectId];
 		}
 
 		const filesToDelete = await sourceFilesCollection
-			.find({ _id: { $in: idsToDelete }, type: 'file' })
+			.find({ _id: { $in: idsToDelete }, workspace_id: context.workspaceId, type: 'file' })
 			.toArray();
 		const keysToDelete = filesToDelete
 			.map((item) => (typeof item.key === 'string' ? item.key.trim() : ''))
@@ -76,7 +84,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			}
 		}
 
-		await sourceFilesCollection.deleteMany({ _id: { $in: idsToDelete } });
+		await sourceFilesCollection.deleteMany({
+			_id: { $in: idsToDelete },
+			workspace_id: context.workspaceId,
+		});
 
 		await recordAuditEvent({
 			workspaceId: fileOrFolder.workspace_id.toString(),

--- a/src/controllers/sourceFiles/getAllSourceFilesFolders.ts
+++ b/src/controllers/sourceFiles/getAllSourceFilesFolders.ts
@@ -1,11 +1,12 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { assertWorkspaceMatch, requireTenantContext, tenantObjectIdFilter } from "../../utils/tenantContext";
 import { getDb } from "../../utils/db";
 import { validateAllObjectIds } from "../../utils/validationUtils";
 import { ObjectId } from "mongodb";
 import { SourceFile } from "../../models/sourceFiles";
+import type { Product } from "../../models/product";
 
 /**
  * @param {APIGatewayProxyEvent} event 
@@ -13,27 +14,41 @@ import { SourceFile } from "../../models/sourceFiles";
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		const workspaceId = event.queryStringParameters?.workspaceId;
-		if (!workspaceId) return ResponseWrapper.badRequest('Missing required query parameter: workspace_id');
-
+		const { context } = tenantResult;
+		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;
 		const productId = event.queryStringParameters?.productId;
 
-		const  validateWorkspaceId = validateAllObjectIds({
-			workspaceId,
-			...(productId && { productId })
-		});
-		if (validateWorkspaceId) return validateWorkspaceId;
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) {
+				return ResponseWrapper.badRequest('Invalid workspaceId');
+			}
+
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
+
+		if (productId) {
+			const validateProductId = validateAllObjectIds({ productId });
+			if (validateProductId) return validateProductId;
+		}
 
 		const db = await getDb();
 		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
 
-		const query: any = {
-			workspace_id: new ObjectId(workspaceId),
+		if (productId) {
+			const product = await db.collection<Product>('products').findOne(
+				tenantObjectIdFilter(productId, context.workspaceId),
+			);
+			if (!product) return ResponseWrapper.notFound('Product not found.');
+		}
+
+		const query: Record<string, unknown> = {
+			workspace_id: context.workspaceId,
 			type: 'folder',
-			parentId: { $eq: null }
+			parentId: { $eq: null },
 		};
 
 		if (productId) {

--- a/src/controllers/sourceFiles/getCurrentFolderById.ts
+++ b/src/controllers/sourceFiles/getCurrentFolderById.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { assertWorkspaceMatch, requireTenantContext, tenantObjectIdFilter } from "../../utils/tenantContext";
 import { getDb } from "../../utils/db";
 import { validateAllObjectIds } from "../../utils/validationUtils";
 import { ObjectId } from "mongodb";
@@ -14,29 +14,39 @@ import { createPresignedGetUrl } from "../../utils/s3-storage";
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		const workspaceId = event.queryStringParameters?.workspaceId;
-		if (!workspaceId) return ResponseWrapper.badRequest('Missing required query parameter: workspaceId');
-
+		const { context } = tenantResult;
+		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;
 		const id = event.queryStringParameters?.id;
+
 		if (!id) return ResponseWrapper.badRequest('Missing required query parameter: id');
 
-		const validationError = validateAllObjectIds({ workspaceId, id });
+		const validationError = validateAllObjectIds({ id });
 		if (validationError) return validationError;
+
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) {
+				return ResponseWrapper.badRequest('Invalid workspaceId');
+			}
+
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
 
 		const db = await getDb();
 		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
 
-		const query = {
-			workspace_id: new ObjectId(workspaceId),
-			_id: new ObjectId(id),
-		};
+		const sourceFileOrFolder = await sourceFilesCollection.findOne(
+			tenantObjectIdFilter(id, context.workspaceId),
+		);
 
-		const sourceFileOrFolder = await sourceFilesCollection.findOne(query);
+		if (!sourceFileOrFolder) {
+			return ResponseWrapper.notFound('Folder or file not found.');
+		}
 
-		if (sourceFileOrFolder?.type === 'file' && sourceFileOrFolder.key) {
+		if (sourceFileOrFolder.type === 'file' && sourceFileOrFolder.key) {
 			try {
 				sourceFileOrFolder.url = await createPresignedGetUrl(sourceFileOrFolder.key);
 			} catch (error) {

--- a/src/controllers/sourceFiles/getCurrentFolderById.ts
+++ b/src/controllers/sourceFiles/getCurrentFolderById.ts
@@ -48,7 +48,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		if (sourceFileOrFolder.type === 'file' && sourceFileOrFolder.key) {
 			try {
-				sourceFileOrFolder.url = await createPresignedGetUrl(sourceFileOrFolder.key);
+				sourceFileOrFolder.url = await createPresignedGetUrl(sourceFileOrFolder.key, {
+					workspaceId: context.workspaceId,
+					pendingOwnerId: context.cognitoSub,
+				});
 			} catch (error) {
 				logError('Failed to generate signed URL for source file', error);
 			}

--- a/src/controllers/sourceFiles/getSourceFilesByParent.ts
+++ b/src/controllers/sourceFiles/getSourceFilesByParent.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { assertWorkspaceMatch, requireTenantContext, tenantObjectIdFilter } from "../../utils/tenantContext";
 import { getDb } from "../../utils/db";
 import { validateAllObjectIds } from "../../utils/validationUtils";
 import { ObjectId } from "mongodb";
@@ -14,23 +14,37 @@ import { enrichItemsWithSignedUrls } from "../../utils/s3-storage";
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		const workspaceId = event.queryStringParameters?.workspaceId;
-		if (!workspaceId) return ResponseWrapper.badRequest('Missing required query parameter: workspace_id');
-
+		const { context } = tenantResult;
+		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;
 		const parentId = event.queryStringParameters?.parentId;
+
 		if (!parentId) return ResponseWrapper.badRequest('Missing required query parameter: parentId');
 
-		const validationError = validateAllObjectIds({ workspaceId, parentId });
+		const validationError = validateAllObjectIds({ parentId });
 		if (validationError) return validationError;
+
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) {
+				return ResponseWrapper.badRequest('Invalid workspaceId');
+			}
+
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
 
 		const db = await getDb();
 		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
 
-		const query: any = {
-			workspace_id: new ObjectId(workspaceId),
+		const parentFolder = await sourceFilesCollection.findOne(
+			tenantObjectIdFilter(parentId, context.workspaceId),
+		);
+		if (!parentFolder) return ResponseWrapper.notFound('Parent folder not found.');
+
+		const query = {
+			workspace_id: context.workspaceId,
 			parentId: new ObjectId(parentId),
 		};
 

--- a/src/controllers/sourceFiles/getSourceFilesByParent.ts
+++ b/src/controllers/sourceFiles/getSourceFilesByParent.ts
@@ -59,6 +59,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const sourceFilesAndFoldersWithSignedUrls = await enrichItemsWithSignedUrls({
 			items: sourceFilesAndFolders,
+			signingOptions: {
+				workspaceId: context.workspaceId,
+				pendingOwnerId: context.cognitoSub,
+			},
 			getKey: (item) => (item.type === 'file' ? item.key : undefined),
 			setSignedUrl: (item, signedUrl) => ({
 				...item,

--- a/src/controllers/sourceFiles/updateSourceFilesFolder.ts
+++ b/src/controllers/sourceFiles/updateSourceFilesFolder.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from "../../utils/authUtils";
+import { requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 import { getDb } from "../../utils/db";
 import { validateAllObjectIds } from "../../utils/validationUtils";
 import { ObjectId } from "mongodb";
@@ -14,8 +14,10 @@ import { recordAuditEvent } from "../../utils/auditLogV2";
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
-		if(!auth.isValid) return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
 
 		if (!event.body) return ResponseWrapper.badRequest('Request body is missing.');
 
@@ -43,7 +45,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const db = await getDb();
 		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
-		const folderObjectId = new ObjectId(folderId);
+		const folderFilter = {
+			...tenantObjectIdFilter(folderId, context.workspaceId),
+			type: 'folder' as const,
+		};
 		const updateFields: Partial<SourceFile> = {};
 
 		if (hasName) {
@@ -53,7 +58,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		if (hasProductId) {
-			const folder = await sourceFilesCollection.findOne({ _id: folderObjectId, type: 'folder' });
+			const folder = await sourceFilesCollection.findOne(folderFilter);
 			if (!folder) {
 				return ResponseWrapper.notFound('Folder not found.');
 			}
@@ -65,12 +70,12 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				: null;
 		}
 
-		const beforeFolder = await sourceFilesCollection.findOne({ _id: folderObjectId, type: 'folder' });
+		const beforeFolder = await sourceFilesCollection.findOne(folderFilter);
 
 		const updatedFolder = await sourceFilesCollection.findOneAndUpdate(
-			{ _id: folderObjectId, type: 'folder' },
+			folderFilter,
 			{ $set: updateFields },
-			{ returnDocument: 'after' }
+			{ returnDocument: 'after' },
 		);
 
 		if (!updatedFolder) {

--- a/src/controllers/users/createUser.ts
+++ b/src/controllers/users/createUser.ts
@@ -6,6 +6,7 @@ import { updateAuditLog } from '../../utils/auditLog';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 
 /**
  * Create a user
@@ -15,20 +16,27 @@ import { normalizePersistedAssetReference } from '../../utils/s3-storage';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		// Parse the request body from the event
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
+
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
+		}
+
 		if (!event.body) {
 			return ResponseWrapper.badRequest('Request body is required');
 		}
 
 		const input: User = JSON.parse(event.body);
 
-		// Validate required fields
 		if (!input.name || !input.email || !input.userType) {
 			return ResponseWrapper.badRequest('Missing required fields: name, email, and userType are required');
 		}
 
 		const db = await getDb();
-		
+
 		const user = await db.collection<User>('users').insertOne({
 			name: input.name,
 			profileAvatar: normalizePersistedAssetReference(input.profileAvatar, ''),
@@ -36,9 +44,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			email: input.email,
 			phone: input.phone,
 			userType: input.userType,
-			location: '',
+			location: input.location ?? '',
 			cognitoSub: '',
-			workspaceId: null,
+			workspaceId: context.workspaceId,
 			status: 'invited',
 		});
 
@@ -46,7 +54,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			entity: 'user',
 			entityId: user.insertedId.toString(),
 			action: AuditLogAction.CREATE,
-			actionBy: user.insertedId.toString(),
+			actionBy: context.userId.toString(),
 			actionAt: new Date(),
 			active: true,
 		});

--- a/src/controllers/users/deleteUser.ts
+++ b/src/controllers/users/deleteUser.ts
@@ -3,9 +3,10 @@ import { getDb } from '../../utils/db';
 import { User } from '../../models/user';
 import { AuditLog, AuditLogAction } from '../../models/auditLog';
 import { updateAuditLog } from '../../utils/auditLog';
-import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
+import { isWorkspaceAdmin, requireTenantContext, tenantUserIdFilter } from '../../utils/tenantContext';
+import { validateAllObjectIds } from '../../utils/validationUtils';
 
 /**
  * Delete a user
@@ -15,22 +16,41 @@ import { logError } from '../../utils/logger';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		// Parse the id from the event
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
+
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
+		}
+
 		if (!event.pathParameters?.id) {
 			return ResponseWrapper.badRequest('User ID is required');
 		}
 
-		const db = await getDb();
-		
-		const user = await db.collection<User>('users').deleteOne({
-			_id: new ObjectId(event.pathParameters?.id)
-		});
+		const objectIdValidation = validateAllObjectIds({ id: event.pathParameters.id });
+		if (objectIdValidation) return objectIdValidation;
 
-		const auditRecord : AuditLog = {
+		if (event.pathParameters.id === context.userId.toString()) {
+			return ResponseWrapper.badRequest('You cannot delete your own user account. Please contact your workspace admin to delete your account.');
+		}
+
+		const db = await getDb();
+
+		const user = await db.collection<User>('users').deleteOne(
+			tenantUserIdFilter(event.pathParameters.id, context.workspaceId),
+		);
+
+		if (user.deletedCount === 0) {
+			return ResponseWrapper.notFound('User not found');
+		}
+
+		const auditRecord: AuditLog = {
 			entity: 'user',
-			entityId: (event.pathParameters?.id).toString(),
+			entityId: (event.pathParameters.id).toString(),
 			action: AuditLogAction.DELETE,
-			actionBy: (event.pathParameters?.id).toString(),
+			actionBy: context.userId.toString(),
 			actionAt: new Date(),
 			active: true,
 		};

--- a/src/controllers/users/getAllUsersByWorkspace.ts
+++ b/src/controllers/users/getAllUsersByWorkspace.ts
@@ -66,7 +66,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			collection.countDocuments(queryFilter),
 		]);
 
-		const usersWithSignedAvatars = await enrichUsersWithProfileAvatarUrls(users);
+		const usersWithSignedAvatars = await enrichUsersWithProfileAvatarUrls(users, {
+			workspaceId: context.workspaceId,
+			pendingOwnerId: context.cognitoSub,
+		});
 		const totalPages = Math.ceil(totalCount / limit);
 
 		return ResponseWrapper.success({

--- a/src/controllers/users/getAllUsersByWorkspace.ts
+++ b/src/controllers/users/getAllUsersByWorkspace.ts
@@ -3,8 +3,8 @@ import { getDb } from '../../utils/db';
 import { User } from '../../models/user';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
 import { ObjectId } from 'mongodb';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
 import { enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
 import { buildListFiltersMatch, ListFilterField, parseListQuery } from '../../utils/listQuery';
 
@@ -23,11 +23,10 @@ const USER_FILTER_FIELDS: Record<string, ListFilterField> = {
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateRequest(event);
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
 
-		if (!auth.isValid) {
-			return auth.error;
-		}
+		const { context } = tenantResult;
 
 		const listQueryResult = parseListQuery({
 			query: event.queryStringParameters,
@@ -37,15 +36,19 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (listQueryResult.error) return listQueryResult.error;
 
 		const { limit, page, skip, sort, order, filters } = listQueryResult.value!;
-		const workspaceId = event.queryStringParameters?.workspaceId;
+		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;
 
-		if (!workspaceId) return ResponseWrapper.badRequest('Valid workspace is required.');
-		if (!ObjectId.isValid(workspaceId)) return ResponseWrapper.badRequest('Invalid workspace');
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) return ResponseWrapper.badRequest('Invalid workspace');
+
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
 
 		const sortObj: { [key: string]: 1 | -1 } = {};
 		sortObj[sort] = order === 'desc' ? -1 : 1;
 
-		const baseMatch = { workspaceId: new ObjectId(workspaceId) };
+		const baseMatch = { workspaceId: context.workspaceId };
 
 		const filtersMatch = buildListFiltersMatch(filters, USER_FILTER_FIELDS);
 		if (filtersMatch.error) return filtersMatch.error;

--- a/src/controllers/users/getUser.ts
+++ b/src/controllers/users/getUser.ts
@@ -1,10 +1,11 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import { User } from '../../models/user';
-import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
+import { requireTenantContext, tenantUserIdFilter } from '../../utils/tenantContext';
+import { validateAllObjectIds } from '../../utils/validationUtils';
 
 /**
  * Get a user
@@ -14,18 +15,29 @@ import { enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		// Parse the path param from the event
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
+
 		if (!event.pathParameters?.id) {
 			return ResponseWrapper.badRequest('Missing required fields: id is required');
 		}
 
-		const db = await getDb();
-		
-		const user: User | null = await db.collection<User>('users').findOne({ _id: new ObjectId(event.pathParameters.id) });
+		const objectIdValidation = validateAllObjectIds({ id: event.pathParameters.id });
+		if (objectIdValidation) return objectIdValidation;
 
-		const [userWithSignedAvatar] = user
-			? await enrichUsersWithProfileAvatarUrls([user])
-			: [];
+		const db = await getDb();
+
+		const user = await db.collection<User>('users').findOne(
+			tenantUserIdFilter(event.pathParameters.id, context.workspaceId),
+		);
+
+		if (!user) {
+			return ResponseWrapper.notFound('User not found');
+		}
+
+		const [userWithSignedAvatar] = await enrichUsersWithProfileAvatarUrls([user]);
 
 		return ResponseWrapper.success({
 			message: 'User retrieved successfully',

--- a/src/controllers/users/getUser.ts
+++ b/src/controllers/users/getUser.ts
@@ -37,7 +37,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.notFound('User not found');
 		}
 
-		const [userWithSignedAvatar] = await enrichUsersWithProfileAvatarUrls([user]);
+		const [userWithSignedAvatar] = await enrichUsersWithProfileAvatarUrls([user], {
+			workspaceId: context.workspaceId,
+			pendingOwnerId: context.cognitoSub,
+		});
 
 		return ResponseWrapper.success({
 			message: 'User retrieved successfully',

--- a/src/controllers/users/updateUser.ts
+++ b/src/controllers/users/updateUser.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateMissingFields } from '../../utils/validationUtils';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 
 /**
  * Update a user
@@ -17,50 +18,64 @@ import { normalizePersistedAssetReference } from '../../utils/s3-storage';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		// Parse the request body from the event
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
+
 		if (!event.body) {
 			return ResponseWrapper.badRequest('Request body is required');
 		}
 
 		const input: User = JSON.parse(event.body);
 
-		// Validate required fields
 		const missingFields = validateMissingFields({
 			name: input.name,
 			email: input.email,
 		});
 
-		if(missingFields) return missingFields;
-
+		if (missingFields) return missingFields;
 
 		const db = await getDb();
 
 		const userRecord: User | null = await db.collection<User>('users').findOne({
 			email: input.email,
-		});
-		
-		if (!userRecord) {
-			return ResponseWrapper.badRequest('User not found');
-		}
-		
-		const user = await db.collection<User>('users').updateOne({
-			_id: new ObjectId((userRecord._id as ObjectId)),
-		}, {
-			$set: {
-				name: input.name,
-				profileAvatar: normalizePersistedAssetReference(input.profileAvatar, userRecord.profileAvatar ?? ''),
-				email: input.email,
-				designation: input.designation || '',
-				phone: input.phone,
-				location: input.location || '',
-			}
+			workspaceId: context.workspaceId,
 		});
 
-		const auditRecord : AuditLog = {
+		if (!userRecord?._id) {
+			return ResponseWrapper.notFound('User not found');
+		}
+
+		const isSelfUpdate = userRecord.cognitoSub === context.cognitoSub;
+		const canManageUsers = isWorkspaceAdmin(context.cognitoGroups);
+
+		if (!isSelfUpdate && !canManageUsers) {
+			return ResponseWrapper.forbidden('You are not authorized to update this user');
+		}
+
+		const user = await db.collection<User>('users').updateOne(
+			{
+				_id: new ObjectId(userRecord._id),
+				workspaceId: context.workspaceId,
+			},
+			{
+				$set: {
+					name: input.name,
+					profileAvatar: normalizePersistedAssetReference(input.profileAvatar, userRecord.profileAvatar ?? ''),
+					email: input.email,
+					designation: input.designation || '',
+					phone: input.phone,
+					location: input.location || '',
+				},
+			},
+		);
+
+		const auditRecord: AuditLog = {
 			entity: 'user',
 			entityId: (userRecord._id as ObjectId).toString(),
 			action: AuditLogAction.UPDATE,
-			actionBy: (userRecord._id as ObjectId).toString(),
+			actionBy: context.userId.toString(),
 			actionAt: new Date(),
 			active: true,
 		};
@@ -71,7 +86,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			message: 'User updated successfully',
 			user: user,
 		});
-		
+
 	} catch (err) {
 		logError('Update user handler failed', err);
 		return ResponseWrapper.internalServerError('Failed to update user');

--- a/src/controllers/workspaces/createWorkspace.ts
+++ b/src/controllers/workspaces/createWorkspace.ts
@@ -11,9 +11,15 @@ import { normalizePersistedAssetReference } from '../../utils/s3-storage';
 
 
 /**
- * API endpoint to create a workspace - only admin can create a workspace
+ * Platform provisioning: creates a new tenant workspace.
+ *
+ * Not scoped to the caller's existing workspace — intentional for onboarding.
+ * Cognito `admin` here means workspace admin during first-time setup, not a
+ * cross-tenant platform operator. Before exposing broadly, gate with a dedicated
+ * platform role (e.g. `platform-admin`) or restrict to internal-only callers.
+ *
  * @param {APIGatewayProxyEvent} event - API Gateway Lambda Proxy Input Format
- * @return {Promise<APIGatewayProxyResult>} API Gateway Lambda Proxy Output Format 
+ * @return {Promise<APIGatewayProxyResult>} API Gateway Lambda Proxy Output Format
  */
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {

--- a/src/controllers/workspaces/getWorkspace.ts
+++ b/src/controllers/workspaces/getWorkspace.ts
@@ -36,7 +36,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.notFound('Workspace not found');
 		}
 
-		const workspaceWithSignedLogo = await enrichWorkspaceWithLogoUrl(workspace);
+		const workspaceWithSignedLogo = await enrichWorkspaceWithLogoUrl(workspace, {
+			workspaceId: context.workspaceId,
+			pendingOwnerId: context.cognitoSub,
+		});
 
 		return ResponseWrapper.success({
 			message: 'Workspace retrieved successfully',

--- a/src/controllers/workspaces/getWorkspace.ts
+++ b/src/controllers/workspaces/getWorkspace.ts
@@ -1,10 +1,9 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getDb } from '../../utils/db';
 import { Workspace } from '../../models/workspace';
-import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { authenticateRequest } from '../../utils/authUtils';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
 import { enrichWorkspaceWithLogoUrl } from '../../utils/s3-storage';
 
 /**
@@ -19,15 +18,19 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.badRequest('Missing required fields: id is required');
 		}
 
-		const auth = await authenticateRequest(event);
-		
-		if(!auth.isValid) {
-			return auth.error;
-		}
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
+
+		const workspaceMismatch = assertWorkspaceMatch(event.pathParameters.id, context.workspaceId);
+		if (workspaceMismatch) return workspaceMismatch;
 
 		const db = await getDb();
-		
-		const workspace: Workspace | null = await db.collection<Workspace>('workspaces').findOne({ _id: new ObjectId(event.pathParameters.id) });
+
+		const workspace: Workspace | null = await db.collection<Workspace>('workspaces').findOne({
+			_id: context.workspaceId,
+		});
 
 		if (!workspace) {
 			return ResponseWrapper.notFound('Workspace not found');

--- a/src/controllers/workspaces/updateWorkspace.ts
+++ b/src/controllers/workspaces/updateWorkspace.ts
@@ -7,8 +7,8 @@ import { ObjectId } from 'mongodb';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
-import { authenticateWithRole } from '../../utils/authUtils';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 
 /**
  * Update a workspace
@@ -18,10 +18,13 @@ import { normalizePersistedAssetReference } from '../../utils/s3-storage';
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
-		const auth = await authenticateWithRole(event, 'admin');
-		
-		if(!auth.isValid) {
-			return auth.error;
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context, auth } = tenantResult;
+
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
 		}
 
 		if (!event.body) {
@@ -53,7 +56,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return objectIdsResult;
 		}
 
-		// Validate user IDs if provided
+		const workspaceMismatch = assertWorkspaceMatch(input._id!, context.workspaceId);
+		if (workspaceMismatch) return workspaceMismatch;
+
 		if (input.userIds && input.userIds.length > 0) {
 			const invalidUserIds = input.userIds.filter((userId) => !ObjectId.isValid(userId));
 			if (invalidUserIds.length > 0) {
@@ -66,7 +71,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const db = await getDb();
 
 		const workspaceRecord: Workspace | null = await db.collection<Workspace>('workspaces').findOne({
-			_id: new ObjectId(input._id),
+			_id: context.workspaceId,
 		});
 
 		if (!workspaceRecord) {
@@ -77,7 +82,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const workspace = await db.collection<Workspace>('workspaces').updateOne(
 			{
-				_id: new ObjectId(workspaceRecord._id as ObjectId),
+				_id: context.workspaceId,
 			},
 			{
 				$set: {
@@ -97,7 +102,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const auditRecord: AuditLog = {
 			entity: 'workspace',
-			entityId: (workspaceRecord._id as ObjectId).toString(),
+			entityId: context.workspaceId.toString(),
 			action: AuditLogAction.UPDATE,
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),

--- a/src/tests/unit/exportJobs.test.ts
+++ b/src/tests/unit/exportJobs.test.ts
@@ -1,0 +1,51 @@
+import { ObjectId } from 'mongodb';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const findOne = jest.fn<() => Promise<unknown>>();
+
+jest.mock('../../utils/db', () => ({
+	getDb: jest.fn(async () => ({
+		collection: jest.fn(() => ({
+			findOne,
+			createIndex: jest.fn(),
+		})),
+	})),
+}));
+
+const { getExportJobById, getExportJobByIdForUser } = require('../../utils/exportJobs');
+
+describe('export job lookups', () => {
+	const jobId = new ObjectId();
+	const workspaceId = new ObjectId();
+	const otherWorkspaceId = new ObjectId();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('getExportJobById filters by workspaceId', async () => {
+		findOne.mockResolvedValue(null);
+
+		await getExportJobById({ jobId, workspaceId });
+
+		expect(findOne).toHaveBeenCalledWith({ _id: jobId, workspaceId });
+	});
+
+	it('getExportJobByIdForUser filters by workspaceId and requestedBySub', async () => {
+		findOne.mockResolvedValue(null);
+
+		await getExportJobByIdForUser({
+			jobId,
+			workspaceId: otherWorkspaceId,
+			requestedBySub: 'user-sub',
+			target: 'product',
+		});
+
+		expect(findOne).toHaveBeenCalledWith({
+			_id: jobId,
+			workspaceId: otherWorkspaceId,
+			requestedBySub: 'user-sub',
+			target: 'product',
+		});
+	});
+});

--- a/src/tests/unit/reportsQuery.test.ts
+++ b/src/tests/unit/reportsQuery.test.ts
@@ -1,0 +1,96 @@
+import { ObjectId } from 'mongodb';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../utils/tenantContext', () => ({
+	requireTenantContext: jest.fn(),
+	assertWorkspaceMatch: jest.fn(),
+}));
+
+jest.mock('../../utils/db', () => ({
+	getDb: jest.fn(),
+}));
+
+jest.mock('../../utils/reports/queryBuilder', () => ({
+	validateConditions: jest.fn(),
+	buildAggregationPipeline: jest.fn(),
+}));
+
+const tenantContext = jest.requireMock('../../utils/tenantContext') as any;
+const dbModule = jest.requireMock('../../utils/db') as any;
+const queryBuilder = jest.requireMock('../../utils/reports/queryBuilder') as any;
+
+const requireTenantContext = tenantContext.requireTenantContext;
+const assertWorkspaceMatch = tenantContext.assertWorkspaceMatch;
+const getDb = dbModule.getDb;
+const buildAggregationPipeline = queryBuilder.buildAggregationPipeline;
+
+const { lambdaHandler } = require('../../controllers/reports/reportsQuery');
+
+describe('reportsQuery', () => {
+	const workspaceId = new ObjectId();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		requireTenantContext.mockResolvedValue({
+			ok: true,
+			context: {
+				workspaceId,
+				userId: new ObjectId(),
+				cognitoSub: 'user-sub',
+				cognitoGroups: ['user'],
+			},
+		});
+
+		assertWorkspaceMatch.mockReturnValue(null);
+
+		buildAggregationPipeline.mockReturnValue([]);
+
+		getDb.mockResolvedValue({
+			collection: () => ({
+				aggregate: () => ({
+					toArray: async () => [{ data: [], metadata: [{ total: 0 }] }],
+				}),
+			}),
+		});
+	});
+
+	it('runs the aggregation pipeline for the authenticated workspace', async () => {
+		const response = await lambdaHandler({
+			body: JSON.stringify({
+				workspaceId: workspaceId.toString(),
+				conditions: [],
+			}),
+			headers: { Authorization: 'Bearer token' },
+		} as any);
+
+		expect(response.statusCode).toBe(200);
+		expect(assertWorkspaceMatch).toHaveBeenCalledWith(
+			workspaceId.toString(),
+			workspaceId,
+			'You are not authorized to query reports for this workspace',
+		);
+		expect(buildAggregationPipeline).toHaveBeenCalledWith(
+			expect.objectContaining({ workspaceId: workspaceId.toString() }),
+			workspaceId,
+		);
+	});
+
+	it('rejects queries for a different workspace', async () => {
+		assertWorkspaceMatch.mockReturnValue({
+			statusCode: 403,
+			body: JSON.stringify({ message: 'You are not authorized to query reports for this workspace' }),
+		});
+
+		const response = await lambdaHandler({
+			body: JSON.stringify({
+				workspaceId: new ObjectId().toString(),
+				conditions: [],
+			}),
+			headers: { Authorization: 'Bearer token' },
+		} as any);
+
+		expect(response.statusCode).toBe(403);
+		expect(buildAggregationPipeline).not.toHaveBeenCalled();
+	});
+});

--- a/src/tests/unit/s3-storage-tenant-keys.test.ts
+++ b/src/tests/unit/s3-storage-tenant-keys.test.ts
@@ -1,0 +1,55 @@
+import { ObjectId } from 'mongodb';
+import { describe, expect, it } from '@jest/globals';
+
+process.env.AWS_REGION = process.env.AWS_REGION ?? 'us-east-1';
+process.env.UPLOADS_BUCKET = process.env.UPLOADS_BUCKET ?? 'test-uploads';
+process.env.EXPORTS_BUCKET = process.env.EXPORTS_BUCKET ?? 'test-exports';
+
+const {
+	assertTenantUploadKeyAllowed,
+	isTenantUploadKeyAllowed,
+	TenantUploadKeyError,
+} = require('../../utils/s3-storage');
+
+describe('tenant upload key validation', () => {
+	const workspaceId = new ObjectId();
+	const otherWorkspaceId = new ObjectId();
+	const pendingOwnerId = 'cognito-sub-123';
+
+	const signingOptions = {
+		workspaceId,
+		pendingOwnerId,
+	};
+
+	it('allows workspace-scoped product asset keys', () => {
+		const key = `uploads/${workspaceId.toString()}/product/507f1f77bcf86cd799439011/file.png`;
+
+		expect(isTenantUploadKeyAllowed(key, signingOptions)).toBe(true);
+		expect(() => assertTenantUploadKeyAllowed(key, signingOptions)).not.toThrow();
+	});
+
+	it('allows pending keys for the configured owner', () => {
+		const key = `uploads/pending/${pendingOwnerId}/avatar.png`;
+
+		expect(isTenantUploadKeyAllowed(key, signingOptions)).toBe(true);
+	});
+
+	it('rejects another workspace prefix', () => {
+		const key = `uploads/${otherWorkspaceId.toString()}/workspace/logo.png`;
+
+		expect(isTenantUploadKeyAllowed(key, signingOptions)).toBe(false);
+		expect(() => assertTenantUploadKeyAllowed(key, signingOptions)).toThrow(TenantUploadKeyError);
+	});
+
+	it('rejects legacy unscoped uploads keys', () => {
+		const key = 'uploads/legacy-file.png';
+
+		expect(isTenantUploadKeyAllowed(key, signingOptions)).toBe(false);
+	});
+
+	it('rejects pending keys for a different owner', () => {
+		const key = 'uploads/pending/other-user/avatar.png';
+
+		expect(isTenantUploadKeyAllowed(key, signingOptions)).toBe(false);
+	});
+});

--- a/src/tests/unit/tenantContext.test.ts
+++ b/src/tests/unit/tenantContext.test.ts
@@ -1,0 +1,131 @@
+import { ObjectId } from 'mongodb';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../utils/authUtils', () => ({
+	authenticateRequest: jest.fn(),
+}));
+
+jest.mock('../../utils/authenticatedUser', () => ({
+	getAuthenticatedUserContext: jest.fn(),
+}));
+
+const authUtils = jest.requireMock('../../utils/authUtils') as any;
+const authenticatedUser = jest.requireMock('../../utils/authenticatedUser') as any;
+
+const {
+	requireTenantContext,
+	assertWorkspaceMatch,
+	tenantObjectIdFilter,
+	tenantUserIdFilter,
+	isWorkspaceAdmin,
+} = require('../../utils/tenantContext');
+
+describe('tenantContext', () => {
+	const workspaceId = new ObjectId();
+	const userId = new ObjectId();
+	const event = { headers: { Authorization: 'Bearer token' } };
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('requireTenantContext', () => {
+		it('returns auth error when token is invalid', async () => {
+			authUtils.authenticateRequest.mockResolvedValue({
+				isValid: false,
+				error: { statusCode: 401, body: '{"message":"Unauthorized"}' },
+			});
+
+			const result = await requireTenantContext(event);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.response.statusCode).toBe(401);
+			}
+		});
+
+		it('returns unauthorized when user context cannot be resolved', async () => {
+			authUtils.authenticateRequest.mockResolvedValue({
+				isValid: true,
+				payload: { sub: 'cognito-sub' },
+				token: 'token',
+			});
+			authenticatedUser.getAuthenticatedUserContext.mockResolvedValue(null);
+
+			const result = await requireTenantContext(event);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(JSON.parse(result.response.body).message).toBe(
+					'Unable to resolve authenticated user context',
+				);
+			}
+		});
+
+		it('returns tenant context when auth and workspace resolve', async () => {
+			authUtils.authenticateRequest.mockResolvedValue({
+				isValid: true,
+				payload: { sub: 'cognito-sub', 'cognito:groups': ['admin', 'user'] },
+				token: 'token',
+			});
+			authenticatedUser.getAuthenticatedUserContext.mockResolvedValue({
+				userId,
+				workspaceId,
+			});
+
+			const result = await requireTenantContext(event);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.context).toEqual({
+					workspaceId,
+					userId,
+					cognitoSub: 'cognito-sub',
+					cognitoGroups: ['admin', 'user'],
+				});
+			}
+		});
+	});
+
+	describe('assertWorkspaceMatch', () => {
+		it('returns null when workspace ids match', () => {
+			expect(assertWorkspaceMatch(workspaceId.toString(), workspaceId)).toBeNull();
+		});
+
+		it('returns forbidden when workspace ids differ', () => {
+			const mismatch = assertWorkspaceMatch(new ObjectId(), workspaceId);
+
+			expect(mismatch?.statusCode).toBe(403);
+			expect(JSON.parse(mismatch!.body).message).toContain('not authorized');
+		});
+	});
+
+	describe('tenantObjectIdFilter', () => {
+		it('builds _id and workspace_id filter', () => {
+			const resourceId = new ObjectId();
+
+			expect(tenantObjectIdFilter(resourceId, workspaceId)).toEqual({
+				_id: resourceId,
+				workspace_id: workspaceId,
+			});
+		});
+	});
+
+	describe('tenantUserIdFilter', () => {
+		it('builds _id and workspaceId filter', () => {
+			const resourceId = new ObjectId();
+
+			expect(tenantUserIdFilter(resourceId, workspaceId)).toEqual({
+				_id: resourceId,
+				workspaceId,
+			});
+		});
+	});
+
+	describe('isWorkspaceAdmin', () => {
+		it('detects admin group membership', () => {
+			expect(isWorkspaceAdmin(['admin'])).toBe(true);
+			expect(isWorkspaceAdmin(['user'])).toBe(false);
+		});
+	});
+});

--- a/src/tests/unit/tenantContext.test.ts
+++ b/src/tests/unit/tenantContext.test.ts
@@ -98,6 +98,13 @@ describe('tenantContext', () => {
 			expect(mismatch?.statusCode).toBe(403);
 			expect(JSON.parse(mismatch!.body).message).toContain('not authorized');
 		});
+
+		it('returns bad request when workspace id is malformed', () => {
+			const mismatch = assertWorkspaceMatch('not-an-objectid', workspaceId);
+
+			expect(mismatch?.statusCode).toBe(400);
+			expect(JSON.parse(mismatch!.body).message).toContain('Invalid workspace id');
+		});
 	});
 
 	describe('tenantObjectIdFilter', () => {

--- a/src/utils/exportExcel.ts
+++ b/src/utils/exportExcel.ts
@@ -110,7 +110,7 @@ const loadSignedUrlMap = async (productData: Product): Promise<Map<string, strin
 	if (!s3Keys.length) return new Map<string, string>();
 
 	try {
-		return await createPresignedGetUrlMap(s3Keys);
+		return await createPresignedGetUrlMap(s3Keys, { workspaceId: productData.workspace_id });
 	} catch (error) {
 		logError("Failed to sign product image URLs for Excel export", error);
 		return new Map<string, string>();

--- a/src/utils/exportJobs.ts
+++ b/src/utils/exportJobs.ts
@@ -252,19 +252,23 @@ export const markExportJobFailed = async ({
 
 export const getExportJobById = async ({
 	jobId,
+	workspaceId,
 }: {
 	jobId: ObjectId;
+	workspaceId: ObjectId;
 }): Promise<ExportJobDocument | null> => {
 	const collection = await getCollection();
-	return collection.findOne({ _id: jobId });
+	return collection.findOne({ _id: jobId, workspaceId });
 };
 
 export const getExportJobByIdForUser = async ({
 	jobId,
+	workspaceId,
 	requestedBySub,
 	target,
 }: {
 	jobId: ObjectId;
+	workspaceId: ObjectId;
 	requestedBySub: string;
 	target?: ExportJobTarget;
 }): Promise<ExportJobDocument | null> => {
@@ -272,10 +276,12 @@ export const getExportJobByIdForUser = async ({
 
 	const query: {
 		_id: ObjectId;
+		workspaceId: ObjectId;
 		requestedBySub: string;
 		target?: ExportJobTarget;
 	} = {
 		_id: jobId,
+		workspaceId,
 		requestedBySub,
 	};
 

--- a/src/utils/exportPDF.ts
+++ b/src/utils/exportPDF.ts
@@ -188,7 +188,7 @@ const loadSignedUrlMap = async (productData: Product): Promise<Map<string, strin
 	if (!s3Keys.length) return new Map<string, string>();
 
 	try {
-		return await createPresignedGetUrlMap(s3Keys);
+		return await createPresignedGetUrlMap(s3Keys, { workspaceId: productData.workspace_id });
 	} catch (error) {
 		logError("Failed to sign product image URLs for PDF export", error);
 		return new Map<string, string>();

--- a/src/utils/productExportJobs.ts
+++ b/src/utils/productExportJobs.ts
@@ -52,15 +52,18 @@ export const markProductExportJobFailed = markExportJobFailed;
 
 export const getProductExportJobByIdForUser = async ({
 	jobId,
+	workspaceId,
 	requestedBySub,
 	target,
 }: {
 	jobId: ObjectId;
+	workspaceId: ObjectId;
 	requestedBySub: string;
 	target?: ExportJobTarget;
 }): Promise<ExportJobDocument | null> => {
 	return getExportJobByIdForUser({
 		jobId,
+		workspaceId,
 		requestedBySub,
 		target,
 	});

--- a/src/utils/s3-storage.ts
+++ b/src/utils/s3-storage.ts
@@ -1,6 +1,19 @@
 import { CopyObjectCommand, DeleteObjectCommand, GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { ObjectId } from "mongodb";
 import crypto from "node:crypto";
+
+export type TenantUploadSigningOptions = {
+	workspaceId: string | ObjectId;
+	pendingOwnerId?: string;
+};
+
+export class TenantUploadKeyError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "TenantUploadKeyError";
+	}
+}
 
 const region = process.env.AWS_REGION;
 const uploadsBucket = process.env.UPLOADS_BUCKET;
@@ -87,10 +100,62 @@ export const createPresignedUrl = async (
 	return {uploadUrl, key};
 };
 
-export const createPresignedGetUrl = async (key: string) => {
+const toWorkspaceIdString = (workspaceId: string | ObjectId): string => {
+	return workspaceId instanceof ObjectId ? workspaceId.toString() : workspaceId;
+};
+
+const normalizeKey = (key: unknown): string | null => {
+	if (typeof key !== "string") return null;
+	const trimmed = key.trim();
+	return trimmed.length > 0 ? trimmed : null;
+};
+
+/**
+ * Returns true when the uploads-bucket key is scoped to the workspace or an allowed pending path.
+ */
+export const isTenantUploadKeyAllowed = (
+	key: string,
+	{ workspaceId, pendingOwnerId }: TenantUploadSigningOptions,
+): boolean => {
+	const normalizedKey = normalizeKey(key);
+	if (!normalizedKey || !normalizedKey.startsWith("uploads/")) return false;
+
+	const workspacePrefix = `uploads/${toWorkspaceIdString(workspaceId)}/`;
+	if (normalizedKey.startsWith(workspacePrefix)) return true;
+
+	if (pendingOwnerId) {
+		const pendingPrefix = `uploads/pending/${pendingOwnerId}/`;
+		if (normalizedKey.startsWith(pendingPrefix)) return true;
+	}
+
+	return false;
+};
+
+export const assertTenantUploadKeyAllowed = (
+	key: string,
+	signingOptions: TenantUploadSigningOptions,
+): void => {
+	if (!isTenantUploadKeyAllowed(key, signingOptions)) {
+		throw new TenantUploadKeyError(
+			`Upload key is not allowed for workspace ${toWorkspaceIdString(signingOptions.workspaceId)}`,
+		);
+	}
+};
+
+export const createPresignedGetUrl = async (
+	key: string,
+	signingOptions: TenantUploadSigningOptions,
+) => {
+	const normalizedKey = normalizeKey(key);
+	if (!normalizedKey) {
+		throw new TenantUploadKeyError("Upload key is required");
+	}
+
+	assertTenantUploadKeyAllowed(normalizedKey, signingOptions);
+
 	const command = new GetObjectCommand({
 		Bucket: uploadsBucket,
-		Key: key,
+		Key: normalizedKey,
 	});
 
 	const url = await getSignedUrl(client, command, { expiresIn: VIEW_URL_EXPIRES_IN_SECONDS });
@@ -225,13 +290,10 @@ export const createDocumentationFilePresignedGetUrl = async (
 	return { url, expiresAt };
 };
 
-const normalizeKey = (key: unknown): string | null => {
-	if (typeof key !== "string") return null;
-	const trimmed = key.trim();
-	return trimmed.length > 0 ? trimmed : null;
-};
-
-export const createPresignedGetUrlMap = async (keys: string[]): Promise<Map<string, string>> => {
+export const createPresignedGetUrlMap = async (
+	keys: string[],
+	signingOptions: TenantUploadSigningOptions,
+): Promise<Map<string, string>> => {
 	const uniqueKeys = [...new Set(keys.map(normalizeKey).filter((key): key is string => Boolean(key)))];
 	const signedUrlMap = new Map<string, string>();
 
@@ -240,7 +302,7 @@ export const createPresignedGetUrlMap = async (keys: string[]): Promise<Map<stri
 		const chunkResults = await Promise.all(
 			keyChunk.map(async (key) => {
 				try {
-					const url = await createPresignedGetUrl(key);
+					const url = await createPresignedGetUrl(key, signingOptions);
 					return { key, url };
 				} catch {
 					return null;
@@ -288,12 +350,14 @@ type EnrichItemsWithSignedUrlParams<T> = {
 	items: T[];
 	getKey: (item: T) => string | undefined | null;
 	setSignedUrl: (item: T, signedUrl: string) => T;
+	signingOptions: TenantUploadSigningOptions;
 };
 
 export const enrichItemsWithSignedUrls = async <T>({
 	items,
 	getKey,
 	setSignedUrl,
+	signingOptions,
 }: EnrichItemsWithSignedUrlParams<T>): Promise<T[]> => {
 	if (!items.length) return items;
 
@@ -303,7 +367,7 @@ export const enrichItemsWithSignedUrls = async <T>({
 
 	if (!keys.length) return items;
 
-	const signedUrlMap = await createPresignedGetUrlMap(keys);
+	const signedUrlMap = await createPresignedGetUrlMap(keys, signingOptions);
 
 	return items.map((item) => {
 		const key = normalizeKey(getKey(item));
@@ -392,9 +456,11 @@ export const normalizePersistedAssetReference = (
 
 export const enrichUsersWithProfileAvatarUrls = async <T extends UserAvatarShape>(
 	users: T[],
+	signingOptions: TenantUploadSigningOptions,
 ): Promise<T[]> => {
 	return enrichItemsWithSignedUrls({
 		items: users,
+		signingOptions,
 		getKey: (item) => extractS3AssetKey(item.profileAvatar),
 		setSignedUrl: (item, signedUrl) => ({
 			...item,
@@ -405,11 +471,15 @@ export const enrichUsersWithProfileAvatarUrls = async <T extends UserAvatarShape
 
 export const enrichWorkspaceWithLogoUrl = async <T extends WorkspaceLogoShape>(
 	workspace: T | null,
+	signingOptions: TenantUploadSigningOptions,
 ): Promise<T | null> => {
 	if (!workspace) return workspace;
 
+	const resolvedSigningOptions = signingOptions;
+
 	const [workspaceWithSignedLogo] = await enrichItemsWithSignedUrls({
 		items: [workspace],
+		signingOptions: resolvedSigningOptions,
 		getKey: (item) => extractS3AssetKey(item.logo),
 		setSignedUrl: (item, signedUrl) => ({
 			...item,
@@ -422,9 +492,11 @@ export const enrichWorkspaceWithLogoUrl = async <T extends WorkspaceLogoShape>(
 
 export const enrichProjectsWithImageUrls = async <T extends ProjectImageShape>(
 	projects: T[],
+	signingOptions: TenantUploadSigningOptions,
 ): Promise<T[]> => {
 	return enrichItemsWithSignedUrls({
 		items: projects,
+		signingOptions,
 		getKey: (item) => extractS3AssetKey(item.image),
 		setSignedUrl: (item, signedUrl) => ({
 			...item,
@@ -435,9 +507,11 @@ export const enrichProjectsWithImageUrls = async <T extends ProjectImageShape>(
 
 export const enrichDepartmentsWithImageUrls = async <T extends DepartmentImageShape>(
 	departments: T[],
+	signingOptions: TenantUploadSigningOptions,
 ): Promise<T[]> => {
 	return enrichItemsWithSignedUrls({
 		items: departments,
+		signingOptions,
 		getKey: (item) => extractS3AssetKey(item.image),
 		setSignedUrl: (item, signedUrl) => ({
 			...item,

--- a/src/utils/s3-storage.ts
+++ b/src/utils/s3-storage.ts
@@ -475,11 +475,9 @@ export const enrichWorkspaceWithLogoUrl = async <T extends WorkspaceLogoShape>(
 ): Promise<T | null> => {
 	if (!workspace) return workspace;
 
-	const resolvedSigningOptions = signingOptions;
-
 	const [workspaceWithSignedLogo] = await enrichItemsWithSignedUrls({
 		items: [workspace],
-		signingOptions: resolvedSigningOptions,
+		signingOptions,
 		getKey: (item) => extractS3AssetKey(item.logo),
 		setSignedUrl: (item, signedUrl) => ({
 			...item,

--- a/src/utils/tenantContext.ts
+++ b/src/utils/tenantContext.ts
@@ -1,0 +1,127 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import { authenticateRequest, type AuthResult } from './authUtils';
+import { getAuthenticatedUserContext } from './authenticatedUser';
+import { ResponseWrapper } from './responseWrapper';
+
+export type TenantContext = {
+	workspaceId: ObjectId;
+	userId: ObjectId;
+	cognitoSub: string;
+	cognitoGroups: string[];
+};
+
+export type TenantContextResult =
+	| { ok: true; context: TenantContext; auth: Extract<AuthResult, { isValid: true }> }
+	| { ok: false; response: APIGatewayProxyResult };
+
+const parseCognitoGroups = (groups: unknown): string[] => {
+	if (Array.isArray(groups)) {
+		return groups.filter((group): group is string => typeof group === 'string');
+	}
+
+	if (typeof groups === 'string') {
+		return groups.split(',').map((group) => group.trim()).filter(Boolean);
+	}
+
+	return [];
+};
+
+/**
+ * Authenticates the request and resolves the caller's workspace from MongoDB.
+ * @param {APIGatewayProxyEvent} event - API Gateway event
+ * @return {Promise<TenantContextResult>} Tenant context result
+*/
+export const requireTenantContext = async (
+	event: APIGatewayProxyEvent,
+): Promise<TenantContextResult> => {
+	const auth = await authenticateRequest(event);
+	if (!auth.isValid) {
+		return { ok: false, response: auth.error };
+	}
+
+	const cognitoSub = auth.payload.sub;
+	if (!cognitoSub) {
+		return { ok: false, response: ResponseWrapper.unauthorized('Unauthorized') };
+	}
+
+	const userContext = await getAuthenticatedUserContext(cognitoSub);
+	if (!userContext) {
+		return {
+			ok: false,
+			response: ResponseWrapper.unauthorized('Unable to resolve authenticated user context'),
+		};
+	}
+
+	return {
+		ok: true,
+		context: {
+			workspaceId: userContext.workspaceId,
+			userId: userContext.userId,
+			cognitoSub,
+			cognitoGroups: parseCognitoGroups(auth.payload['cognito:groups']),
+		},
+		auth,
+	};
+};
+
+/**
+ * Returns a 403 response when the requested workspace does not match the caller's workspace.
+ * @param {string | ObjectId} requestedWorkspaceId - The requested workspace id
+ * @param {ObjectId} contextWorkspaceId - The context workspace id
+ * @param {string} message - The message to return in the response
+ * @return {APIGatewayProxyResult | null} The response or null if the workspaces match
+*/
+export const assertWorkspaceMatch = (
+	requestedWorkspaceId: string | ObjectId,
+	contextWorkspaceId: ObjectId,
+	message = 'You are not authorized to access resources for this workspace',
+): APIGatewayProxyResult | null => {
+	const requestedId = requestedWorkspaceId instanceof ObjectId
+		? requestedWorkspaceId
+		: ObjectId.createFromHexString(requestedWorkspaceId.toString());
+
+	if (requestedId.toString() !== contextWorkspaceId.toString()) {
+		return ResponseWrapper.forbidden(message);
+	}
+
+	return null;
+};
+
+/**
+ * Standard Mongo filter for tenant-scoped resource lookups by id.
+ * @param {string | ObjectId} resourceId - The resource id
+ * @param {ObjectId} workspaceId - The workspace id
+ * @return {Object} The filter object
+*/
+export const tenantObjectIdFilter = (
+	resourceId: string | ObjectId,
+	workspaceId: ObjectId,
+): { _id: ObjectId; workspace_id: ObjectId } => {
+	const id = resourceId instanceof ObjectId ? resourceId : new ObjectId(resourceId.toString());
+
+	return {
+		_id: id,
+		workspace_id: workspaceId,
+	};
+};
+
+/**
+ * Standard Mongo filter for tenant-scoped user lookups by id.
+ * @param {string | ObjectId} userId - The user id
+ * @param {ObjectId} workspaceId - The workspace id
+ * @return {Object} The filter object
+*/
+export const tenantUserIdFilter = (
+	userId: string | ObjectId,
+	workspaceId: ObjectId,
+): { _id: ObjectId; workspaceId: ObjectId } => {
+	const id = userId instanceof ObjectId ? userId : new ObjectId(userId.toString());
+
+	return {
+		_id: id,
+		workspaceId,
+	};
+};
+
+export const isWorkspaceAdmin = (cognitoGroups: string[]): boolean => cognitoGroups.includes('admin');

--- a/src/utils/tenantContext.ts
+++ b/src/utils/tenantContext.ts
@@ -77,9 +77,21 @@ export const assertWorkspaceMatch = (
 	contextWorkspaceId: ObjectId,
 	message = 'You are not authorized to access resources for this workspace',
 ): APIGatewayProxyResult | null => {
-	const requestedId = requestedWorkspaceId instanceof ObjectId
-		? requestedWorkspaceId
-		: ObjectId.createFromHexString(requestedWorkspaceId.toString());
+	if (!(requestedWorkspaceId instanceof ObjectId)) {
+		const requestedWorkspaceIdString = requestedWorkspaceId.toString().trim();
+		if (!ObjectId.isValid(requestedWorkspaceIdString)) {
+			return ResponseWrapper.badRequest('Invalid workspace id');
+		}
+	}
+
+	let requestedId: ObjectId;
+	try {
+		requestedId = requestedWorkspaceId instanceof ObjectId
+			? requestedWorkspaceId
+			: new ObjectId(requestedWorkspaceId.toString());
+	} catch {
+		return ResponseWrapper.badRequest('Invalid workspace id');
+	}
 
 	if (requestedId.toString() !== contextWorkspaceId.toString()) {
 		return ResponseWrapper.forbidden(message);


### PR DESCRIPTION
- Add `tenantContext` utilities to resolve workspace from JWT/Mongo and standardize tenant filters
- Require auth and workspace scope on user endpoints, `getAllProducts`, and report sync/export routes
- Scope get/update/archive/delete by resource id to the caller’s workspace (products, projects, departments, source files, workspace)
- Scope list, dashboard, audit log, bookmark, and create endpoints to the caller’s workspace
- Scope workspace-admin mutations (departments, projects, workspace update, admin invites) to the caller’s workspace
- Validate S3 upload keys before issuing presigned GET URLs (`uploads/{workspaceId}/...` and allowed pending paths)
- Filter export job lookups by `workspaceId` in Mongo for get-by-id helpers and HTTP handlers
- Add unit tests for tenant context, report query scoping, S3 key rules, and export job queries