### PR TITLE
Fix CloudFront documentation video distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Requires `AWS_REGION` and credentials with `s3:PutObject` on `DOCUMENTATION_FILE
 
 `GET /docs/videos/{videoKey}/signed-url` returns a **CloudFront signed URL** when domain, key pair id, and private key PEM are set.
 
-**GitHub (per environment):** variables `DOCUMENTATION_CLOUDFRONT_DOMAIN`, `DOCUMENTATION_CLOUDFRONT_KEY_PAIR_ID`; secret `DOCUMENTATION_CLOUDFRONT_PRIVATE_KEY` (full PEM).
+**GitHub (per environment):** variables `DOCUMENTATION_CLOUDFRONT_DOMAIN`, `DOCUMENTATION_CLOUDFRONT_KEY_PAIR_ID`; secret `DOCUMENTATION_CLOUDFRONT_PRIVATE_KEY` (full private PEM, including `BEGIN PRIVATE KEY` / `END PRIVATE KEY`). The key pair id must be the CloudFront public key ID for the public key generated from that exact private key. Paste the secret as multiline PEM when possible; the backend also normalizes JSON-style `\n` and space-flattened PEMs.
 
 **Local:** copy `GetDocumentationVideoSignedUrlFunction` from `env.example.json` into `env.json` with the same three values.
 

--- a/src/controllers/docs/getDocumentationVideoSignedUrl.ts
+++ b/src/controllers/docs/getDocumentationVideoSignedUrl.ts
@@ -2,6 +2,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { getDocumentationVideoObjectKey } from "../../config/documentationVideos";
 import { authenticateRequest } from "../../utils/authUtils";
 import { createDocumentationVideoSignedUrl } from "../../utils/documentation-video-url";
+import { logError } from "../../utils/logger";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 
 /**
@@ -34,7 +35,8 @@ export const lambdaHandler = async (
 			message: "Documentation video URL generated",
 			result: { url, expiresAt },
 		});
-	} catch {
+	} catch (error) {
+		logError("Failed to generate documentation video URL", error);
 		return ResponseWrapper.internalServerError("Failed to generate documentation video URL");
 	}
 };

--- a/src/scripts/seedDocumentationVideos.mjs
+++ b/src/scripts/seedDocumentationVideos.mjs
@@ -195,6 +195,7 @@ const main = async () => {
 				Key: item.objectKey,
 				Body: body,
 				ContentType: "video/mp4",
+				CacheControl: "public, max-age=31536000, immutable",
 			}),
 		);
 		uploaded += 1;

--- a/src/tests/unit/documentation-video-url.test.ts
+++ b/src/tests/unit/documentation-video-url.test.ts
@@ -77,4 +77,32 @@ describe("documentation-video-url", () => {
 		);
 		expect(mockCreateDocumentationFilePresignedGetUrl).not.toHaveBeenCalled();
 	});
+
+	it("normalizes a private key that was flattened with spaces", async () => {
+		process.env = {
+			...ORIGINAL_ENV,
+			AWS_REGION: "us-east-1",
+			DOCUMENTATION_CLOUDFRONT_DOMAIN: "d123.cloudfront.net",
+			DOCUMENTATION_CLOUDFRONT_KEY_PAIR_ID: "KTESTKEY",
+			DOCUMENTATION_CLOUDFRONT_PRIVATE_KEY:
+				"-----BEGIN PRIVATE KEY----- abc def ghi -----END PRIVATE KEY-----",
+		};
+
+		mockGetSignedUrl.mockReturnValue(
+			"https://d123.cloudfront.net/videos/foo.mp4?Expires=1&Signature=abc",
+		);
+
+		let createDocumentationVideoSignedUrl: typeof import("../../utils/documentation-video-url").createDocumentationVideoSignedUrl;
+		jest.isolateModules(() => {
+			({ createDocumentationVideoSignedUrl } = require("../../utils/documentation-video-url"));
+		});
+
+		await createDocumentationVideoSignedUrl!("videos/foo.mp4");
+
+		expect(mockGetSignedUrl).toHaveBeenCalledWith(
+			expect.objectContaining({
+				privateKey: "-----BEGIN PRIVATE KEY-----\nabcdefghi\n-----END PRIVATE KEY-----",
+			}),
+		);
+	});
 });

--- a/src/utils/documentation-video-url.ts
+++ b/src/utils/documentation-video-url.ts
@@ -24,7 +24,23 @@ const CLOUDFRONT_URL_EXPIRES_IN_SECONDS = parsePositiveInteger(
 const isCloudFrontSigningConfigured = (): boolean =>
 	Boolean(cloudFrontDomain && cloudFrontKeyPairId && cloudFrontPrivateKeyEnv);
 
-const normalizePrivateKey = (raw: string): string => raw.replace(/\\n/g, "\n").trim();
+const wrapPemBody = (body: string): string => {
+	const compactBody = body.replace(/\s+/g, "");
+	const chunks = compactBody.match(/.{1,64}/g) ?? [];
+	return chunks.join("\n");
+};
+
+const normalizePrivateKey = (raw: string): string => {
+	const normalizedNewlines = raw.replace(/\\n/g, "\n").trim();
+	const pemMatch = normalizedNewlines.match(
+		/^(-----BEGIN (?:RSA )?PRIVATE KEY-----)\s+([\s\S]+?)\s+(-----END (?:RSA )?PRIVATE KEY-----)$/,
+	);
+
+	if (!pemMatch) return normalizedNewlines;
+
+	const [, header, body, footer] = pemMatch;
+	return `${header}\n${wrapPemBody(body)}\n${footer}`;
+};
 
 const buildCloudFrontObjectUrl = (objectKey: string): string => {
 	if (!cloudFrontDomain) {


### PR DESCRIPTION
- Normalize CloudFront private key PEM formatting for documentation video signed URLs.\n- Add immutable cache headers for seeded video uploads and document the key-pair requirements.