### PR TITLE
Add usage tracking and billing enforcement

### DIFF
--- a/src/controllers/billing/getSummary.ts
+++ b/src/controllers/billing/getSummary.ts
@@ -1,0 +1,47 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
+import { getBillingAccountByWorkspaceId } from '../../utils/billing/billingAccounts';
+import { buildBillingSummary } from '../../utils/billing/serializers';
+import { getWorkspaceById } from '../../utils/billing/enforcement';
+import { serializeWorkspaceFreezes } from '../../utils/billing/serializers';
+
+/**
+ * Returns workspace billing summary for workspace admins.
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Workspace billing summary payload
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const tenantResult = await requireTenantContext(event, { allowAccessFrozen: true });
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
+		}
+
+		const account = await getBillingAccountByWorkspaceId(context.workspaceId);
+		if (!account) {
+			return ResponseWrapper.notFound('Billing account not found');
+		}
+
+		const workspace = await getWorkspaceById(context.workspaceId);
+		const summary = await buildBillingSummary({
+			account,
+			workspaceId: context.workspaceId,
+		});
+
+		return ResponseWrapper.success({
+			message: 'Billing summary retrieved',
+			data: {
+				...summary,
+				freezes: workspace ? serializeWorkspaceFreezes(workspace) : null,
+			},
+		});
+	} catch (error) {
+		logError('Get billing summary failed', error);
+		return ResponseWrapper.internalServerError('Failed to load billing summary');
+	}
+};

--- a/src/controllers/billing/updatePreferences.ts
+++ b/src/controllers/billing/updatePreferences.ts
@@ -1,0 +1,72 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import {
+	BILLING_ACCOUNTS_COLLECTION,
+	type BillingAccount,
+	type EnforcementMode,
+} from '../../models/billing';
+import { getDb } from '../../utils/db';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
+import { getBillingAccountByWorkspaceId } from '../../utils/billing/billingAccounts';
+import { serializeBillingAccount } from '../../utils/billing/serializers';
+
+const isEnforcementMode = (value: unknown): value is EnforcementMode =>
+	value === 'overage' || value === 'block';
+
+/**
+ * Updates workspace billing preferences allowed for workspace admins.
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Billing preferences updated payload
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
+		if (!isWorkspaceAdmin(context.cognitoGroups)) {
+			return ResponseWrapper.forbidden('Insufficient permissions');
+		}
+
+		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
+
+		let input: { enforcementMode?: unknown };
+		try {
+			input = JSON.parse(event.body);
+		} catch {
+			return ResponseWrapper.badRequest('Invalid JSON in request body');
+		}
+
+		if (!isEnforcementMode(input.enforcementMode)) {
+			return ResponseWrapper.badRequest("enforcementMode must be 'overage' or 'block'");
+		}
+
+		const account = await getBillingAccountByWorkspaceId(context.workspaceId);
+		if (!account) return ResponseWrapper.notFound('Billing account not found');
+
+		const now = new Date();
+		const db = await getDb();
+		const updated = await db.collection(BILLING_ACCOUNTS_COLLECTION).findOneAndUpdate(
+			{ _id: account._id },
+			{
+				$set: {
+					'workspacePreferences.enforcementMode': input.enforcementMode,
+					updatedAt: now,
+				},
+			},
+			{ returnDocument: 'after' },
+		);
+
+		if (!updated) return ResponseWrapper.notFound('Billing account not found');
+
+		return ResponseWrapper.success({
+			message: 'Billing preferences updated',
+			data: serializeBillingAccount(updated as BillingAccount & { _id: ObjectId }),
+		});
+	} catch (error) {
+		logError('Update billing preferences failed', error);
+		return ResponseWrapper.internalServerError('Failed to update billing preferences');
+	}
+};

--- a/src/controllers/departments/createDepartment.ts
+++ b/src/controllers/departments/createDepartment.ts
@@ -7,6 +7,7 @@ import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
 import { recordAuditEvent } from '../../utils/auditLogV2';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
 import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 
 /**
@@ -89,6 +90,14 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			meta: {
 				departmentName: input.department_name,
 			},
+		});
+
+		await recordCommittedUploadIfNew({
+			workspaceId: workspaceObjectId,
+			previousKey: '',
+			newKey: normalizedDepartmentImage,
+			sizeBytes: input.imageSizeBytes ?? input.sizeBytes,
+			metadata: { assetType: 'department_image' },
 		});
 
 		return ResponseWrapper.created({

--- a/src/controllers/departments/updateDepartment.ts
+++ b/src/controllers/departments/updateDepartment.ts
@@ -7,6 +7,7 @@ import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
 import { recordAuditEvent } from '../../utils/auditLogV2';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
 import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 
 /**
@@ -111,6 +112,15 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			meta: {
 				departmentName: input.department_name,
 			},
+		});
+
+		await recordCommittedUploadIfNew({
+			workspaceId: context.workspaceId,
+			previousKey: departmentRecord.image,
+			newKey: normalizedDepartmentImage,
+			sizeBytes: (input as Department & { imageSizeBytes?: number; sizeBytes?: number }).imageSizeBytes
+				?? (input as { sizeBytes?: number }).sizeBytes,
+			metadata: { assetType: 'department_image' },
 		});
 
 		return ResponseWrapper.success({

--- a/src/controllers/onboarding/InviteNewUserByAdmin.ts
+++ b/src/controllers/onboarding/InviteNewUserByAdmin.ts
@@ -8,8 +8,21 @@ import { logError } from '../../utils/logger';
 import { validateUserArray } from "../../utils/validationUtils";
 import { Workspace } from "../../models/workspace";
 import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext } from "../../utils/tenantContext";
+import { assertUsageActionAllowed } from "../../utils/billing/enforcement";
+import {
+	assertEmailAvailableForWorkspaceMemberInvite,
+	InviteEmailConflictError,
+	normalizeInviteEmail,
+} from "../../utils/platformInviteUtils";
+import { findInactiveWorkspaceUserByEmail, reactivateWorkspaceUser } from "../../utils/userRemoval";
 
 const cognito = new CognitoIdentityProviderClient({ region: 'us-east-1' });
+
+type InviteResult = {
+	email: string;
+	status: 'Success' | 'Failed' | 'Reactivated';
+	reason?: string;
+};
 
 /**
  * @param {APIGatewayProxyEvent} event 
@@ -42,22 +55,41 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 		const validationError = validateUserArray(users, "users");
 		if(validationError) return validationError;
 
+		const inviteCheck = await assertUsageActionAllowed(context.workspaceId, 'invite');
+		if (!inviteCheck.allowed) return ResponseWrapper.forbidden(inviteCheck.reason);
+
 		const db = await getDb();
 		const workspaceObjectId = context.workspaceId;
-		const results = [];
+		const results: InviteResult[] = [];
 
 		for (const user of users) {
 			const { email, name } = user;
+			const normalizedEmail = normalizeInviteEmail(email);
 			try {
+				await assertEmailAvailableForWorkspaceMemberInvite(db, normalizedEmail, workspaceObjectId);
+
+				const inactiveUser = await findInactiveWorkspaceUserByEmail(db, normalizedEmail, workspaceObjectId);
+				if (inactiveUser) {
+					await reactivateWorkspaceUser({
+						email: normalizedEmail,
+						name,
+						workspaceId: workspaceObjectId,
+						actorUserId: context.userId,
+						userType: inactiveUser.userType ?? 'user',
+					});
+					results.push({ email: normalizedEmail, status: 'Reactivated' });
+					continue;
+				}
+
 				const createUserResponse = await cognito.send(new AdminCreateUserCommand({
 					UserPoolId: process.env.USER_POOL_ID,
-					Username: email,
+					Username: normalizedEmail,
 					UserAttributes: [{ Name: "name", Value: name }],
 					DesiredDeliveryMediums: [ "EMAIL"],
 				}));
 		      
 				const newCognitoUser = createUserResponse.User;
-				if (!newCognitoUser) throw new Error(`Failed to create Cognito user for ${email}`);
+				if (!newCognitoUser) throw new Error(`Failed to create Cognito user for ${normalizedEmail}`);
 
 
 				const cognitoSub = newCognitoUser.Attributes?.find(attr => attr.Name === "sub")?.Value;
@@ -65,7 +97,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
 
 				const newUserDoc: User = {
-					email: email,
+					email: normalizedEmail,
 					name: name,
 					cognitoSub: cognitoSub,
 					workspaceId: workspaceObjectId,
@@ -82,7 +114,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 		      
 				await cognito.send(new AdminUpdateUserAttributesCommand({
 					UserPoolId: process.env.USER_POOL_ID,
-					Username: email,
+					Username: normalizedEmail,
 					UserAttributes: [
 						{ Name: "custom:userId", Value: dbUserId },
 						{ Name: "custom:workspaceId", Value: workspaceObjectId.toString() },
@@ -92,14 +124,20 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
 				await cognito.send(new AdminAddUserToGroupCommand({
 					UserPoolId: process.env.USER_POOL_ID!,
-					Username: email,
+					Username: normalizedEmail,
 					GroupName: "user",
 				}));
 
-				results.push({ email, status: "Success" });
-			} catch (error: any) {
-				logError(`Failed to invite user: ${email}`, error);
-				results.push({ email, status: "Failed", reason: error.message || 'Invitation failed' });
+				results.push({ email: normalizedEmail, status: "Success" });
+			} catch (error: unknown) {
+				if (error instanceof InviteEmailConflictError) {
+					results.push({ email: normalizedEmail, status: "Failed", reason: error.message });
+					continue;
+				}
+
+				const message = error instanceof Error ? error.message : 'Invitation failed';
+				logError(`Failed to invite user: ${normalizedEmail}`, error);
+				results.push({ email: normalizedEmail, status: "Failed", reason: message });
 			}
 		}
 

--- a/src/controllers/onboarding/adminOnboardingCreateWorkspace.ts
+++ b/src/controllers/onboarding/adminOnboardingCreateWorkspace.ts
@@ -10,6 +10,9 @@ import { authenticateWithRole } from "../../utils/authUtils";
 import { User } from "../../models/user";
 import { AdminAddUserToGroupCommand, AdminUpdateUserAttributesCommand, CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
 import { movePendingWorkspaceAssetToWorkspace, normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { createBillingAccountForWorkspace } from '../../utils/billing/billingAccounts';
+import { assertSeatActivationAllowed } from '../../utils/billing/enforcement';
+import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
 
 const cognito = new CognitoIdentityProviderClient();
 
@@ -73,7 +76,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			userIds: [],
 		});
 
-		const workspaceId = workspace.insertedId
+		const workspaceId = workspace.insertedId;
+
+		await createBillingAccountForWorkspace(workspaceId);
 
 		const workspaceLogo = normalizedLogo
 			? await movePendingWorkspaceAssetToWorkspace(normalizedLogo, workspaceId.toString())
@@ -86,6 +91,16 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			);
 		}
 
+		if (workspaceLogo) {
+			await recordCommittedUploadIfNew({
+				workspaceId,
+				previousKey: '',
+				newKey: workspaceLogo,
+				sizeBytes: input.logoSizeBytes ?? input.sizeBytes,
+				metadata: { assetType: 'workspace_logo' },
+			});
+		}
+
 		await updateAuditLog({
 			entity: 'workspace',
 			entityId: workspaceId.toString(),
@@ -94,6 +109,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actionAt: new Date(),
 			active: true,
 		});
+
+		const seatCheck = await assertSeatActivationAllowed(workspaceId, 1);
+		if (!seatCheck.allowed) return ResponseWrapper.forbidden(seatCheck.reason);
 
 		const user = await db.collection<User>('users').insertOne({
 			name: adminName,
@@ -135,7 +153,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			Username: normalizedEmail,
 			GroupName: "admin",
 		}));
-		
 
 		return ResponseWrapper.created({
 			message: 'Onboarding successful, workspace created',

--- a/src/controllers/onboarding/onboardAndUpdateInvitedUser.ts
+++ b/src/controllers/onboarding/onboardAndUpdateInvitedUser.ts
@@ -7,6 +7,8 @@ import { validateMissingFields } from "../../utils/validationUtils";
 import { updateAuditLog } from "../../utils/auditLog";
 import { AuditLogAction } from "../../models/auditLog";
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { assertSeatActivationAllowed } from '../../utils/billing/enforcement';
+import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
 
 /**
  * @param {APIGatewayProxyEvent} event
@@ -30,12 +32,27 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
 		const db = await getDb();
 
+		const existingUser = await db.collection('users').findOne({
+			cognitoSub: context.cognitoSub,
+			workspaceId: context.workspaceId,
+		});
+
+		const normalizedAvatar = normalizePersistedAssetReference(
+			input.profileAvatar,
+			typeof existingUser?.profileAvatar === 'string' ? existingUser.profileAvatar : '',
+		);
+
+		if (existingUser?.status !== 'active') {
+			const seatCheck = await assertSeatActivationAllowed(context.workspaceId, 1);
+			if (!seatCheck.allowed) return ResponseWrapper.forbidden(seatCheck.reason);
+		}
+
 		const updateResult = await db.collection("users").updateOne(
 			{ cognitoSub: context.cognitoSub, workspaceId: context.workspaceId },
 			{
 				$set: {
 					name: input.name,
-					profileAvatar: normalizePersistedAssetReference(input.profileAvatar, ''),
+					profileAvatar: normalizedAvatar,
 					designation: input.designation || '',
 					location: input.location || '',
 					status: 'active',
@@ -51,9 +68,17 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 			entity: 'user',
 			entityId: context.userId.toString(),
 			action: AuditLogAction.UPDATE,
-			actionBy: input.name,
 			actionAt: new Date(),
 			active: true,
+			actionBy: input.name,
+		});
+
+		await recordCommittedUploadIfNew({
+			workspaceId: context.workspaceId,
+			previousKey: typeof existingUser?.profileAvatar === 'string' ? existingUser.profileAvatar : '',
+			newKey: normalizedAvatar,
+			sizeBytes: input.profileAvatarSizeBytes ?? input.sizeBytes,
+			metadata: { assetType: 'profile_avatar' },
 		});
 
 		return ResponseWrapper.success({ message: "Profile updated successfully." });

--- a/src/controllers/onboarding/onboardAndUpdateInvitedUser.ts
+++ b/src/controllers/onboarding/onboardAndUpdateInvitedUser.ts
@@ -7,7 +7,7 @@ import { validateMissingFields } from "../../utils/validationUtils";
 import { updateAuditLog } from "../../utils/auditLog";
 import { AuditLogAction } from "../../models/auditLog";
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
-import { assertSeatActivationAllowed } from '../../utils/billing/enforcement';
+import { assertSeatActivationAllowed, verifySeatLimitAfterActivation } from '../../utils/billing/enforcement';
 import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
 
 /**
@@ -42,7 +42,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 			typeof existingUser?.profileAvatar === 'string' ? existingUser.profileAvatar : '',
 		);
 
-		if (existingUser?.status !== 'active') {
+		const previousStatus = existingUser?.status ?? 'invited';
+		const activatingUser = previousStatus !== 'active';
+
+		if (activatingUser) {
 			const seatCheck = await assertSeatActivationAllowed(context.workspaceId, 1);
 			if (!seatCheck.allowed) return ResponseWrapper.forbidden(seatCheck.reason);
 		}
@@ -62,6 +65,17 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
 		if (updateResult.matchedCount === 0) {
 			return ResponseWrapper.notFound("User not found or no changes were made.");
+		}
+
+		if (activatingUser) {
+			const postActivationCheck = await verifySeatLimitAfterActivation(context.workspaceId);
+			if (!postActivationCheck.allowed) {
+				await db.collection("users").updateOne(
+					{ cognitoSub: context.cognitoSub, workspaceId: context.workspaceId },
+					{ $set: { status: previousStatus } },
+				);
+				return ResponseWrapper.forbidden(postActivationCheck.reason);
+			}
 		}
         
 		await updateAuditLog({

--- a/src/controllers/platformAdmin/createBillingAccount.ts
+++ b/src/controllers/platformAdmin/createBillingAccount.ts
@@ -1,0 +1,85 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import { Workspace } from '../../models/workspace';
+import { getDb } from '../../utils/db';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { requirePlatformOperator } from '../../utils/platformAdminContext';
+import { recordPlatformAuditEvent } from '../../utils/platformAuditLog';
+import {
+	createBillingAccountForWorkspace,
+	getBillingAccountByWorkspaceId,
+} from '../../utils/billing/billingAccounts';
+import {
+	buildBillingSummary,
+	serializeBillingAccount,
+	serializeUsageSnapshot,
+	serializeWorkspaceFreezes,
+} from '../../utils/billing/serializers';
+import { getCurrentUsageSnapshot } from '../../utils/billing/snapshots';
+
+/**
+ * Creates a draft billing account for a workspace that does not have one yet.
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Billing account created payload
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const operatorResult = await requirePlatformOperator(event);
+		if (!operatorResult.ok) return operatorResult.response;
+
+		const workspaceId = event.pathParameters?.workspaceId;
+		if (!workspaceId || !ObjectId.isValid(workspaceId)) {
+			return ResponseWrapper.badRequest('workspaceId must be a valid ObjectId');
+		}
+
+		const workspaceObjectId = new ObjectId(workspaceId);
+		const db = await getDb();
+		const workspace = await db.collection<Workspace>('workspaces').findOne({ _id: workspaceObjectId });
+		if (!workspace) return ResponseWrapper.notFound('Workspace not found');
+
+		const existing = await getBillingAccountByWorkspaceId(workspaceObjectId);
+		const created = !existing;
+		const account = existing ?? (await createBillingAccountForWorkspace(workspaceObjectId));
+
+		const snapshot = await getCurrentUsageSnapshot({
+			workspaceId: workspaceObjectId,
+			billingAccount: account,
+			recomputeIfStale: created,
+		});
+
+		const summary = await buildBillingSummary({
+			account,
+			workspaceId: workspaceObjectId,
+		});
+
+		const { auth, operator } = operatorResult.context;
+		if (created) {
+			await recordPlatformAuditEvent({
+				action: 'billing.account.update',
+				targetType: 'billing_account',
+				workspaceId: workspaceObjectId,
+				entityId: account._id.toString(),
+				summary: `Created billing account for ${workspace.workspaceName}`,
+				changes: [{ path: 'status', to: account.status }],
+				auth: auth.payload,
+				operator,
+				event,
+				source: 'platform-admin-portal',
+			});
+		}
+
+		return ResponseWrapper.success({
+			message: created ? 'Billing account created' : 'Billing account already exists',
+			data: {
+				account: serializeBillingAccount(account),
+				summary,
+				snapshot: snapshot?._id ? serializeUsageSnapshot(snapshot) : null,
+				freezes: serializeWorkspaceFreezes(workspace),
+			},
+		});
+	} catch (error) {
+		logError('Platform admin create billing account failed', error);
+		return ResponseWrapper.internalServerError('Failed to create billing account');
+	}
+};

--- a/src/controllers/platformAdmin/createUsageAdjustment.ts
+++ b/src/controllers/platformAdmin/createUsageAdjustment.ts
@@ -1,0 +1,116 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import {
+	USAGE_ADJUSTMENTS_COLLECTION,
+	type BillingUsageMetric,
+	type UsageAdjustment,
+	type UsageUnit,
+} from '../../models/billing';
+import { Workspace } from '../../models/workspace';
+import { getDb } from '../../utils/db';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { requirePlatformOperator } from '../../utils/platformAdminContext';
+import { recordPlatformAuditEvent } from '../../utils/platformAuditLog';
+import { getBillingAccountByWorkspaceId } from '../../utils/billing/billingAccounts';
+import { resolveBillingPeriod } from '../../utils/billing/billingPeriod';
+import { recordUsageEvent } from '../../utils/billing/usageRecording';
+import { serializeUsageAdjustment } from '../../utils/billing/serializers';
+
+const METRICS: BillingUsageMetric[] = ['completed_export', 'upload_bytes'];
+
+/**
+ * Creates a platform usage adjustment and records a matching usage event.
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Usage adjustment created payload
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const operatorResult = await requirePlatformOperator(event);
+		if (!operatorResult.ok) return operatorResult.response;
+
+		const workspaceId = event.pathParameters?.workspaceId;
+		if (!workspaceId || !ObjectId.isValid(workspaceId)) {
+			return ResponseWrapper.badRequest('workspaceId must be a valid ObjectId');
+		}
+
+		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
+
+		let input: { metric?: BillingUsageMetric; quantityDelta?: number };
+		try {
+			input = JSON.parse(event.body);
+		} catch {
+			return ResponseWrapper.badRequest('Invalid JSON in request body');
+		}
+
+		if (!input.metric || !METRICS.includes(input.metric)) {
+			return ResponseWrapper.badRequest('Invalid usage metric');
+		}
+		if (typeof input.quantityDelta !== 'number' || !Number.isFinite(input.quantityDelta) || input.quantityDelta === 0) {
+			return ResponseWrapper.badRequest('quantityDelta must be a non-zero number');
+		}
+
+		const workspaceObjectId = new ObjectId(workspaceId);
+		const db = await getDb();
+		const workspace = await db.collection<Workspace>('workspaces').findOne({ _id: workspaceObjectId });
+		if (!workspace) return ResponseWrapper.notFound('Workspace not found');
+
+		const account = await getBillingAccountByWorkspaceId(workspaceObjectId);
+		if (!account) return ResponseWrapper.notFound('Billing account not found');
+
+		const { periodStart, periodEnd } = resolveBillingPeriod(account);
+		const unit: UsageUnit = input.metric === 'upload_bytes' ? 'bytes' : 'count';
+		const now = new Date();
+		const { operator } = operatorResult.context;
+
+		const adjustment: UsageAdjustment = {
+			workspaceId: workspaceObjectId,
+			billingAccountId: account._id,
+			metric: input.metric,
+			quantityDelta: input.quantityDelta,
+			unit,
+			billingPeriodStart: periodStart,
+			billingPeriodEnd: periodEnd,
+			createdByPlatformAdminId: operator._id!,
+			createdAt: now,
+		};
+
+		const insertResult = await db.collection<UsageAdjustment>(USAGE_ADJUSTMENTS_COLLECTION).insertOne(adjustment);
+		const adjustmentId = insertResult.insertedId;
+
+		await recordUsageEvent({
+			workspaceId: workspaceObjectId,
+			billingAccountId: account._id,
+			metric: input.metric,
+			quantity: input.quantityDelta,
+			unit,
+			source: 'platform_adjustment',
+			sourceId: adjustmentId.toString(),
+			idempotencyKey: `adjustment:${adjustmentId.toString()}`,
+			occurredAt: now,
+			billingPeriodStart: periodStart,
+			billingPeriodEnd: periodEnd,
+		});
+
+		const { auth } = operatorResult.context;
+		await recordPlatformAuditEvent({
+			action: 'usage.adjustment.create',
+			targetType: 'usage_event',
+			workspaceId: workspaceObjectId,
+			entityId: adjustmentId.toString(),
+			summary: `Created usage adjustment for ${workspace.workspaceName}`,
+			auth: auth.payload,
+			operator,
+			event,
+			source: 'platform-admin-portal',
+		});
+
+		return ResponseWrapper.created({
+			message: 'Usage adjustment created',
+			data: serializeUsageAdjustment({ ...adjustment, _id: adjustmentId }),
+		});
+	} catch (error) {
+		logError('Platform admin create usage adjustment failed', error);
+		return ResponseWrapper.internalServerError('Failed to create usage adjustment');
+	}
+};

--- a/src/controllers/platformAdmin/getBillingAccount.ts
+++ b/src/controllers/platformAdmin/getBillingAccount.ts
@@ -1,0 +1,77 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import { Workspace } from '../../models/workspace';
+import { getDb } from '../../utils/db';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { requirePlatformOperator } from '../../utils/platformAdminContext';
+import { recordPlatformAuditEvent } from '../../utils/platformAuditLog';
+import { getBillingAccountByWorkspaceId } from '../../utils/billing/billingAccounts';
+import {
+	buildBillingSummary,
+	serializeBillingAccount,
+	serializeUsageSnapshot,
+	serializeWorkspaceFreezes,
+} from '../../utils/billing/serializers';
+import { getCurrentUsageSnapshot } from '../../utils/billing/snapshots';
+
+/**
+ * Returns full billing account detail for a workspace.
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Billing account retrieved payload
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const operatorResult = await requirePlatformOperator(event);
+		if (!operatorResult.ok) return operatorResult.response;
+
+		const workspaceId = event.pathParameters?.workspaceId;
+		if (!workspaceId || !ObjectId.isValid(workspaceId)) {
+			return ResponseWrapper.badRequest('workspaceId must be a valid ObjectId');
+		}
+
+		const workspaceObjectId = new ObjectId(workspaceId);
+		const db = await getDb();
+		const workspace = await db.collection<Workspace>('workspaces').findOne({ _id: workspaceObjectId });
+		if (!workspace) return ResponseWrapper.notFound('Workspace not found');
+
+		const account = await getBillingAccountByWorkspaceId(workspaceObjectId);
+		if (!account) return ResponseWrapper.notFound('Billing account not found');
+
+		const snapshot = await getCurrentUsageSnapshot({
+			workspaceId: workspaceObjectId,
+			billingAccount: account,
+		});
+
+		const summary = await buildBillingSummary({
+			account,
+			workspaceId: workspaceObjectId,
+		});
+
+		const { auth, operator } = operatorResult.context;
+		await recordPlatformAuditEvent({
+			action: 'billing.account.view',
+			targetType: 'billing_account',
+			workspaceId: workspaceObjectId,
+			entityId: account._id.toString(),
+			summary: `Viewed billing account for ${workspace.workspaceName}`,
+			auth: auth.payload,
+			operator,
+			event,
+			source: 'platform-admin-portal',
+		});
+
+		return ResponseWrapper.success({
+			message: 'Billing account retrieved',
+			data: {
+				account: serializeBillingAccount(account),
+				summary,
+				snapshot: snapshot?._id ? serializeUsageSnapshot(snapshot) : null,
+				freezes: serializeWorkspaceFreezes(workspace),
+			},
+		});
+	} catch (error) {
+		logError('Platform admin get billing account failed', error);
+		return ResponseWrapper.internalServerError('Failed to load billing account');
+	}
+};

--- a/src/controllers/platformAdmin/getSummary.ts
+++ b/src/controllers/platformAdmin/getSummary.ts
@@ -3,6 +3,7 @@ import { getDb } from '../../utils/db';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { requirePlatformOperator } from '../../utils/platformAdminContext';
+import { BILLING_ACCOUNTS_COLLECTION } from '../../models/billing';
 
 /**
  * Returns platform-wide dashboard summary counts.
@@ -21,11 +22,17 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			activeUsers,
 			invitedUsers,
 			workspaceAdmins,
+			billingAccounts,
+			pastDueWorkspaces,
+			meteringEnabledWorkspaces,
 		] = await Promise.all([
 			db.collection('workspaces').countDocuments({}),
 			db.collection('users').countDocuments({ status: 'active', workspaceId: { $ne: null } }),
 			db.collection('users').countDocuments({ status: 'invited', workspaceId: { $ne: null } }),
 			db.collection('users').countDocuments({ userType: 'admin', workspaceId: { $ne: null } }),
+			db.collection(BILLING_ACCOUNTS_COLLECTION).countDocuments({}),
+			db.collection(BILLING_ACCOUNTS_COLLECTION).countDocuments({ pastDue: true }),
+			db.collection(BILLING_ACCOUNTS_COLLECTION).countDocuments({ meteringEnabled: true }),
 		]);
 
 		return ResponseWrapper.success({
@@ -36,9 +43,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				invitedUsers,
 				workspaceAdmins,
 				billing: {
-					accountsLinked: null,
-					pastDueWorkspaces: null,
-					meteringEnabledWorkspaces: null,
+					accountsLinked: billingAccounts,
+					pastDueWorkspaces,
+					limitsEnabledWorkspaces: meteringEnabledWorkspaces,
+					meteringEnabledWorkspaces,
 				},
 			},
 		});

--- a/src/controllers/platformAdmin/getWorkspaceDetail.ts
+++ b/src/controllers/platformAdmin/getWorkspaceDetail.ts
@@ -13,10 +13,11 @@ import {
 import { Workspace } from '../../models/workspace';
 import { User } from '../../models/user';
 import {
-	emptyBillingPreview,
 	serializePlatformAuditLog,
 	serializeWorkspaceAdmin,
 } from '../../utils/platformAdminSerializers';
+import { getBillingAccountByWorkspaceId } from '../../utils/billing/billingAccounts';
+import { serializeWorkspaceBillingPreview, serializeWorkspaceFreezes } from '../../utils/billing/serializers';
 
 /**
  * Returns workspace profile, admin list, billing preview, and recent platform audit events.
@@ -39,7 +40,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const workspace = await db.collection<Workspace>('workspaces').findOne({ _id: workspaceObjectId });
 		if (!workspace) return ResponseWrapper.notFound('Workspace not found');
 
-		const [admins, memberCount, activeCount, invitedCount, recentAuditLogs] = await Promise.all([
+		const [admins, memberCount, activeCount, invitedCount, recentAuditLogs, billingAccount] = await Promise.all([
 			db.collection<User>('users').find({
 				workspaceId: workspaceObjectId,
 				userType: 'admin',
@@ -55,6 +56,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				.sort({ occurredAt: -1 })
 				.limit(20)
 				.toArray(),
+			getBillingAccountByWorkspaceId(workspaceObjectId),
 		]);
 
 		const { auth, operator } = operatorResult.context;
@@ -87,7 +89,8 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 					admins: admins.length,
 				},
 				admins: admins.map((admin) => serializeWorkspaceAdmin(admin as User & { _id: ObjectId })),
-				billing: emptyBillingPreview(),
+				billing: serializeWorkspaceBillingPreview(billingAccount),
+				freezes: serializeWorkspaceFreezes(workspace),
 				recentAuditLogs: recentAuditLogs.map(serializePlatformAuditLog),
 			},
 		});

--- a/src/controllers/platformAdmin/inviteWorkspaceAdmin.ts
+++ b/src/controllers/platformAdmin/inviteWorkspaceAdmin.ts
@@ -12,6 +12,7 @@ import {
 	AdminUpdateUserAttributesCommand,
 	CognitoIdentityProviderClient,
 } from '@aws-sdk/client-cognito-identity-provider';
+import { assertUsageActionAllowed } from '../../utils/billing/enforcement';
 import {
 	assertEmailAvailableForWorkspaceAdminInvite,
 	createInvitedCognitoUser,
@@ -54,6 +55,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const workspace = await db.collection<Workspace>('workspaces').findOne({ _id: workspaceObjectId });
 		if (!workspace) return ResponseWrapper.notFound('Workspace not found');
+
+		const inviteCheck = await assertUsageActionAllowed(workspaceObjectId, 'invite');
+		if (!inviteCheck.allowed) return ResponseWrapper.forbidden(inviteCheck.reason);
 
 		try {
 			await assertEmailAvailableForWorkspaceAdminInvite(db, normalizedEmail, workspaceObjectId);

--- a/src/controllers/platformAdmin/listUsageEvents.ts
+++ b/src/controllers/platformAdmin/listUsageEvents.ts
@@ -1,0 +1,61 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import { USAGE_EVENTS_COLLECTION, type UsageEvent } from '../../models/billing';
+import { getDb } from '../../utils/db';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { requirePlatformOperator } from '../../utils/platformAdminContext';
+import { serializeUsageEvent } from '../../utils/billing/serializers';
+
+/**
+ * Lists usage events for a workspace.
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const operatorResult = await requirePlatformOperator(event);
+		if (!operatorResult.ok) return operatorResult.response;
+
+		const workspaceId = event.pathParameters?.workspaceId;
+		if (!workspaceId || !ObjectId.isValid(workspaceId)) {
+			return ResponseWrapper.badRequest('workspaceId must be a valid ObjectId');
+		}
+
+		const page = Math.max(1, Number.parseInt(event.queryStringParameters?.page ?? '1', 10) || 1);
+		const limit = Math.min(50, Math.max(1, Number.parseInt(event.queryStringParameters?.limit ?? '20', 10) || 20));
+		const skip = (page - 1) * limit;
+		const metric = event.queryStringParameters?.metric;
+
+		const workspaceObjectId = new ObjectId(workspaceId);
+		const db = await getDb();
+		const query: Record<string, unknown> = { workspaceId: workspaceObjectId };
+		if (metric) query.metric = metric;
+
+		const [events, total] = await Promise.all([
+			db.collection<UsageEvent>(USAGE_EVENTS_COLLECTION)
+				.find(query)
+				.sort({ occurredAt: -1 })
+				.skip(skip)
+				.limit(limit)
+				.toArray(),
+			db.collection<UsageEvent>(USAGE_EVENTS_COLLECTION).countDocuments(query),
+		]);
+
+		return ResponseWrapper.success({
+			message: 'Usage events retrieved',
+			data: {
+				items: events
+					.filter((item): item is UsageEvent & { _id: ObjectId } => Boolean(item._id))
+					.map(serializeUsageEvent),
+				pagination: {
+					page,
+					limit,
+					total,
+					totalPages: Math.max(1, Math.ceil(total / limit)),
+				},
+			},
+		});
+	} catch (error) {
+		logError('Platform admin list usage events failed', error);
+		return ResponseWrapper.internalServerError('Failed to list usage events');
+	}
+};

--- a/src/controllers/platformAdmin/listWorkspaces.ts
+++ b/src/controllers/platformAdmin/listWorkspaces.ts
@@ -5,6 +5,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { requirePlatformOperator } from '../../utils/platformAdminContext';
 import { buildListFiltersMatch, parseListQuery } from '../../utils/listQuery';
+import { BILLING_ACCOUNTS_COLLECTION, type BillingAccount } from '../../models/billing';
 import { Workspace } from '../../models/workspace';
 import { serializeWorkspaceListItem } from '../../utils/platformAdminSerializers';
 
@@ -89,13 +90,25 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const [result] = await db.collection<Workspace>('workspaces').aggregate(pipeline).toArray();
 		const items = (result?.items ?? []) as Array<Workspace & { _id: ObjectId; memberCount: number }>;
 		const total = result?.total?.[0]?.count ?? 0;
+		const workspaceIds = items.map((workspace) => workspace._id).filter(Boolean);
+		const billingAccounts = workspaceIds.length
+			? await db.collection<BillingAccount>(BILLING_ACCOUNTS_COLLECTION)
+				.find({ workspaceId: { $in: workspaceIds } })
+				.toArray()
+			: [];
+		const billingByWorkspaceId = new Map(
+			billingAccounts.map((account) => [account.workspaceId.toString(), account]),
+		);
 
 		return ResponseWrapper.success({
 			message: 'Workspaces retrieved',
 			data: {
 				items: items
 					.filter((workspace): workspace is Workspace & { _id: ObjectId; memberCount: number } => Boolean(workspace._id))
-					.map((workspace) => serializeWorkspaceListItem(workspace)),
+					.map((workspace) => serializeWorkspaceListItem(
+						workspace,
+						billingByWorkspaceId.get(workspace._id.toString()) ?? null,
+					)),
 				pagination: {
 					page,
 					limit,

--- a/src/controllers/platformAdmin/recomputeUsageSnapshot.ts
+++ b/src/controllers/platformAdmin/recomputeUsageSnapshot.ts
@@ -1,0 +1,46 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import { Workspace } from '../../models/workspace';
+import { getDb } from '../../utils/db';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { requirePlatformOperator } from '../../utils/platformAdminContext';
+import { getBillingAccountByWorkspaceId } from '../../utils/billing/billingAccounts';
+import { recomputeUsageSnapshot } from '../../utils/billing/snapshots';
+import { serializeUsageSnapshot } from '../../utils/billing/serializers';
+
+/**
+ * Recomputes the current billing period usage snapshot for a workspace.
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const operatorResult = await requirePlatformOperator(event);
+		if (!operatorResult.ok) return operatorResult.response;
+
+		const workspaceId = event.pathParameters?.workspaceId;
+		if (!workspaceId || !ObjectId.isValid(workspaceId)) {
+			return ResponseWrapper.badRequest('workspaceId must be a valid ObjectId');
+		}
+
+		const workspaceObjectId = new ObjectId(workspaceId);
+		const db = await getDb();
+		const workspace = await db.collection<Workspace>('workspaces').findOne({ _id: workspaceObjectId });
+		if (!workspace) return ResponseWrapper.notFound('Workspace not found');
+
+		const account = await getBillingAccountByWorkspaceId(workspaceObjectId);
+		if (!account) return ResponseWrapper.notFound('Billing account not found');
+
+		const snapshot = await recomputeUsageSnapshot({
+			workspaceId: workspaceObjectId,
+			billingAccount: account,
+		});
+
+		return ResponseWrapper.success({
+			message: 'Usage snapshot recomputed',
+			data: serializeUsageSnapshot(snapshot),
+		});
+	} catch (error) {
+		logError('Platform admin recompute usage snapshot failed', error);
+		return ResponseWrapper.internalServerError('Failed to recompute usage snapshot');
+	}
+};

--- a/src/controllers/platformAdmin/runReconciliation.ts
+++ b/src/controllers/platformAdmin/runReconciliation.ts
@@ -1,0 +1,41 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { requirePlatformOperator } from '../../utils/platformAdminContext';
+import { runBillingReconciliation } from '../../utils/billing/reconciliation';
+
+/**
+ * Runs billing reconciliation across all workspaces or a single workspace.
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const operatorResult = await requirePlatformOperator(event);
+		if (!operatorResult.ok) return operatorResult.response;
+
+		let workspaceId: ObjectId | undefined;
+		if (event.body) {
+			try {
+				const input = JSON.parse(event.body) as { workspaceId?: string };
+				if (input.workspaceId) {
+					if (!ObjectId.isValid(input.workspaceId)) {
+						return ResponseWrapper.badRequest('workspaceId must be a valid ObjectId');
+					}
+					workspaceId = new ObjectId(input.workspaceId);
+				}
+			} catch {
+				return ResponseWrapper.badRequest('Invalid JSON in request body');
+			}
+		}
+
+		const results = await runBillingReconciliation({ workspaceId });
+
+		return ResponseWrapper.success({
+			message: 'Billing reconciliation completed',
+			data: { results },
+		});
+	} catch (error) {
+		logError('Platform admin run reconciliation failed', error);
+		return ResponseWrapper.internalServerError('Failed to run billing reconciliation');
+	}
+};

--- a/src/controllers/platformAdmin/updateBillingAccount.ts
+++ b/src/controllers/platformAdmin/updateBillingAccount.ts
@@ -20,6 +20,7 @@ import {
 	usageLimitsToIncluded,
 } from '../../utils/billing/billingAccounts';
 import { recordSsoAddOnEvent } from '../../utils/billing/usageRecording';
+import { parseOptionalIsoDate } from '../../utils/billing/billingPeriod';
 import { serializeBillingAccount } from '../../utils/billing/serializers';
 
 const ACCOUNT_STATUSES: BillingAccountStatus[] = ['draft', 'pilot', 'active', 'past_due', 'cancelled'];
@@ -104,8 +105,16 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			updates.paymentMode = input.paymentMode;
 		}
 		if (typeof input.pastDue === 'boolean') updates.pastDue = input.pastDue;
-		if (input.periodStart) updates.periodStart = new Date(input.periodStart);
-		if (input.periodEnd) updates.periodEnd = new Date(input.periodEnd);
+		if (input.periodStart !== undefined) {
+			const parsedPeriodStart = parseOptionalIsoDate(input.periodStart, 'periodStart');
+			if (!parsedPeriodStart.ok) return ResponseWrapper.badRequest(parsedPeriodStart.message);
+			updates.periodStart = parsedPeriodStart.date;
+		}
+		if (input.periodEnd !== undefined) {
+			const parsedPeriodEnd = parseOptionalIsoDate(input.periodEnd, 'periodEnd');
+			if (!parsedPeriodEnd.ok) return ResponseWrapper.badRequest(parsedPeriodEnd.message);
+			updates.periodEnd = parsedPeriodEnd.date;
+		}
 
 		const usageLimits = normalizeUsageLimits(existing);
 		let usageLimitsChanged = false;

--- a/src/controllers/platformAdmin/updateBillingAccount.ts
+++ b/src/controllers/platformAdmin/updateBillingAccount.ts
@@ -1,0 +1,204 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import {
+	BILLING_ACCOUNTS_COLLECTION,
+	type BillingAccount,
+	type BillingAccountStatus,
+	type BillingCadence,
+	type BillingPaymentMode,
+	type UsageLimits,
+} from '../../models/billing';
+import { Workspace } from '../../models/workspace';
+import { getDb } from '../../utils/db';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { requirePlatformOperator } from '../../utils/platformAdminContext';
+import { recordPlatformAuditEvent } from '../../utils/platformAuditLog';
+import {
+	getBillingAccountByWorkspaceId,
+	normalizeUsageLimits,
+	usageLimitsToIncluded,
+} from '../../utils/billing/billingAccounts';
+import { recordSsoAddOnEvent } from '../../utils/billing/usageRecording';
+import { serializeBillingAccount } from '../../utils/billing/serializers';
+
+const ACCOUNT_STATUSES: BillingAccountStatus[] = ['draft', 'pilot', 'active', 'past_due', 'cancelled'];
+const CADENCES: BillingCadence[] = ['monthly', 'yearly'];
+const PAYMENT_MODES: BillingPaymentMode[] = ['offline_wire', 'provider_bank_transfer', 'manual_external'];
+
+type UpdateBillingInput = {
+	status?: BillingAccountStatus;
+	meteringEnabled?: boolean;
+	limitsEnabled?: boolean;
+	billingCadence?: BillingCadence;
+	currency?: string;
+	netTermDays?: number;
+	paymentMode?: BillingPaymentMode;
+	periodStart?: string;
+	periodEnd?: string;
+	pastDue?: boolean;
+	included?: {
+		seatMonths?: number;
+		exports?: number;
+		uploadGb?: number;
+		sso?: boolean;
+	};
+	usageLimits?: Partial<UsageLimits>;
+	ssoEnabled?: boolean;
+};
+
+/**
+ * Updates billing account fields for platform operators.
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const operatorResult = await requirePlatformOperator(event);
+		if (!operatorResult.ok) return operatorResult.response;
+
+		const workspaceId = event.pathParameters?.workspaceId;
+		if (!workspaceId || !ObjectId.isValid(workspaceId)) {
+			return ResponseWrapper.badRequest('workspaceId must be a valid ObjectId');
+		}
+
+		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
+
+		let input: UpdateBillingInput;
+		try {
+			input = JSON.parse(event.body);
+		} catch {
+			return ResponseWrapper.badRequest('Invalid JSON in request body');
+		}
+
+		const workspaceObjectId = new ObjectId(workspaceId);
+		const db = await getDb();
+		const workspace = await db.collection<Workspace>('workspaces').findOne({ _id: workspaceObjectId });
+		if (!workspace) return ResponseWrapper.notFound('Workspace not found');
+
+		const existing = await getBillingAccountByWorkspaceId(workspaceObjectId);
+		if (!existing) return ResponseWrapper.notFound('Billing account not found');
+
+		const updates: Record<string, unknown> = {};
+		const now = new Date();
+		const isCountLimit = (path: keyof Omit<UsageLimits, 'ssoAllowed'>) => path === 'seats' || path === 'exports';
+
+		if (input.status !== undefined) {
+			if (!ACCOUNT_STATUSES.includes(input.status)) {
+				return ResponseWrapper.badRequest('Invalid billing account status');
+			}
+			updates.status = input.status;
+		}
+		if (typeof input.limitsEnabled === 'boolean') updates.meteringEnabled = input.limitsEnabled;
+		if (typeof input.meteringEnabled === 'boolean') updates.meteringEnabled = input.meteringEnabled;
+		if (input.billingCadence !== undefined) {
+			if (!CADENCES.includes(input.billingCadence)) {
+				return ResponseWrapper.badRequest('billingCadence must be monthly or yearly');
+			}
+			updates.billingCadence = input.billingCadence;
+		}
+		if (typeof input.currency === 'string' && input.currency.trim()) updates.currency = input.currency.trim();
+		if (typeof input.netTermDays === 'number' && input.netTermDays >= 0) updates.netTermDays = input.netTermDays;
+		if (input.paymentMode !== undefined) {
+			if (!PAYMENT_MODES.includes(input.paymentMode)) {
+				return ResponseWrapper.badRequest('Invalid payment mode');
+			}
+			updates.paymentMode = input.paymentMode;
+		}
+		if (typeof input.pastDue === 'boolean') updates.pastDue = input.pastDue;
+		if (input.periodStart) updates.periodStart = new Date(input.periodStart);
+		if (input.periodEnd) updates.periodEnd = new Date(input.periodEnd);
+
+		const usageLimits = normalizeUsageLimits(existing);
+		let usageLimitsChanged = false;
+		const applyNumericLimit = (path: keyof Omit<UsageLimits, 'ssoAllowed'>, value: unknown): boolean | APIGatewayProxyResult => {
+			if (value === undefined) return false;
+			if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+				return ResponseWrapper.badRequest(`${path} must be a non-negative number`);
+			}
+			if (isCountLimit(path) && !Number.isInteger(value)) {
+				return ResponseWrapper.badRequest(`${path} must be a whole number`);
+			}
+			usageLimits[path] = value;
+			return true;
+		};
+
+		const seatLimitResult = applyNumericLimit('seats', input.usageLimits?.seats ?? input.included?.seatMonths);
+		if (typeof seatLimitResult !== 'boolean') return seatLimitResult;
+		usageLimitsChanged = usageLimitsChanged || seatLimitResult;
+
+		const exportLimitResult = applyNumericLimit('exports', input.usageLimits?.exports ?? input.included?.exports);
+		if (typeof exportLimitResult !== 'boolean') return exportLimitResult;
+		usageLimitsChanged = usageLimitsChanged || exportLimitResult;
+
+		const uploadLimitResult = applyNumericLimit('uploadGb', input.usageLimits?.uploadGb ?? input.included?.uploadGb);
+		if (typeof uploadLimitResult !== 'boolean') return uploadLimitResult;
+		usageLimitsChanged = usageLimitsChanged || uploadLimitResult;
+
+		const ssoAllowedInput = input.usageLimits?.ssoAllowed ?? input.included?.sso;
+		if (ssoAllowedInput !== undefined) {
+			if (typeof ssoAllowedInput !== 'boolean') {
+				return ResponseWrapper.badRequest('ssoAllowed must be a boolean');
+			}
+			usageLimits.ssoAllowed = ssoAllowedInput;
+			usageLimitsChanged = true;
+		}
+
+		if (usageLimitsChanged) {
+			updates.usageLimits = usageLimits;
+			updates.included = usageLimitsToIncluded(usageLimits);
+		}
+
+		let ssoAction: 'enabled' | 'disabled' | null = null;
+		if (typeof input.ssoEnabled === 'boolean' && input.ssoEnabled !== existing.sso.enabled) {
+			if (input.ssoEnabled && !usageLimits.ssoAllowed) {
+				return ResponseWrapper.badRequest('SSO is not allowed by this workspace usage limit');
+			}
+			updates['sso.enabled'] = input.ssoEnabled;
+			updates[`sso.${input.ssoEnabled ? 'enabledAt' : 'disabledAt'}`] = now;
+			ssoAction = input.ssoEnabled ? 'enabled' : 'disabled';
+		}
+
+		if (Object.keys(updates).length === 0) {
+			return ResponseWrapper.badRequest('No valid fields to update');
+		}
+
+		updates.updatedAt = now;
+
+		const updated = await db.collection(BILLING_ACCOUNTS_COLLECTION).findOneAndUpdate(
+			{ _id: existing._id },
+			{ $set: updates },
+			{ returnDocument: 'after' },
+		);
+
+		if (!updated) return ResponseWrapper.notFound('Billing account not found');
+
+		if (ssoAction) {
+			await recordSsoAddOnEvent({
+				workspaceId: workspaceObjectId,
+				billingAccountId: existing._id,
+				action: ssoAction,
+			});
+		}
+
+		const { auth, operator } = operatorResult.context;
+		await recordPlatformAuditEvent({
+			action: 'billing.account.update',
+			targetType: 'billing_account',
+			workspaceId: workspaceObjectId,
+			entityId: existing._id.toString(),
+			summary: `Updated billing account for ${workspace.workspaceName}`,
+			changes: Object.keys(updates).map((path) => ({ path, to: updates[path] })),
+			auth: auth.payload,
+			operator,
+			event,
+			source: 'platform-admin-portal',
+		});
+
+		return ResponseWrapper.success({
+			message: 'Billing account updated',
+			data: serializeBillingAccount(updated as BillingAccount & { _id: ObjectId }),
+		});
+	} catch (error) {
+		logError('Platform admin update billing account failed', error);
+		return ResponseWrapper.internalServerError('Failed to update billing account');
+	}
+};

--- a/src/controllers/platformAdmin/updateFreezes.ts
+++ b/src/controllers/platformAdmin/updateFreezes.ts
@@ -1,0 +1,96 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import { Workspace } from '../../models/workspace';
+import { getDb } from '../../utils/db';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { requirePlatformOperator } from '../../utils/platformAdminContext';
+import { recordPlatformAuditEvent } from '../../utils/platformAuditLog';
+import { serializeWorkspaceFreezes } from '../../utils/billing/serializers';
+
+type FreezeInput = {
+	usageFreezeEnabled?: boolean;
+	accessFreezeEnabled?: boolean;
+};
+
+/**
+ * Updates workspace usage and access freeze flags.
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const operatorResult = await requirePlatformOperator(event);
+		if (!operatorResult.ok) return operatorResult.response;
+
+		const workspaceId = event.pathParameters?.workspaceId;
+		if (!workspaceId || !ObjectId.isValid(workspaceId)) {
+			return ResponseWrapper.badRequest('workspaceId must be a valid ObjectId');
+		}
+
+		if (!event.body) return ResponseWrapper.badRequest('Request body is required');
+
+		let input: FreezeInput;
+		try {
+			input = JSON.parse(event.body);
+		} catch {
+			return ResponseWrapper.badRequest('Invalid JSON in request body');
+		}
+
+		if (typeof input.usageFreezeEnabled !== 'boolean' && typeof input.accessFreezeEnabled !== 'boolean') {
+			return ResponseWrapper.badRequest('At least one freeze flag is required');
+		}
+
+		const workspaceObjectId = new ObjectId(workspaceId);
+		const db = await getDb();
+		const workspace = await db.collection<Workspace>('workspaces').findOne({ _id: workspaceObjectId });
+		if (!workspace) return ResponseWrapper.notFound('Workspace not found');
+
+		const now = new Date();
+		const { operator } = operatorResult.context;
+		const updates: Record<string, unknown> = {};
+
+		if (typeof input.usageFreezeEnabled === 'boolean') {
+			updates.workspaceUsageFreeze = {
+				enabled: input.usageFreezeEnabled,
+				updatedAt: now,
+				updatedByPlatformAdminId: operator._id,
+			};
+		}
+		if (typeof input.accessFreezeEnabled === 'boolean') {
+			updates.workspaceAccessFreeze = {
+				enabled: input.accessFreezeEnabled,
+				updatedAt: now,
+				updatedByPlatformAdminId: operator._id,
+			};
+		}
+
+		const updated = await db.collection<Workspace>('workspaces').findOneAndUpdate(
+			{ _id: workspaceObjectId },
+			{ $set: updates },
+			{ returnDocument: 'after' },
+		);
+
+		if (!updated) return ResponseWrapper.notFound('Workspace not found');
+
+		const { auth } = operatorResult.context;
+		await recordPlatformAuditEvent({
+			action: 'workspace.freeze.update',
+			targetType: 'workspace',
+			workspaceId: workspaceObjectId,
+			entityId: workspaceObjectId.toString(),
+			summary: `Updated workspace freezes for ${workspace.workspaceName}`,
+			changes: Object.entries(updates).map(([path, value]) => ({ path, to: value })),
+			auth: auth.payload,
+			operator,
+			event,
+			source: 'platform-admin-portal',
+		});
+
+		return ResponseWrapper.success({
+			message: 'Workspace freezes updated',
+			data: serializeWorkspaceFreezes(updated),
+		});
+	} catch (error) {
+		logError('Platform admin update freezes failed', error);
+		return ResponseWrapper.internalServerError('Failed to update workspace freezes');
+	}
+};

--- a/src/controllers/products/enqueueProductExport.ts
+++ b/src/controllers/products/enqueueProductExport.ts
@@ -16,6 +16,7 @@ import {
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { validateAllObjectIds } from '../../utils/validationUtils';
 import { getAuthenticatedUserContext } from '../../utils/authenticatedUser';
+import { assertUsageActionAllowed } from '../../utils/billing/enforcement';
 
 /**
  * Queues a product export job from request body format.
@@ -85,6 +86,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (product.workspace_id.toString() !== userContext.workspaceId.toString()) {
 			return ResponseWrapper.forbidden('You are not authorized to export this product');
 		}
+
+		const exportCheck = await assertUsageActionAllowed(userContext.workspaceId, 'export', 1);
+		if (!exportCheck.allowed) return ResponseWrapper.forbidden(exportCheck.reason);
 
 		const job = await createQueuedProductExportJob({
 			productId: productObjectId,

--- a/src/controllers/products/updateProductData.ts
+++ b/src/controllers/products/updateProductData.ts
@@ -22,6 +22,10 @@ import { addOperationalParameters, deleteOperationalParameters, updateOperationa
 import { addLabelTag, deleteLabelTag, updateLabelTag, updateLabelTagsTabCompletion, updateLabelTagTaggedImage, updateLabelTagLegend } from './productData/label-tags';
 import { SymbolsGraphics } from '../../types/products/symbols-graphics';
 import { recordAuditEvent } from '../../utils/auditLogV2';
+import {
+	assertNewUploadCommitsAllowed,
+	recordUploadCommitsFromPayload,
+} from '../../utils/billing/uploadCommit';
 
 const validTabs = [
 	'product-information',
@@ -633,6 +637,11 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			});
 		}
 
+		const uploadCommitCheck = await assertNewUploadCommitsAllowed(context.workspaceId, input.data);
+		if (!uploadCommitCheck.allowed) {
+			return ResponseWrapper.forbidden(uploadCommitCheck.reason);
+		}
+
 		const options: { arrayFilters?: any[] } = {};
 		if ('arrayFilters' in updateQuery) {
 			options.arrayFilters = (updateQuery as any).arrayFilters;
@@ -678,6 +687,8 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				meta: payloadMeta,
 			});
 		}
+
+		await recordUploadCommitsFromPayload(context.workspaceId, input.data);
 
 		return ResponseWrapper.success({
 			message: 'Product updated successfully',

--- a/src/controllers/projects/createProject.ts
+++ b/src/controllers/projects/createProject.ts
@@ -7,6 +7,7 @@ import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
 import { recordAuditEvent } from '../../utils/auditLogV2';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
 import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 
 /**
@@ -119,6 +120,14 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			meta: {
 				projectName: input.project_name,
 			},
+		});
+
+		await recordCommittedUploadIfNew({
+			workspaceId: workspaceObjectId,
+			previousKey: '',
+			newKey: normalizedProjectImage,
+			sizeBytes: input.imageSizeBytes ?? input.sizeBytes,
+			metadata: { assetType: 'project_image' },
 		});
 
 		return ResponseWrapper.created({

--- a/src/controllers/projects/updateProject.ts
+++ b/src/controllers/projects/updateProject.ts
@@ -7,6 +7,7 @@ import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
 import { recordAuditEvent } from '../../utils/auditLogV2';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
 import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
 
 /**
@@ -145,6 +146,15 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			meta: {
 				projectName: input.project_name,
 			},
+		});
+
+		await recordCommittedUploadIfNew({
+			workspaceId: context.workspaceId,
+			previousKey: projectRecord.image,
+			newKey: normalizedProjectImage,
+			sizeBytes: (input as { imageSizeBytes?: number; sizeBytes?: number }).imageSizeBytes
+				?? (input as { sizeBytes?: number }).sizeBytes,
+			metadata: { assetType: 'project_image' },
 		});
 
 		return ResponseWrapper.success({

--- a/src/controllers/reports/enqueueReportExport.ts
+++ b/src/controllers/reports/enqueueReportExport.ts
@@ -12,6 +12,7 @@ import { validateConditions } from '../../utils/reports/queryBuilder';
 import { validateMissingFields, validateObjectIds } from '../../utils/validationUtils';
 import type { PersistedReportExportRequest, QueryCondition } from '../../types/reports';
 import { ALLOWED_SORT_FIELDS } from '../../types/reports';
+import { assertUsageActionAllowed } from '../../utils/billing/enforcement';
 
 type RequestBody = {
 	workspaceId?: string;
@@ -110,6 +111,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (requestedWorkspaceId.toString() !== userContext.workspaceId.toString()) {
 			return ResponseWrapper.forbidden('You are not authorized to export reports for this workspace');
 		}
+
+		const exportCheck = await assertUsageActionAllowed(userContext.workspaceId, 'export', 1);
+		if (!exportCheck.allowed) return ResponseWrapper.forbidden(exportCheck.reason);
 
 		const reportParams: PersistedReportExportRequest = {
 			conditions,

--- a/src/controllers/s3Storage/presignUpload.ts
+++ b/src/controllers/s3Storage/presignUpload.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from "../../utils/responseWrapper";
 import { validateMissingFields } from "../../utils/validationUtils";
 import { createPresignedUrl, type UploadScope } from "../../utils/s3-storage";
 import type { Product } from "../../models/product";
+import { assertUsageActionAllowed, checkUploadWouldExceedLimit } from "../../utils/billing/enforcement";
 
 const PRODUCT_ASSET_CONTENT_TYPES = new Set([
 	"image/png",
@@ -65,6 +66,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.badRequest(`Unsupported contentType: ${input.contentType}`);
 		}
 
+		const sizeBytes = typeof input.sizeBytes === 'number' && input.sizeBytes > 0
+			? Math.floor(input.sizeBytes)
+			: undefined;
+
 		const userContext = await getAuthenticatedUserContext(auth.payload.sub);
 
 		if (!userContext) {
@@ -78,6 +83,18 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			});
 
 			return ResponseWrapper.created({ message: "Presigned URL generated successfully.", uploadUrl, key, expiresIn: 3600 });
+		}
+
+		if (userContext.workspaceId) {
+			const uploadCheck = await assertUsageActionAllowed(userContext.workspaceId, 'upload');
+			if (!uploadCheck.allowed) return ResponseWrapper.forbidden(uploadCheck.reason);
+
+			if (sizeBytes) {
+				const limitCheck = await checkUploadWouldExceedLimit(userContext.workspaceId, sizeBytes);
+				if (!limitCheck.allowed) {
+					return ResponseWrapper.forbidden(limitCheck.reason ?? 'Upload limit reached');
+				}
+			}
 		}
 
 		let productId: string | undefined;

--- a/src/controllers/sourceFiles/createSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/createSourceFileAndFolder.ts
@@ -8,6 +8,8 @@ import { SourceFile } from "../../models/sourceFiles";
 import type { Product } from "../../models/product";
 import { ObjectId } from "mongodb";
 import { recordAuditEvent } from "../../utils/auditLogV2";
+import { assertUsageActionAllowed, checkUploadWouldExceedLimit } from "../../utils/billing/enforcement";
+import { recordCommittedUploadBytes } from "../../utils/billing/uploadCommit";
 
 /**
  * @param {APIGatewayProxyEvent} event
@@ -42,6 +44,22 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			...(input.product_id && { 'product_id': input.product_id })
 		});
 		if (objectIdValidation) return objectIdValidation;
+
+		const sizeBytes = input.type === 'file' && typeof input.sizeBytes === 'number' && input.sizeBytes > 0
+			? Math.floor(input.sizeBytes)
+			: undefined;
+
+		if (input.type === 'file') {
+			const uploadCheck = await assertUsageActionAllowed(context.workspaceId, 'upload');
+			if (!uploadCheck.allowed) return ResponseWrapper.forbidden(uploadCheck.reason);
+
+			if (sizeBytes) {
+				const limitCheck = await checkUploadWouldExceedLimit(context.workspaceId, sizeBytes);
+				if (!limitCheck.allowed) {
+					return ResponseWrapper.forbidden(limitCheck.reason ?? 'Upload limit reached');
+				}
+			}
+		}
 
 		const db = await getDb();
 		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
@@ -94,10 +112,20 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			...(input.type === 'file' && {
 				...(input.url && { url: input.url }),
 				...(input.key && { key: input.key }),
+				...(sizeBytes && { sizeBytes }),
 			}),
 		};
 
 		await sourceFilesCollection.insertOne(newSourceFile);
+
+		if (newSourceFile.type === 'file' && sizeBytes && newSourceFile.key) {
+			await recordCommittedUploadBytes({
+				workspaceId,
+				uploadKey: newSourceFile.key,
+				sizeBytes,
+				metadata: { sourceFileId: newSourceFile._id.toString() },
+			});
+		}
 
 		const isFolder = newSourceFile.type === 'folder';
 		await recordAuditEvent({

--- a/src/controllers/sourceFiles/createSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/createSourceFileAndFolder.ts
@@ -9,6 +9,7 @@ import type { Product } from "../../models/product";
 import { ObjectId } from "mongodb";
 import { recordAuditEvent } from "../../utils/auditLogV2";
 import { assertUsageActionAllowed, checkUploadWouldExceedLimit } from "../../utils/billing/enforcement";
+import { getBillingAccountByWorkspaceId } from "../../utils/billing/billingAccounts";
 import { recordCommittedUploadBytes } from "../../utils/billing/uploadCommit";
 
 /**
@@ -52,6 +53,11 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (input.type === 'file') {
 			const uploadCheck = await assertUsageActionAllowed(context.workspaceId, 'upload');
 			if (!uploadCheck.allowed) return ResponseWrapper.forbidden(uploadCheck.reason);
+
+			const billingAccount = await getBillingAccountByWorkspaceId(context.workspaceId);
+			if (billingAccount?.meteringEnabled && !sizeBytes) {
+				return ResponseWrapper.badRequest('sizeBytes is required for file uploads when usage limits are enabled');
+			}
 
 			if (sizeBytes) {
 				const limitCheck = await checkUploadWouldExceedLimit(context.workspaceId, sizeBytes);

--- a/src/controllers/users/createUser.ts
+++ b/src/controllers/users/createUser.ts
@@ -6,6 +6,7 @@ import { updateAuditLog } from '../../utils/auditLog';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
 import { isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 
 /**
@@ -36,10 +37,11 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		const db = await getDb();
+		const normalizedAvatar = normalizePersistedAssetReference(input.profileAvatar, '');
 
 		const user = await db.collection<User>('users').insertOne({
 			name: input.name,
-			profileAvatar: normalizePersistedAssetReference(input.profileAvatar, ''),
+			profileAvatar: normalizedAvatar,
 			designation: input.designation,
 			email: input.email,
 			phone: input.phone,
@@ -57,6 +59,15 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			actionBy: context.userId.toString(),
 			actionAt: new Date(),
 			active: true,
+		});
+
+		await recordCommittedUploadIfNew({
+			workspaceId: context.workspaceId,
+			previousKey: '',
+			newKey: normalizedAvatar,
+			sizeBytes: (input as { profileAvatarSizeBytes?: number; sizeBytes?: number }).profileAvatarSizeBytes
+				?? (input as { sizeBytes?: number }).sizeBytes,
+			metadata: { assetType: 'profile_avatar' },
 		});
 
 		return ResponseWrapper.created({

--- a/src/controllers/users/deleteUser.ts
+++ b/src/controllers/users/deleteUser.ts
@@ -1,19 +1,18 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { getDb } from '../../utils/db';
-import { User } from '../../models/user';
+import { ObjectId } from 'mongodb';
 import { AuditLog, AuditLogAction } from '../../models/auditLog';
 import { updateAuditLog } from '../../utils/auditLog';
-import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { isWorkspaceAdmin, requireTenantContext, tenantUserIdFilter } from '../../utils/tenantContext';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 import { validateAllObjectIds } from '../../utils/validationUtils';
+import { deactivateWorkspaceUser, UserRemovalError } from '../../utils/userRemoval';
 
 /**
- * Delete a user
+ * Remove a user from the workspace (soft deactivation).
  * @param {APIGatewayProxyEvent} event - API Gateway Lambda Proxy Input Format
  * @return {Promise<APIGatewayProxyResult>} API Gateway Lambda Proxy Output Format
  */
-
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {
 		const tenantResult = await requireTenantContext(event);
@@ -33,22 +32,27 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (objectIdValidation) return objectIdValidation;
 
 		if (event.pathParameters.id === context.userId.toString()) {
-			return ResponseWrapper.badRequest('You cannot delete your own user account. Please contact your workspace admin to delete your account.');
+			return ResponseWrapper.badRequest(
+				'You cannot remove your own user account. Please contact another workspace admin.',
+			);
 		}
 
-		const db = await getDb();
-
-		const user = await db.collection<User>('users').deleteOne(
-			tenantUserIdFilter(event.pathParameters.id, context.workspaceId),
-		);
-
-		if (user.deletedCount === 0) {
-			return ResponseWrapper.notFound('User not found');
+		let targetUserId: ObjectId;
+		try {
+			targetUserId = new ObjectId(event.pathParameters.id);
+		} catch {
+			return ResponseWrapper.badRequest('Invalid user ID');
 		}
+
+		const deactivatedUser = await deactivateWorkspaceUser({
+			targetUserId,
+			workspaceId: context.workspaceId,
+			actorUserId: context.userId,
+		});
 
 		const auditRecord: AuditLog = {
 			entity: 'user',
-			entityId: (event.pathParameters.id).toString(),
+			entityId: event.pathParameters.id,
 			action: AuditLogAction.DELETE,
 			actionBy: context.userId.toString(),
 			actionAt: new Date(),
@@ -58,12 +62,18 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		await updateAuditLog(auditRecord);
 
 		return ResponseWrapper.success({
-			message: 'User deleted successfully',
-			user: user,
+			message: 'User removed from workspace successfully',
+			user: deactivatedUser,
 		});
-
 	} catch (err) {
-		logError('Delete user handler failed', err);
-		return ResponseWrapper.internalServerError('Failed to delete user');
+		if (err instanceof UserRemovalError) {
+			if (err.code === 'not_found') {
+				return ResponseWrapper.notFound(err.message);
+			}
+			return ResponseWrapper.badRequest(err.message);
+		}
+
+		logError('Remove user handler failed', err);
+		return ResponseWrapper.internalServerError('Failed to remove user');
 	}
 };

--- a/src/controllers/users/getAllUsersByWorkspace.ts
+++ b/src/controllers/users/getAllUsersByWorkspace.ts
@@ -48,10 +48,17 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const sortObj: { [key: string]: 1 | -1 } = {};
 		sortObj[sort] = order === 'desc' ? -1 : 1;
 
-		const baseMatch = { workspaceId: context.workspaceId };
+		const baseMatch: Record<string, unknown> = { workspaceId: context.workspaceId };
 
 		const filtersMatch = buildListFiltersMatch(filters, USER_FILTER_FIELDS);
 		if (filtersMatch.error) return filtersMatch.error;
+
+		const hasStatusFilter = filters.some((filter) => filter.field === 'status');
+		const includeInactive = event.queryStringParameters?.includeInactive === 'true';
+
+		if (!hasStatusFilter && !includeInactive) {
+			baseMatch.status = { $ne: 'inactive' };
+		}
 
 		const queryFilter =
 			filtersMatch.match != null

--- a/src/controllers/users/updateUser.ts
+++ b/src/controllers/users/updateUser.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateMissingFields } from '../../utils/validationUtils';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
 import { isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 
 /**
@@ -54,6 +55,11 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.forbidden('You are not authorized to update this user');
 		}
 
+		const normalizedAvatar = normalizePersistedAssetReference(
+			input.profileAvatar,
+			userRecord.profileAvatar ?? '',
+		);
+
 		const user = await db.collection<User>('users').updateOne(
 			{
 				_id: new ObjectId(userRecord._id),
@@ -62,7 +68,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			{
 				$set: {
 					name: input.name,
-					profileAvatar: normalizePersistedAssetReference(input.profileAvatar, userRecord.profileAvatar ?? ''),
+					profileAvatar: normalizedAvatar,
 					email: input.email,
 					designation: input.designation || '',
 					phone: input.phone,
@@ -81,6 +87,15 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		};
 
 		await updateAuditLog(auditRecord);
+
+		await recordCommittedUploadIfNew({
+			workspaceId: context.workspaceId,
+			previousKey: userRecord.profileAvatar,
+			newKey: normalizedAvatar,
+			sizeBytes: (input as { profileAvatarSizeBytes?: number; sizeBytes?: number }).profileAvatarSizeBytes
+				?? (input as { sizeBytes?: number }).sizeBytes,
+			metadata: { assetType: 'profile_avatar' },
+		});
 
 		return ResponseWrapper.success({
 			message: 'User updated successfully',

--- a/src/controllers/workspaces/createWorkspace.ts
+++ b/src/controllers/workspaces/createWorkspace.ts
@@ -8,6 +8,7 @@ import { validateMissingFields } from '../../utils/validationUtils';
 import { authenticateWithRole } from '../../utils/authUtils';
 import { logError } from '../../utils/logger';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { createBillingAccountForWorkspace } from '../../utils/billing/billingAccounts';
 
 
 /**
@@ -50,7 +51,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const db = await getDb();
 		
-		const workspace = await db.collection<Workspace>('workspaces').insertOne({
+		const workspaceInsert = await db.collection<Workspace>('workspaces').insertOne({
 			workspaceName: input.workspaceName,
 			companyName: input.companyName,
 			description: input.description || '',
@@ -64,9 +65,11 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			userIds: input.userIds || []
 		});
 
+		await createBillingAccountForWorkspace(workspaceInsert.insertedId);
+
 		await updateAuditLog({
 			entity: 'workspace',
-			entityId: workspace.insertedId.toString(),
+			entityId: workspaceInsert.insertedId.toString(),
 			action: AuditLogAction.CREATE,
 			actionBy: auth.payload?.name?.toString()!,
 			actionAt: new Date(),
@@ -75,7 +78,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		return ResponseWrapper.created({
 			message: 'Workspace created successfully',
-			workspace: workspace,
+			workspace: workspaceInsert,
 		});
 		
 	} catch (err) {

--- a/src/controllers/workspaces/updateWorkspace.ts
+++ b/src/controllers/workspaces/updateWorkspace.ts
@@ -8,6 +8,7 @@ import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { validateAllObjectIds, validateMissingFields } from '../../utils/validationUtils';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
+import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
 import { assertWorkspaceMatch, isWorkspaceAdmin, requireTenantContext } from '../../utils/tenantContext';
 
 /**
@@ -79,24 +80,31 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		const userObjectIds = input.userIds ? input.userIds.map((userId) => new ObjectId(userId)) : [];
+		const normalizedLogo = normalizePersistedAssetReference(input.logo, workspaceRecord.logo ?? '');
+
+		const updateFields: Partial<Workspace> = {
+			workspaceName: input.workspaceName,
+			companyName: input.companyName,
+			description: input.description,
+			logo: normalizedLogo,
+			plan: input.plan,
+			planId: input.planId,
+			planStart: input.planStart,
+			planEnd: input.planEnd,
+			cost: input.cost,
+			userIds: userObjectIds,
+		};
+
+		if (typeof input.memberListIncludeInactive === 'boolean') {
+			updateFields.memberListIncludeInactive = input.memberListIncludeInactive;
+		}
 
 		const workspace = await db.collection<Workspace>('workspaces').updateOne(
 			{
 				_id: context.workspaceId,
 			},
 			{
-				$set: {
-					workspaceName: input.workspaceName,
-					companyName: input.companyName,
-					description: input.description,
-					logo: normalizePersistedAssetReference(input.logo, workspaceRecord.logo ?? ''),
-					plan: input.plan,
-					planId: input.planId,
-					planStart: input.planStart,
-					planEnd: input.planEnd,
-					cost: input.cost,
-					userIds: userObjectIds,
-				},
+				$set: updateFields,
 			},
 		);
 
@@ -110,6 +118,15 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		};
 
 		await updateAuditLog(auditRecord);
+
+		await recordCommittedUploadIfNew({
+			workspaceId: context.workspaceId,
+			previousKey: workspaceRecord.logo,
+			newKey: normalizedLogo,
+			sizeBytes: (input as { logoSizeBytes?: number; sizeBytes?: number }).logoSizeBytes
+				?? (input as { sizeBytes?: number }).sizeBytes,
+			metadata: { assetType: 'workspace_logo' },
+		});
 
 		return ResponseWrapper.success({
 			message: 'Workspace updated successfully',

--- a/src/models/billing.ts
+++ b/src/models/billing.ts
@@ -1,0 +1,146 @@
+import { ObjectId } from 'mongodb';
+
+export type BillingCadence = 'monthly' | 'yearly';
+export type BillingAccountStatus = 'draft' | 'pilot' | 'active' | 'past_due' | 'cancelled';
+export type BillingPaymentMode = 'offline_wire' | 'provider_bank_transfer' | 'manual_external';
+export type EnforcementMode = 'overage' | 'block';
+
+export type BillingUsageMetric =
+	| 'activated_seat_month'
+	| 'completed_export'
+	| 'upload_bytes';
+
+export type UsageEventSource =
+	| 'user_activation'
+	| 'export_job'
+	| 'upload_commit'
+	| 'platform_adjustment'
+	| 'reconciliation_backfill';
+
+export type UsageUnit = 'count' | 'bytes';
+
+export type UsageLimits = {
+	seats: number;
+	exports: number;
+	uploadGb: number;
+	ssoAllowed: boolean;
+};
+
+export type DeprecatedIncludedLimits = {
+	seatMonths: number;
+	exports: number;
+	uploadGb: number;
+	sso: boolean;
+};
+
+export type LimitStatusMetric = {
+	used: number;
+	limit: number;
+	delta: number;
+	overLimit: boolean;
+};
+
+export type LimitStatus = {
+	seats: LimitStatusMetric;
+	exports: LimitStatusMetric;
+	uploadGb: LimitStatusMetric;
+};
+
+export const BILLING_ACCOUNTS_COLLECTION = 'billingAccounts';
+export const USAGE_EVENTS_COLLECTION = 'usageEvents';
+export const USAGE_SNAPSHOTS_COLLECTION = 'usageSnapshots';
+export const USAGE_ADJUSTMENTS_COLLECTION = 'usageAdjustments';
+export const BILLING_ADDON_EVENTS_COLLECTION = 'billingAddOnEvents';
+
+export type BillingAccount = {
+	_id?: ObjectId;
+	workspaceId: ObjectId;
+	status: BillingAccountStatus;
+	meteringEnabled: boolean;
+	billingCadence: BillingCadence;
+	currency: string;
+	netTermDays: number;
+	paymentMode: BillingPaymentMode;
+	periodStart?: Date;
+	periodEnd?: Date;
+	usageLimits?: UsageLimits;
+	/** @deprecated Use usageLimits. Kept for existing documents and one-release API compatibility. */
+	included?: DeprecatedIncludedLimits;
+	workspacePreferences: {
+		enforcementMode: EnforcementMode;
+	};
+	sso: {
+		enabled: boolean;
+		enabledAt?: Date;
+		disabledAt?: Date;
+	};
+	pastDue: boolean;
+	lastReconciledAt?: Date;
+	createdAt: Date;
+	updatedAt: Date;
+};
+
+export type UsageEvent = {
+	_id?: ObjectId;
+	workspaceId: ObjectId;
+	billingAccountId?: ObjectId;
+	metric: BillingUsageMetric;
+	quantity: number;
+	unit: UsageUnit;
+	source: UsageEventSource;
+	sourceId: string;
+	idempotencyKey: string;
+	occurredAt: Date;
+	billingPeriodStart: Date;
+	billingPeriodEnd: Date;
+	metadata?: Record<string, unknown>;
+	createdAt: Date;
+	updatedAt: Date;
+};
+
+export type BillingAddOnEvent = {
+	_id?: ObjectId;
+	workspaceId: ObjectId;
+	billingAccountId: ObjectId;
+	addOn: 'sso';
+	action: 'enabled' | 'disabled';
+	occurredAt: Date;
+	billingPeriodStart: Date;
+	billingPeriodEnd: Date;
+	idempotencyKey: string;
+	createdAt: Date;
+};
+
+export type UsageSnapshot = {
+	_id?: ObjectId;
+	workspaceId: ObjectId;
+	billingAccountId: ObjectId;
+	periodStart: Date;
+	periodEnd: Date;
+	usage: {
+		activeSeats: number;
+		exports: number;
+		uploadBytes: number;
+		uploadGb: number;
+	};
+	usageLimits: UsageLimits;
+	limitStatus: LimitStatus;
+	reconciliationStatus: 'pending' | 'ok' | 'mismatch';
+	approvedForBillingAt?: Date;
+	approvedByPlatformAdminId?: ObjectId;
+	createdAt: Date;
+	updatedAt: Date;
+};
+
+export type UsageAdjustment = {
+	_id?: ObjectId;
+	workspaceId: ObjectId;
+	billingAccountId: ObjectId;
+	metric: BillingUsageMetric;
+	quantityDelta: number;
+	unit: UsageUnit;
+	billingPeriodStart: Date;
+	billingPeriodEnd: Date;
+	createdByPlatformAdminId: ObjectId;
+	createdAt: Date;
+};

--- a/src/models/sourceFiles.ts
+++ b/src/models/sourceFiles.ts
@@ -10,4 +10,5 @@ export interface SourceFile {
     product_id?: ObjectId | null
     url?: string
     key?: string
+    sizeBytes?: number
 }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -12,4 +12,6 @@ export type User = {
 	cognitoSub: string;
 	workspaceId: ObjectId | null;
 	status: 'invited' | 'active' | 'inactive';
+	removedAt?: Date;
+	removedByUserId?: ObjectId;
 };

--- a/src/models/workspace.ts
+++ b/src/models/workspace.ts
@@ -1,5 +1,11 @@
 import { ObjectId } from "mongodb";
 
+export type WorkspaceFreeze = {
+	enabled: boolean;
+	updatedAt: Date;
+	updatedByPlatformAdminId?: ObjectId;
+};
+
 export type Workspace = {
 	_id?: ObjectId;
 	workspaceName: string;
@@ -15,4 +21,7 @@ export type Workspace = {
 	cost: number;
 	adminIds?: ObjectId[];
 	userIds?: ObjectId[];
-}
+	workspaceUsageFreeze?: WorkspaceFreeze;
+	workspaceAccessFreeze?: WorkspaceFreeze;
+	memberListIncludeInactive?: boolean;
+};

--- a/src/package.json
+++ b/src/package.json
@@ -9,7 +9,9 @@
 		"type-check": "tsc --noEmit",
 		"test": "jest",
 		"seed:documentation-videos": "node scripts/seedDocumentationVideos.mjs",
-		"bootstrap:platform-admin": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/bootstrapPlatformAdmin.ts"
+		"bootstrap:platform-admin": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/bootstrapPlatformAdmin.ts",
+		"backfill:billing-accounts": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/backfillBillingAccounts.ts",
+		"fix:billing-period-anchors": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/fixBillingPeriodAnchors.ts"
 	},
 	"dependencies": {
 		"@aws-sdk/client-cognito-identity-provider": "^3.679.0",

--- a/src/scripts/backfillBillingAccounts.ts
+++ b/src/scripts/backfillBillingAccounts.ts
@@ -1,0 +1,12 @@
+import { backfillBillingAccounts } from '../utils/billing/billingAccounts';
+
+const main = async () => {
+	const result = await backfillBillingAccounts();
+	console.log(`Billing backfill complete. Created: ${result.created}, existing: ${result.existing}`);
+	process.exit(0);
+};
+
+main().catch((error) => {
+	console.error('Billing backfill failed', error);
+	process.exit(1);
+});

--- a/src/scripts/fixBillingPeriodAnchors.ts
+++ b/src/scripts/fixBillingPeriodAnchors.ts
@@ -1,0 +1,69 @@
+import { ObjectId } from 'mongodb';
+import {
+	BILLING_ACCOUNTS_COLLECTION,
+	type BillingAccount,
+} from '../models/billing';
+import { getDb } from '../utils/db';
+import { computeBillingPeriodFromAnchor } from '../utils/billing/billingPeriod';
+
+const ANCHOR_TOLERANCE_MS = 60_000;
+
+const isAlreadyAnchored = (account: BillingAccount): boolean => {
+	if (!account.periodStart) return false;
+	return Math.abs(account.periodStart.getTime() - account.createdAt.getTime()) <= ANCHOR_TOLERANCE_MS;
+};
+
+const main = async () => {
+	const db = await getDb();
+	const collection = db.collection<BillingAccount>(BILLING_ACCOUNTS_COLLECTION);
+	const accounts = await collection.find({}).toArray();
+
+	let updated = 0;
+	let skipped = 0;
+
+	for (const account of accounts) {
+		if (!account._id || !(account.workspaceId instanceof ObjectId)) {
+			skipped += 1;
+			continue;
+		}
+
+		if (isAlreadyAnchored(account)) {
+			skipped += 1;
+			continue;
+		}
+
+		const anchor = account.createdAt;
+		const { periodStart, periodEnd } = computeBillingPeriodFromAnchor(
+			anchor,
+			account.billingCadence,
+			new Date(),
+		);
+
+		await collection.updateOne(
+			{ _id: account._id },
+			{
+				$set: {
+					periodStart: anchor,
+					periodEnd,
+					updatedAt: new Date(),
+				},
+			},
+		);
+
+		updated += 1;
+		console.log(
+			`Updated workspace ${account.workspaceId.toString()}: anchor=${anchor.toISOString()}, current period=${periodStart.toISOString()} – ${periodEnd.toISOString()}`,
+		);
+	}
+
+	console.log(`Billing period anchor fix complete. Updated: ${updated}, skipped: ${skipped}`);
+	console.log(
+		'Note: usage events recorded under old calendar-month periods are not retagged automatically. Recompute snapshots after verifying usage totals, or adjust manually for test workspaces.',
+	);
+	process.exit(0);
+};
+
+main().catch((error) => {
+	console.error('Billing period anchor fix failed', error);
+	process.exit(1);
+});

--- a/src/tests/unit/billing.test.ts
+++ b/src/tests/unit/billing.test.ts
@@ -1,0 +1,975 @@
+import { ObjectId } from 'mongodb';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../utils/db', () => ({
+	getDb: jest.fn(),
+}));
+
+const dbModule = jest.requireMock('../../utils/db') as any;
+
+const {
+	assertSeatActivationAllowed,
+	assertUsageActionAllowed,
+	checkMetricLimit,
+	isWorkspaceAccessFrozen,
+	isWorkspaceUsageFrozen,
+} = require('../../utils/billing/enforcement');
+const {
+	bytesToGb,
+	gbToBytes,
+	calendarMonthKey,
+	computeBillingPeriodFromAnchor,
+	defaultPeriodForCadence,
+	endOfBillingPeriod,
+	resolveBillingPeriod,
+} = require('../../utils/billing/billingPeriod');
+const { createBillingAccountForWorkspace, DEFAULT_INCLUDED_LIMITS, getBillingAccountByWorkspaceId } = require('../../utils/billing/billingAccounts');
+const {
+	assertNewUploadCommitsAllowed,
+	collectUploadCommitsFromValue,
+	isNewUploadKey,
+	normalizeSizeBytes,
+	recordCommittedUploadBytes,
+	recordCommittedUploadIfNew,
+	sumNewUploadCommitBytes,
+} = require('../../utils/billing/uploadCommit');
+const { aggregateUploadReconciliationBreakdown } = require('../../utils/billing/usageRecording');
+const { recordUsageEvent } = require('../../utils/billing/usageRecording');
+const { buildBillingSummary } = require('../../utils/billing/serializers');
+
+describe('billing period helpers', () => {
+	it('converts bytes and gb', () => {
+		expect(bytesToGb(gbToBytes(2))).toBeCloseTo(2);
+	});
+
+	it('builds calendar month keys', () => {
+		expect(calendarMonthKey(new Date('2026-03-15T00:00:00.000Z'))).toBe('2026-03');
+	});
+
+	it('anchors monthly periods to account creation time', () => {
+		const anchor = new Date('2026-06-06T10:30:00.000Z');
+		const now = new Date('2026-06-20T12:00:00.000Z');
+		const { periodStart, periodEnd } = computeBillingPeriodFromAnchor(anchor, 'monthly', now);
+
+		expect(periodStart.toISOString()).toBe(anchor.toISOString());
+		expect(periodEnd.toISOString()).toBe('2026-07-06T10:29:59.999Z');
+	});
+
+	it('rolls monthly periods forward from the anchor', () => {
+		const anchor = new Date('2026-06-06T10:30:00.000Z');
+		const now = new Date('2026-08-01T00:00:00.000Z');
+		const { periodStart, periodEnd } = computeBillingPeriodFromAnchor(anchor, 'monthly', now);
+
+		expect(periodStart.toISOString()).toBe('2026-07-06T10:30:00.000Z');
+		expect(periodEnd.toISOString()).toBe('2026-08-06T10:29:59.999Z');
+	});
+
+	it('creates default monthly periods from the creation timestamp', () => {
+		const now = new Date('2026-06-06T10:30:00.000Z');
+		const { periodStart, periodEnd } = defaultPeriodForCadence('monthly', now);
+
+		expect(periodStart.toISOString()).toBe(now.toISOString());
+		expect(periodEnd.toISOString()).toBe(endOfBillingPeriod(now, 'monthly').toISOString());
+	});
+
+	it('resolves the current period from stored anchor and createdAt fallback', () => {
+		const createdAt = new Date('2026-06-06T10:30:00.000Z');
+		const now = new Date('2026-06-20T12:00:00.000Z');
+
+		const fromAnchor = resolveBillingPeriod({
+			billingCadence: 'monthly',
+			periodStart: createdAt,
+			periodEnd: new Date('2026-07-01T00:00:00.000Z'),
+			createdAt,
+		}, now);
+		const fromCreatedAt = resolveBillingPeriod({
+			billingCadence: 'monthly',
+			createdAt,
+		}, now);
+
+		expect(fromAnchor.periodStart.toISOString()).toBe(createdAt.toISOString());
+		expect(fromCreatedAt.periodStart.toISOString()).toBe(createdAt.toISOString());
+	});
+});
+
+describe('workspace freezes', () => {
+	it('detects access and usage freezes independently', () => {
+		expect(isWorkspaceAccessFrozen({ workspaceAccessFreeze: { enabled: true, updatedAt: new Date() } } as any)).toBe(true);
+		expect(isWorkspaceUsageFrozen({ workspaceUsageFreeze: { enabled: true, updatedAt: new Date() } } as any)).toBe(true);
+		expect(isWorkspaceAccessFrozen({} as any)).toBe(false);
+	});
+});
+
+describe('metric enforcement', () => {
+	const workspaceId = new ObjectId();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('allows usage when metering is disabled', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: false,
+							billingCadence: 'monthly',
+							createdAt: new Date(),
+							workspacePreferences: { enforcementMode: 'block' },
+							included: DEFAULT_INCLUDED_LIMITS,
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'usageEvents') {
+					return {
+						find: jest.fn(() => ({ toArray: jest.fn(async () => [{ metric: 'completed_export', quantity: 999 }]) })),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 0),
+					};
+				}
+				if (name === 'billingAddOnEvents') {
+					return {
+						createIndex: jest.fn(async () => undefined),
+						findOne: jest.fn(async () => null),
+					};
+				}
+				return {};
+			}),
+		});
+
+		const result = await checkMetricLimit(workspaceId, 'completed_export');
+		expect(result.allowed).toBe(true);
+		expect(result.meteringEnabled).toBe(false);
+	});
+
+	it('blocks only the exceeded metric when enforcement is block', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: true,
+							billingCadence: 'monthly',
+							createdAt: new Date(),
+							workspacePreferences: { enforcementMode: 'block' },
+							included: { seatMonths: 1, exports: 1, uploadGb: 1, sso: false },
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'usageEvents') {
+					return {
+						find: jest.fn(() => ({
+							toArray: jest.fn(async () => [
+								{ metric: 'completed_export', quantity: 1 },
+								{ metric: 'upload_bytes', quantity: 0 },
+							]),
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 0),
+					};
+				}
+				if (name === 'billingAddOnEvents') {
+					return {
+						createIndex: jest.fn(async () => undefined),
+						findOne: jest.fn(async () => null),
+					};
+				}
+				return {};
+			}),
+		});
+
+		const exportResult = await checkMetricLimit(workspaceId, 'completed_export', 1);
+		const uploadResult = await checkMetricLimit(workspaceId, 'upload_bytes', 1);
+
+		expect(exportResult.allowed).toBe(false);
+		expect(uploadResult.allowed).toBe(true);
+	});
+
+	it('blocks a new export when completed exports are already at the limit', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'workspaces') {
+					return {
+						findOne: jest.fn(async () => ({ _id: workspaceId })),
+					};
+				}
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: true,
+							billingCadence: 'monthly',
+							createdAt: new Date(),
+							workspacePreferences: { enforcementMode: 'block' },
+							usageLimits: { seats: 5, exports: 5, uploadGb: 10, ssoAllowed: false },
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'usageEvents') {
+					return {
+						find: jest.fn(() => ({
+							toArray: jest.fn(async () => [
+								{ metric: 'completed_export', quantity: 5 },
+							]),
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 1),
+					};
+				}
+				return {};
+			}),
+		});
+
+		const result = await assertUsageActionAllowed(workspaceId, 'export');
+
+		expect(result.allowed).toBe(false);
+	});
+
+	it('does not block workspace-member invites at the seat limit', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'workspaces') {
+					return {
+						findOne: jest.fn(async () => ({ _id: workspaceId })),
+					};
+				}
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: true,
+							billingCadence: 'monthly',
+							createdAt: new Date(),
+							workspacePreferences: { enforcementMode: 'block' },
+							included: { seatMonths: 2, exports: 10, uploadGb: 10, sso: false },
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'usageEvents') {
+					return {
+						find: jest.fn(() => ({
+							toArray: jest.fn(async () => [
+								{ metric: 'activated_seat_month', quantity: 2 },
+							]),
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'billingAddOnEvents') {
+					return {
+						createIndex: jest.fn(async () => undefined),
+						findOne: jest.fn(async () => null),
+					};
+				}
+				return {};
+			}),
+		});
+
+		const atLimit = await assertUsageActionAllowed(workspaceId, 'invite', 1);
+		const underLimit = await assertUsageActionAllowed(workspaceId, 'invite', 0);
+
+		expect(atLimit.allowed).toBe(true);
+		expect(underLimit.allowed).toBe(true);
+	});
+
+	it('blocks activation at the active-seat limit in block mode', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'workspaces') {
+					return {
+						findOne: jest.fn(async () => ({ _id: workspaceId })),
+					};
+				}
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: true,
+							billingCadence: 'monthly',
+							createdAt: new Date(),
+							workspacePreferences: { enforcementMode: 'block' },
+							usageLimits: { seats: 2, exports: 10, uploadGb: 10, ssoAllowed: false },
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 2),
+					};
+				}
+				return {};
+			}),
+		});
+
+		const result = await assertSeatActivationAllowed(workspaceId, 1);
+
+		expect(result.allowed).toBe(false);
+	});
+
+	it('allows activation over the active-seat limit in overage mode', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'workspaces') {
+					return {
+						findOne: jest.fn(async () => ({ _id: workspaceId })),
+					};
+				}
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: true,
+							billingCadence: 'monthly',
+							createdAt: new Date(),
+							workspacePreferences: { enforcementMode: 'overage' },
+							usageLimits: { seats: 2, exports: 10, uploadGb: 10, ssoAllowed: false },
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 2),
+					};
+				}
+				return {};
+			}),
+		});
+
+		const result = await assertSeatActivationAllowed(workspaceId, 1);
+
+		expect(result.allowed).toBe(true);
+	});
+
+	it('bypasses active-seat activation limits when limits are disabled', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'workspaces') {
+					return {
+						findOne: jest.fn(async () => ({ _id: workspaceId })),
+					};
+				}
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: false,
+							billingCadence: 'monthly',
+							createdAt: new Date(),
+							workspacePreferences: { enforcementMode: 'block' },
+							usageLimits: { seats: 2, exports: 10, uploadGb: 10, ssoAllowed: false },
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 2),
+					};
+				}
+				return {};
+			}),
+		});
+
+		const result = await assertSeatActivationAllowed(workspaceId, 1);
+
+		expect(result.allowed).toBe(true);
+	});
+
+	it('allows replacement activation after an active member is removed', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'workspaces') {
+					return {
+						findOne: jest.fn(async () => ({ _id: workspaceId })),
+					};
+				}
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: true,
+							billingCadence: 'monthly',
+							createdAt: new Date(),
+							workspacePreferences: { enforcementMode: 'block' },
+							usageLimits: { seats: 5, exports: 10, uploadGb: 10, ssoAllowed: false },
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 4),
+					};
+				}
+				return {};
+			}),
+		});
+
+		const result = await assertSeatActivationAllowed(workspaceId, 1);
+
+		expect(result.allowed).toBe(true);
+	});
+
+	it('enforces legacy-only included limits for export checks', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: true,
+							billingCadence: 'monthly',
+							createdAt: new Date(),
+							workspacePreferences: { enforcementMode: 'block' },
+							included: { seatMonths: 5, exports: 1, uploadGb: 10, sso: false },
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'usageEvents') {
+					return {
+						find: jest.fn(() => ({
+							toArray: jest.fn(async () => [{ metric: 'completed_export', quantity: 1 }]),
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 0),
+					};
+				}
+				return {};
+			}),
+		});
+
+		const result = await checkMetricLimit(workspaceId, 'completed_export', 1);
+
+		expect(result.allowed).toBe(false);
+	});
+});
+
+describe('billing account creation', () => {
+	it('creates a draft billing account with defaults', async () => {
+		const workspaceId = new ObjectId();
+		const insertedId = new ObjectId();
+
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn(() => ({
+				findOne: jest.fn(async () => null),
+				insertOne: jest.fn(async (doc: Record<string, unknown>) => {
+					expect(doc.status).toBe('draft');
+					expect(doc.meteringEnabled).toBe(false);
+					return { insertedId };
+				}),
+				createIndex: jest.fn(async () => undefined),
+			})),
+		});
+
+		const account = await createBillingAccountForWorkspace(workspaceId);
+		expect(account._id?.toString()).toBe(insertedId.toString());
+		expect(account.usageLimits?.seats).toBe(DEFAULT_INCLUDED_LIMITS.seatMonths);
+		expect(account.included.seatMonths).toBe(DEFAULT_INCLUDED_LIMITS.seatMonths);
+	});
+});
+
+describe('upload commit helpers', () => {
+	const workspaceId = new ObjectId();
+	const billingAccountId = new ObjectId();
+	let getAccountSpy: jest.SpiedFunction<typeof getBillingAccountByWorkspaceId>;
+	let recordUsageSpy: jest.SpiedFunction<typeof recordUsageEvent>;
+
+	beforeEach(() => {
+		getAccountSpy = jest.spyOn(
+			require('../../utils/billing/billingAccounts'),
+			'getBillingAccountByWorkspaceId',
+		).mockResolvedValue({
+			_id: billingAccountId,
+			workspaceId,
+			billingCadence: 'monthly',
+			createdAt: new Date(),
+		} as any);
+		recordUsageSpy = jest.spyOn(
+			require('../../utils/billing/usageRecording'),
+			'recordUsageEvent',
+		).mockResolvedValue(null);
+	});
+
+	afterEach(() => {
+		getAccountSpy.mockRestore();
+		recordUsageSpy.mockRestore();
+	});
+
+	it('normalizes size bytes', () => {
+		expect(normalizeSizeBytes(1024)).toBe(1024);
+		expect(normalizeSizeBytes(0)).toBeUndefined();
+		expect(normalizeSizeBytes(-1)).toBeUndefined();
+	});
+
+	it('detects new upload keys', () => {
+		expect(isNewUploadKey('', 'uploads/ws/file.png')).toBe(true);
+		expect(isNewUploadKey('uploads/ws/file.png', 'uploads/ws/file.png')).toBe(false);
+		expect(isNewUploadKey('uploads/ws/old.png', 'uploads/ws/new.png')).toBe(true);
+	});
+
+	it('collects upload commits from nested payloads', () => {
+		const commits = collectUploadCommitsFromValue([
+			{ key: 'uploads/ws/product/a.png', sizeBytes: 100 },
+			{ tagged_image_key: 'uploads/ws/product/tagged.png', sizeBytes: 250 },
+		]);
+
+		expect(commits).toEqual([
+			{ key: 'uploads/ws/product/a.png', sizeBytes: 100 },
+			{ key: 'uploads/ws/product/tagged.png', sizeBytes: 250 },
+		]);
+	});
+
+	it('records committed upload bytes with S3 key idempotency', async () => {
+		await recordCommittedUploadBytes({
+			workspaceId,
+			uploadKey: 'uploads/ws/source-files/doc.pdf',
+			sizeBytes: 4096,
+		});
+
+		expect(recordUsageSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metric: 'upload_bytes',
+				quantity: 4096,
+				sourceId: 'uploads/ws/source-files/doc.pdf',
+				idempotencyKey: 'upload:uploads/ws/source-files/doc.pdf',
+			}),
+		);
+	});
+
+	it('skips recording when asset key is unchanged', async () => {
+		await recordCommittedUploadIfNew({
+			workspaceId,
+			previousKey: 'uploads/ws/logo.png',
+			newKey: 'uploads/ws/logo.png',
+			sizeBytes: 2048,
+		});
+
+		expect(recordUsageSpy).not.toHaveBeenCalled();
+	});
+
+	it('sums only upload commits that have not been recorded yet', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn(() => ({
+				findOne: jest.fn(async ({ idempotencyKey }: { idempotencyKey: string }) => (
+					idempotencyKey === 'upload:uploads/ws/product/existing.png'
+						? { idempotencyKey }
+						: null
+				)),
+			})),
+		});
+
+		const total = await sumNewUploadCommitBytes(workspaceId, [
+			{ key: 'uploads/ws/product/existing.png', sizeBytes: 100 },
+			{ key: 'uploads/ws/product/new.png', sizeBytes: 250 },
+		]);
+
+		expect(total).toBe(250);
+	});
+
+	it('blocks new upload commits that would exceed the limit', async () => {
+		const getAccountSpy = jest.spyOn(
+			require('../../utils/billing/billingAccounts'),
+			'getBillingAccountByWorkspaceId',
+		).mockResolvedValue({
+			_id: billingAccountId,
+			workspaceId,
+			meteringEnabled: true,
+			billingCadence: 'monthly',
+			createdAt: new Date(),
+			workspacePreferences: { enforcementMode: 'block' },
+			included: { seatMonths: 1, exports: 1, uploadGb: 0.001, sso: false },
+		} as any);
+
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'usageEvents') {
+					return {
+						findOne: jest.fn(async () => null),
+						find: jest.fn(() => ({
+							toArray: jest.fn(async () => [
+								{ metric: 'upload_bytes', quantity: gbToBytes(0.001) - 1 },
+							]),
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'billingAddOnEvents') {
+					return {
+						createIndex: jest.fn(async () => undefined),
+						findOne: jest.fn(async () => null),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 0),
+					};
+				}
+				return {
+					findOne: jest.fn(async () => null),
+				};
+			}),
+		});
+
+		const result = await assertNewUploadCommitsAllowed(workspaceId, [
+			{ key: 'uploads/ws/product/new.png', sizeBytes: 2048 },
+		]);
+
+		expect(result.allowed).toBe(false);
+		getAccountSpy.mockRestore();
+	});
+
+	it('records when asset key changes', async () => {
+		await recordCommittedUploadIfNew({
+			workspaceId,
+			previousKey: 'uploads/ws/logo-old.png',
+			newKey: 'uploads/ws/logo-new.png',
+			sizeBytes: 2048,
+		});
+
+		expect(recordUsageSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				quantity: 2048,
+				idempotencyKey: 'upload:uploads/ws/logo-new.png',
+			}),
+		);
+	});
+});
+
+describe('upload reconciliation breakdown', () => {
+	const workspaceId = new ObjectId();
+	const periodStart = new Date('2026-06-01T00:00:00.000Z');
+	const periodEnd = new Date('2026-06-30T23:59:59.999Z');
+
+	it('separates upload commit bytes from platform adjustments', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn(() => ({
+				find: jest.fn(() => ({
+					toArray: jest.fn(async () => [
+						{
+							metric: 'upload_bytes',
+							source: 'upload_commit',
+							quantity: 1000,
+						},
+						{
+							metric: 'upload_bytes',
+							source: 'platform_adjustment',
+							quantity: 200,
+						},
+					]),
+				})),
+				createIndex: jest.fn(async () => undefined),
+			})),
+		});
+
+		const breakdown = await aggregateUploadReconciliationBreakdown({
+			workspaceId,
+			periodStart,
+			periodEnd,
+		});
+
+		expect(breakdown.commitBytes).toBe(1000);
+		expect(breakdown.adjustmentBytes).toBe(200);
+		expect(breakdown.totalBytes).toBe(1200);
+	});
+});
+
+describe('usage snapshots', () => {
+	const workspaceId = new ObjectId();
+	const billingAccountId = new ObjectId();
+	const periodStart = new Date('2026-06-01T00:00:00.000Z');
+	const periodEnd = new Date('2026-06-30T23:59:59.999Z');
+	const billingAccount = {
+		_id: billingAccountId,
+		workspaceId,
+		status: 'active',
+		meteringEnabled: true,
+		billingCadence: 'monthly',
+		currency: 'USD',
+		netTermDays: 30,
+		paymentMode: 'offline_wire',
+		periodStart,
+		periodEnd,
+		createdAt: periodStart,
+		updatedAt: periodStart,
+		usageLimits: { seats: 5, exports: 100, uploadGb: 10, ssoAllowed: false },
+		included: { seatMonths: 5, exports: 100, uploadGb: 10, sso: false },
+		workspacePreferences: { enforcementMode: 'block' },
+		sso: { enabled: false },
+		pastDue: false,
+	};
+
+	const { getCurrentUsageSnapshot, recomputeUsageSnapshot } = require('../../utils/billing/snapshots');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.spyOn(
+			require('../../utils/billing/billingAccounts'),
+			'getBillingAccountByWorkspaceId',
+		).mockResolvedValue(billingAccount);
+	});
+
+	it('recomputes zero-usage snapshots as ok', async () => {
+		const findOneAndUpdate = jest.fn(async () => ({
+			_id: new ObjectId(),
+			workspaceId,
+			billingAccountId,
+			periodStart,
+			periodEnd,
+			usage: { activeSeats: 0, exports: 0, uploadBytes: 0, uploadGb: 0 },
+			usageLimits: billingAccount.usageLimits,
+			limitStatus: {
+				seats: { used: 0, limit: 5, delta: 0, overLimit: false },
+				exports: { used: 0, limit: 100, delta: 0, overLimit: false },
+				uploadGb: { used: 0, limit: 10, delta: 0, overLimit: false },
+			},
+			reconciliationStatus: 'ok',
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		}));
+
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'usageEvents') {
+					return {
+						find: jest.fn(() => ({
+							toArray: jest.fn(async () => []),
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'billingAddOnEvents') {
+					return {
+						createIndex: jest.fn(async () => undefined),
+						findOne: jest.fn(async () => null),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 0),
+					};
+				}
+				if (name === 'usageSnapshots') {
+					return {
+						createIndex: jest.fn(async () => undefined),
+						findOneAndUpdate,
+					};
+				}
+				return {
+					findOne: jest.fn(async () => null),
+					createIndex: jest.fn(async () => undefined),
+				};
+			}),
+		});
+
+		const snapshot = await recomputeUsageSnapshot({
+			workspaceId,
+			billingAccount,
+		});
+
+		expect(snapshot.reconciliationStatus).toBe('ok');
+		expect(findOneAndUpdate).toHaveBeenCalled();
+	});
+
+	it('replaces stale pending snapshots on read', async () => {
+		const pendingSnapshot = {
+			_id: new ObjectId(),
+			workspaceId,
+			billingAccountId,
+			periodStart,
+			periodEnd,
+			reconciliationStatus: 'pending',
+		};
+
+		const findOne = jest.fn(async () => pendingSnapshot);
+		const findOneAndUpdate = jest.fn(async () => ({
+			...pendingSnapshot,
+			reconciliationStatus: 'ok',
+			usage: { activeSeats: 0, exports: 0, uploadBytes: 0, uploadGb: 0 },
+			usageLimits: billingAccount.usageLimits,
+			limitStatus: {
+				seats: { used: 0, limit: 5, delta: 0, overLimit: false },
+				exports: { used: 0, limit: 100, delta: 0, overLimit: false },
+				uploadGb: { used: 0, limit: 10, delta: 0, overLimit: false },
+			},
+			updatedAt: new Date(),
+		}));
+
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'usageEvents') {
+					return {
+						find: jest.fn(() => ({
+							toArray: jest.fn(async () => []),
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'billingAddOnEvents') {
+					return {
+						createIndex: jest.fn(async () => undefined),
+						findOne: jest.fn(async () => null),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 0),
+					};
+				}
+				if (name === 'usageSnapshots') {
+					return {
+						createIndex: jest.fn(async () => undefined),
+						findOne,
+						findOneAndUpdate,
+					};
+				}
+				return {
+					findOne: jest.fn(async () => null),
+					createIndex: jest.fn(async () => undefined),
+				};
+			}),
+		});
+
+		const snapshot = await getCurrentUsageSnapshot({
+			workspaceId,
+			billingAccount,
+		});
+
+		expect(snapshot?.reconciliationStatus).toBe('ok');
+		expect(findOneAndUpdate).toHaveBeenCalled();
+	});
+
+	it('recomputes old-shape snapshots that lack active seats and limit status', async () => {
+		const oldShapeSnapshot = {
+			_id: new ObjectId(),
+			workspaceId,
+			billingAccountId,
+			periodStart,
+			periodEnd,
+			reconciliationStatus: 'ok',
+			usage: { seatMonths: 3, exports: 0, uploadBytes: 0, uploadGb: 0 },
+			included: { seatMonths: 5, exports: 100, uploadGb: 10, sso: false },
+			overages: { seatMonths: 0, exports: 0, uploadGb: 0 },
+		};
+
+		const findOne = jest.fn(async () => oldShapeSnapshot);
+		const findOneAndUpdate = jest.fn(async () => ({
+			...oldShapeSnapshot,
+			usage: { activeSeats: 1, exports: 0, uploadBytes: 0, uploadGb: 0 },
+			usageLimits: billingAccount.usageLimits,
+			limitStatus: {
+				seats: { used: 1, limit: 5, delta: 0, overLimit: false },
+				exports: { used: 0, limit: 100, delta: 0, overLimit: false },
+				uploadGb: { used: 0, limit: 10, delta: 0, overLimit: false },
+			},
+			updatedAt: new Date(),
+		}));
+
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'usageEvents') {
+					return {
+						find: jest.fn(() => ({
+							toArray: jest.fn(async () => []),
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 1),
+					};
+				}
+				if (name === 'usageSnapshots') {
+					return {
+						createIndex: jest.fn(async () => undefined),
+						findOne,
+						findOneAndUpdate,
+					};
+				}
+				return {
+					findOne: jest.fn(async () => null),
+					createIndex: jest.fn(async () => undefined),
+				};
+			}),
+		});
+
+		const snapshot = await getCurrentUsageSnapshot({
+			workspaceId,
+			billingAccount,
+		});
+
+		expect(snapshot?.usage.activeSeats).toBe(1);
+		expect(findOneAndUpdate).toHaveBeenCalled();
+	});
+
+	it('builds summaries from active seats and ignores legacy seat-month events', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'usageEvents') {
+					return {
+						find: jest.fn(() => ({
+							toArray: jest.fn(async () => [
+								{ metric: 'activated_seat_month', quantity: 99 },
+								{ metric: 'completed_export', quantity: 2 },
+							]),
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 3),
+					};
+				}
+				return {
+					findOne: jest.fn(async () => null),
+					createIndex: jest.fn(async () => undefined),
+				};
+			}),
+		});
+
+		const summary = await buildBillingSummary({
+			workspaceId,
+			account: billingAccount,
+		});
+
+		expect(summary.usage.activeSeats).toBe(3);
+		expect(summary.usage.exports).toBe(2);
+		expect(summary.limitStatus.seats.used).toBe(3);
+	});
+});

--- a/src/tests/unit/billing.test.ts
+++ b/src/tests/unit/billing.test.ts
@@ -7,16 +7,25 @@ jest.mock('../../utils/db', () => ({
 
 const dbModule = jest.requireMock('../../utils/db') as any;
 
+const defaultCollectionFallback = () => ({
+	countDocuments: jest.fn(async () => 0),
+	createIndex: jest.fn(async () => undefined),
+	findOne: jest.fn(async () => null),
+	find: jest.fn(() => ({ toArray: jest.fn(async () => []) })),
+});
+
 const {
 	assertSeatActivationAllowed,
 	assertUsageActionAllowed,
 	checkMetricLimit,
 	isWorkspaceAccessFrozen,
 	isWorkspaceUsageFrozen,
+	verifySeatLimitAfterActivation,
 } = require('../../utils/billing/enforcement');
 const {
 	bytesToGb,
 	gbToBytes,
+	addUtcMonths,
 	calendarMonthKey,
 	computeBillingPeriodFromAnchor,
 	defaultPeriodForCadence,
@@ -90,6 +99,25 @@ describe('billing period helpers', () => {
 		expect(fromAnchor.periodStart.toISOString()).toBe(createdAt.toISOString());
 		expect(fromCreatedAt.periodStart.toISOString()).toBe(createdAt.toISOString());
 	});
+
+	it('clamps month-end anchors when advancing monthly periods', () => {
+		const jan31 = new Date('2026-01-31T12:00:00.000Z');
+		const febAnchor = addUtcMonths(jan31, 1);
+		const mar31 = new Date('2026-03-31T12:00:00.000Z');
+		const aprAnchor = addUtcMonths(mar31, 1);
+
+		expect(febAnchor.toISOString()).toBe('2026-02-28T12:00:00.000Z');
+		expect(aprAnchor.toISOString()).toBe('2026-04-30T12:00:00.000Z');
+	});
+
+	it('advances monthly periods from a Jan 31 anchor without skipping February', () => {
+		const anchor = new Date('2026-01-31T12:00:00.000Z');
+		const now = new Date('2026-03-15T12:00:00.000Z');
+		const { periodStart, periodEnd } = computeBillingPeriodFromAnchor(anchor, 'monthly', now);
+
+		expect(periodStart.toISOString()).toBe('2026-02-28T12:00:00.000Z');
+		expect(periodEnd.toISOString()).toBe('2026-03-28T11:59:59.999Z');
+	});
 });
 
 describe('workspace freezes', () => {
@@ -141,7 +169,7 @@ describe('metric enforcement', () => {
 						findOne: jest.fn(async () => null),
 					};
 				}
-				return {};
+				return defaultCollectionFallback();
 			}),
 		});
 
@@ -189,7 +217,7 @@ describe('metric enforcement', () => {
 						findOne: jest.fn(async () => null),
 					};
 				}
-				return {};
+				return defaultCollectionFallback();
 			}),
 		});
 
@@ -237,13 +265,63 @@ describe('metric enforcement', () => {
 						countDocuments: jest.fn(async () => 1),
 					};
 				}
-				return {};
+				return defaultCollectionFallback();
 			}),
 		});
 
 		const result = await assertUsageActionAllowed(workspaceId, 'export');
 
 		expect(result.allowed).toBe(false);
+	});
+
+	it('blocks a new export when completed and queued exports reach the limit', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: true,
+							billingCadence: 'monthly',
+							periodStart: new Date('2026-06-01T00:00:00.000Z'),
+							periodEnd: new Date('2026-06-30T23:59:59.999Z'),
+							createdAt: new Date('2026-06-01T00:00:00.000Z'),
+							workspacePreferences: { enforcementMode: 'block' },
+							usageLimits: { seats: 5, exports: 5, uploadGb: 10, ssoAllowed: false },
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'usageEvents') {
+					return {
+						find: jest.fn(() => ({
+							toArray: jest.fn(async () => [
+								{ metric: 'completed_export', quantity: 3 },
+							]),
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'exportJobs') {
+					return {
+						countDocuments: jest.fn(async () => 3),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 0),
+					};
+				}
+				return defaultCollectionFallback();
+			}),
+		});
+
+		const result = await checkMetricLimit(workspaceId, 'completed_export', 1);
+
+		expect(result.allowed).toBe(false);
+		expect(result.used).toBe(6);
 	});
 
 	it('does not block workspace-member invites at the seat limit', async () => {
@@ -284,7 +362,7 @@ describe('metric enforcement', () => {
 						findOne: jest.fn(async () => null),
 					};
 				}
-				return {};
+				return defaultCollectionFallback();
 			}),
 		});
 
@@ -322,7 +400,7 @@ describe('metric enforcement', () => {
 						countDocuments: jest.fn(async () => 2),
 					};
 				}
-				return {};
+				return defaultCollectionFallback();
 			}),
 		});
 
@@ -358,7 +436,7 @@ describe('metric enforcement', () => {
 						countDocuments: jest.fn(async () => 2),
 					};
 				}
-				return {};
+				return defaultCollectionFallback();
 			}),
 		});
 
@@ -394,7 +472,7 @@ describe('metric enforcement', () => {
 						countDocuments: jest.fn(async () => 2),
 					};
 				}
-				return {};
+				return defaultCollectionFallback();
 			}),
 		});
 
@@ -430,13 +508,45 @@ describe('metric enforcement', () => {
 						countDocuments: jest.fn(async () => 4),
 					};
 				}
-				return {};
+				return defaultCollectionFallback();
 			}),
 		});
 
 		const result = await assertSeatActivationAllowed(workspaceId, 1);
 
 		expect(result.allowed).toBe(true);
+	});
+
+	it('rejects post-activation verification when concurrent activations exceed the seat limit', async () => {
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn((name: string) => {
+				if (name === 'billingAccounts') {
+					return {
+						findOne: jest.fn(async () => ({
+							_id: new ObjectId(),
+							workspaceId,
+							meteringEnabled: true,
+							billingCadence: 'monthly',
+							createdAt: new Date(),
+							workspacePreferences: { enforcementMode: 'block' },
+							usageLimits: { seats: 1, exports: 10, uploadGb: 10, ssoAllowed: false },
+						})),
+						createIndex: jest.fn(async () => undefined),
+					};
+				}
+				if (name === 'users') {
+					return {
+						countDocuments: jest.fn(async () => 2),
+					};
+				}
+				return defaultCollectionFallback();
+			}),
+		});
+
+		const result = await verifySeatLimitAfterActivation(workspaceId);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('Seat limit reached');
 	});
 
 	it('enforces legacy-only included limits for export checks', async () => {
@@ -469,7 +579,7 @@ describe('metric enforcement', () => {
 						countDocuments: jest.fn(async () => 0),
 					};
 				}
-				return {};
+				return defaultCollectionFallback();
 			}),
 		});
 

--- a/src/tests/unit/createSourceFileAndFolder.test.ts
+++ b/src/tests/unit/createSourceFileAndFolder.test.ts
@@ -1,0 +1,87 @@
+import { ObjectId } from 'mongodb';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+jest.mock('../../utils/db', () => ({
+	getDb: jest.fn(),
+}));
+
+jest.mock('../../utils/tenantContext', () => ({
+	requireTenantContext: jest.fn(),
+	tenantObjectIdFilter: jest.fn((id: ObjectId) => ({ _id: id })),
+}));
+
+jest.mock('../../utils/auditLogV2', () => ({
+	recordAuditEvent: jest.fn(async () => undefined),
+}));
+
+jest.mock('../../utils/billing/enforcement', () => ({
+	assertUsageActionAllowed: jest.fn(async () => ({ allowed: true })),
+	checkUploadWouldExceedLimit: jest.fn(async () => ({ allowed: true })),
+}));
+
+jest.mock('../../utils/billing/billingAccounts', () => ({
+	getBillingAccountByWorkspaceId: jest.fn(),
+}));
+
+jest.mock('../../utils/billing/uploadCommit', () => ({
+	recordCommittedUploadBytes: jest.fn(async () => undefined),
+}));
+
+const dbModule = jest.requireMock('../../utils/db') as any;
+const tenantContext = jest.requireMock('../../utils/tenantContext') as any;
+const billingAccounts = jest.requireMock('../../utils/billing/billingAccounts') as any;
+
+const { lambdaHandler } = require('../../controllers/sourceFiles/createSourceFileAndFolder');
+
+const workspaceId = new ObjectId();
+
+const buildEvent = (body: Record<string, unknown>): APIGatewayProxyEvent => ({
+	httpMethod: 'POST',
+	path: '/source-files',
+	headers: { Authorization: 'Bearer token' },
+	body: JSON.stringify(body),
+	pathParameters: null,
+	queryStringParameters: null,
+	multiValueHeaders: {},
+	multiValueQueryStringParameters: null,
+	isBase64Encoded: false,
+	requestContext: { requestId: 'req-1' } as APIGatewayProxyEvent['requestContext'],
+	resource: '',
+	stageVariables: null,
+} as APIGatewayProxyEvent);
+
+describe('createSourceFileAndFolder', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		tenantContext.requireTenantContext.mockResolvedValue({
+			ok: true,
+			context: { workspaceId },
+			auth: { payload: { sub: 'user-sub' } },
+		});
+
+		billingAccounts.getBillingAccountByWorkspaceId.mockResolvedValue({
+			meteringEnabled: true,
+		});
+
+		dbModule.getDb.mockResolvedValue({
+			collection: jest.fn(() => ({
+				findOne: jest.fn(async () => null),
+				insertOne: jest.fn(async () => ({ insertedId: new ObjectId() })),
+			})),
+		});
+	});
+
+	it('requires sizeBytes for file uploads when metering is enabled', async () => {
+		const response = await lambdaHandler(buildEvent({
+			name: 'spec.pdf',
+			type: 'file',
+			key: 'uploads/ws/source-files/spec.pdf',
+		}));
+
+		expect(response.statusCode).toBe(400);
+		const body = JSON.parse(response.body);
+		expect(body.message).toContain('sizeBytes');
+	});
+});

--- a/src/tests/unit/enqueueReportExport.test.ts
+++ b/src/tests/unit/enqueueReportExport.test.ts
@@ -21,10 +21,15 @@ jest.mock('../../utils/db', () => ({
 	getDb: jest.fn(),
 }));
 
+jest.mock('../../utils/billing/enforcement', () => ({
+	assertUsageActionAllowed: jest.fn(async () => ({ allowed: true })),
+}));
+
 const authUtils = jest.requireMock('../../utils/authUtils') as any;
 const authenticatedUser = jest.requireMock('../../utils/authenticatedUser') as any;
 const exportJobs = jest.requireMock('../../utils/exportJobs') as any;
 const exportQueue = jest.requireMock('../../utils/exportQueue') as any;
+const billingEnforcement = jest.requireMock('../../utils/billing/enforcement') as any;
 
 const authenticateRequest = authUtils.authenticateRequest;
 
@@ -95,6 +100,12 @@ describe('enqueueReportExport', () => {
 				sort: { field: 'product_name', order: 'asc' },
 			},
 		});
+
+		expect(billingEnforcement.assertUsageActionAllowed).toHaveBeenCalledWith(
+			workspaceId,
+			'export',
+			1,
+		);
 
 		expect(enqueueExportJobMessage).toHaveBeenCalledWith({
 			schemaVersion: 1,

--- a/src/tests/unit/platformAdmin.test.ts
+++ b/src/tests/unit/platformAdmin.test.ts
@@ -456,6 +456,43 @@ describe('platformAdmin', () => {
 			const body = JSON.parse(response.body);
 			expect(body.message).toContain('whole number');
 		});
+
+		it('rejects invalid billing period date strings', async () => {
+			const workspaceId = new ObjectId();
+			mockValidOperatorAuth();
+
+			getCollection('workspaces').findOne.mockResolvedValue({
+				_id: workspaceId,
+				workspaceName: 'Acme',
+			});
+			getCollection('billingAccounts').findOne.mockResolvedValue({
+				_id: new ObjectId(),
+				workspaceId,
+				status: 'active',
+				meteringEnabled: true,
+				billingCadence: 'monthly',
+				currency: 'USD',
+				netTermDays: 30,
+				paymentMode: 'offline_wire',
+				usageLimits: { seats: 5, exports: 100, uploadGb: 10, ssoAllowed: false },
+				workspacePreferences: { enforcementMode: 'block' },
+				sso: { enabled: false },
+				pastDue: false,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			});
+
+			const response = await updateBillingAccountHandler(buildEvent({
+				httpMethod: 'PUT',
+				pathParameters: { workspaceId: workspaceId.toString() },
+				body: JSON.stringify({ periodStart: 'not-a-date' }),
+			}));
+
+			expect(response.statusCode).toBe(400);
+			const body = JSON.parse(response.body);
+			expect(body.message).toContain('periodStart');
+			expect(getCollection('billingAccounts').findOneAndUpdate).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('usage adjustments', () => {

--- a/src/tests/unit/platformAdmin.test.ts
+++ b/src/tests/unit/platformAdmin.test.ts
@@ -50,6 +50,8 @@ const { lambdaHandler: getSessionHandler } = require('../../controllers/platform
 const { lambdaHandler: provisionInviteHandler } = require('../../controllers/platformAdmin/provisionInvite');
 const { lambdaHandler: inviteWorkspaceAdminHandler } = require('../../controllers/platformAdmin/inviteWorkspaceAdmin');
 const { lambdaHandler: listAuditLogsHandler } = require('../../controllers/platformAdmin/listAuditLogs');
+const { lambdaHandler: updateBillingAccountHandler } = require('../../controllers/platformAdmin/updateBillingAccount');
+const { lambdaHandler: createUsageAdjustmentHandler } = require('../../controllers/platformAdmin/createUsageAdjustment');
 const { serializeWorkspaceListItem, serializePlatformAuditLog } = require('../../utils/platformAdminSerializers');
 
 const activeOperator = {
@@ -103,6 +105,8 @@ type CollectionMocks = Record<string, {
 	find: ReturnType<typeof jest.fn>;
 	aggregate: ReturnType<typeof jest.fn>;
 	countDocuments: ReturnType<typeof jest.fn>;
+	createIndex: ReturnType<typeof jest.fn>;
+	findOneAndUpdate: ReturnType<typeof jest.fn>;
 }>;
 
 const createDb = () => {
@@ -117,6 +121,8 @@ const createDb = () => {
 				find: jest.fn(),
 				aggregate: jest.fn(),
 				countDocuments: jest.fn(),
+				createIndex: jest.fn().mockResolvedValue(undefined as never),
+				findOneAndUpdate: jest.fn(),
 			};
 		}
 		return collections[name];
@@ -373,6 +379,98 @@ describe('platformAdmin', () => {
 			expect(response.statusCode).toBe(400);
 			const body = JSON.parse(response.body);
 			expect(body.message).toContain('different workspace');
+		});
+	});
+
+	describe('billing account updates', () => {
+		it('rejects enabling SSO when usage limits do not allow it', async () => {
+			const workspaceId = new ObjectId();
+			const billingAccountId = new ObjectId();
+			mockValidOperatorAuth();
+
+			getCollection('workspaces').findOne.mockResolvedValue({
+				_id: workspaceId,
+				workspaceName: 'Acme',
+			});
+			getCollection('billingAccounts').findOne.mockResolvedValue({
+				_id: billingAccountId,
+				workspaceId,
+				status: 'active',
+				meteringEnabled: true,
+				billingCadence: 'monthly',
+				currency: 'USD',
+				netTermDays: 30,
+				paymentMode: 'offline_wire',
+				periodStart: new Date(),
+				periodEnd: new Date(),
+				usageLimits: { seats: 5, exports: 100, uploadGb: 10, ssoAllowed: false },
+				workspacePreferences: { enforcementMode: 'block' },
+				sso: { enabled: false },
+				pastDue: false,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			});
+
+			const response = await updateBillingAccountHandler(buildEvent({
+				httpMethod: 'PUT',
+				pathParameters: { workspaceId: workspaceId.toString() },
+				body: JSON.stringify({ ssoEnabled: true }),
+			}));
+
+			expect(response.statusCode).toBe(400);
+			expect(getCollection('billingAccounts').findOneAndUpdate).not.toHaveBeenCalled();
+		});
+
+		it('rejects fractional seat limits', async () => {
+			const workspaceId = new ObjectId();
+			mockValidOperatorAuth();
+
+			getCollection('workspaces').findOne.mockResolvedValue({
+				_id: workspaceId,
+				workspaceName: 'Acme',
+			});
+			getCollection('billingAccounts').findOne.mockResolvedValue({
+				_id: new ObjectId(),
+				workspaceId,
+				status: 'active',
+				meteringEnabled: true,
+				billingCadence: 'monthly',
+				currency: 'USD',
+				netTermDays: 30,
+				paymentMode: 'offline_wire',
+				usageLimits: { seats: 5, exports: 100, uploadGb: 10, ssoAllowed: false },
+				workspacePreferences: { enforcementMode: 'block' },
+				sso: { enabled: false },
+				pastDue: false,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			});
+
+			const response = await updateBillingAccountHandler(buildEvent({
+				httpMethod: 'PUT',
+				pathParameters: { workspaceId: workspaceId.toString() },
+				body: JSON.stringify({ usageLimits: { seats: 2.5 } }),
+			}));
+
+			expect(response.statusCode).toBe(400);
+			const body = JSON.parse(response.body);
+			expect(body.message).toContain('whole number');
+		});
+	});
+
+	describe('usage adjustments', () => {
+		it('rejects legacy seat-month adjustments', async () => {
+			const workspaceId = new ObjectId();
+			mockValidOperatorAuth();
+
+			const response = await createUsageAdjustmentHandler(buildEvent({
+				httpMethod: 'POST',
+				pathParameters: { workspaceId: workspaceId.toString() },
+				body: JSON.stringify({ metric: 'activated_seat_month', quantityDelta: 1 }),
+			}));
+
+			expect(response.statusCode).toBe(400);
+			expect(getCollection('usageAdjustments').insertOne).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/tests/unit/tenantContext.test.ts
+++ b/src/tests/unit/tenantContext.test.ts
@@ -9,6 +9,10 @@ jest.mock('../../utils/authenticatedUser', () => ({
 	getAuthenticatedUserContext: jest.fn(),
 }));
 
+jest.mock('../../utils/billing/enforcement', () => ({
+	assertWorkspaceAccessAllowed: jest.fn(async () => ({ allowed: true })),
+}));
+
 const authUtils = jest.requireMock('../../utils/authUtils') as any;
 const authenticatedUser = jest.requireMock('../../utils/authenticatedUser') as any;
 

--- a/src/tests/unit/userRemoval.test.ts
+++ b/src/tests/unit/userRemoval.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../utils/auditLog', () => ({
 jest.mock('../../utils/billing/enforcement', () => ({
 	assertWorkspaceAccessAllowed: jest.fn(async () => ({ allowed: true })),
 	assertSeatActivationAllowed: jest.fn(async () => ({ allowed: true })),
+	verifySeatLimitAfterActivation: jest.fn(async () => ({ allowed: true })),
 }));
 
 const cognitoSend = jest.fn(async () => ({}));
@@ -51,6 +52,7 @@ const {
 	countActiveWorkspaceAdmins,
 	reactivateWorkspaceUser,
 	UserRemovalError,
+	UserReactivationError,
 } = require('../../utils/userRemoval');
 const { getAuthenticatedUserContext } = require('../../utils/authenticatedUser');
 const { lambdaHandler: deleteUserHandler } = require('../../controllers/users/deleteUser');
@@ -227,7 +229,69 @@ describe('userRemoval', () => {
 
 		expect(result.reactivated).toBe(true);
 		expect(billingEnforcement.assertSeatActivationAllowed).toHaveBeenCalledWith(workspaceId, 1);
+		expect(billingEnforcement.verifySeatLimitAfterActivation).toHaveBeenCalledWith(workspaceId);
 		expect(collections.workspaces.updateOne).toHaveBeenCalled();
+	});
+
+	it('rolls back Cognito when database activation fails after enabling an existing user', async () => {
+		const { collections, primeCollections } = createDb();
+		primeCollections('users', 'workspaces');
+		const inactiveUser = {
+			_id: targetUserId,
+			email: 'member@example.com',
+			name: 'Member',
+			status: 'inactive',
+			userType: 'user',
+			cognitoSub: 'sub-1',
+			workspaceId,
+		};
+
+		collections.users.find.mockReturnValue({
+			toArray: jest.fn(async () => [inactiveUser]),
+		});
+		collections.users.updateOne.mockRejectedValueOnce(new Error('Database write failed'));
+
+		await expect(reactivateWorkspaceUser({
+			email: 'member@example.com',
+			name: 'Member',
+			workspaceId,
+			actorUserId,
+		})).rejects.toBeInstanceOf(UserReactivationError);
+
+		expect(cognitoSend).toHaveBeenCalled();
+		expect(collections.users.updateOne).toHaveBeenCalled();
+	});
+
+	it('rejects reactivation when post-activation seat verification fails', async () => {
+		const { collections, primeCollections } = createDb();
+		primeCollections('users', 'workspaces');
+		const inactiveUser = {
+			_id: targetUserId,
+			email: 'member@example.com',
+			name: 'Member',
+			status: 'inactive',
+			userType: 'user',
+			cognitoSub: 'sub-1',
+			workspaceId,
+		};
+
+		collections.users.find.mockReturnValue({
+			toArray: jest.fn(async () => [inactiveUser]),
+		});
+		billingEnforcement.verifySeatLimitAfterActivation.mockResolvedValueOnce({
+			allowed: false,
+			reason: 'Seat limit reached for this workspace',
+		});
+
+		await expect(reactivateWorkspaceUser({
+			email: 'member@example.com',
+			name: 'Member',
+			workspaceId,
+			actorUserId,
+		})).rejects.toBeInstanceOf(UserReactivationError);
+
+		expect(collections.users.updateOne).toHaveBeenCalledTimes(2);
+		expect(collections.workspaces.updateOne).toHaveBeenCalledTimes(2);
 	});
 
 	it('rejects inactive users in authenticated user context', async () => {

--- a/src/tests/unit/userRemoval.test.ts
+++ b/src/tests/unit/userRemoval.test.ts
@@ -1,0 +1,288 @@
+import { ObjectId } from 'mongodb';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+jest.mock('../../utils/db', () => ({
+	getDb: jest.fn(),
+}));
+
+jest.mock('../../utils/authUtils', () => ({
+	authenticateRequest: jest.fn(),
+}));
+
+jest.mock('../../utils/auditLog', () => ({
+	updateAuditLog: jest.fn(),
+}));
+
+jest.mock('../../utils/billing/enforcement', () => ({
+	assertWorkspaceAccessAllowed: jest.fn(async () => ({ allowed: true })),
+	assertSeatActivationAllowed: jest.fn(async () => ({ allowed: true })),
+}));
+
+const cognitoSend = jest.fn(async () => ({}));
+
+jest.mock('@aws-sdk/client-cognito-identity-provider', () => ({
+	CognitoIdentityProviderClient: jest.fn().mockImplementation(() => ({
+		send: cognitoSend,
+	})),
+	AdminDisableUserCommand: jest.fn(),
+	AdminEnableUserCommand: jest.fn(),
+	AdminRemoveUserFromGroupCommand: jest.fn(),
+	AdminUpdateUserAttributesCommand: jest.fn(),
+	AdminAddUserToGroupCommand: jest.fn(),
+	AdminDeleteUserCommand: jest.fn(),
+	UserNotFoundException: class UserNotFoundException extends Error {},
+}));
+
+jest.mock('../../utils/platformInviteUtils', () => ({
+	normalizeInviteEmail: (email: string) => email.trim().toLowerCase(),
+	deleteCognitoInviteUser: jest.fn(async () => undefined),
+	cognitoUserExists: jest.fn(async () => true),
+	createInvitedCognitoUser: jest.fn(async () => ({ cognitoSub: 'new-sub' })),
+}));
+
+const dbModule = jest.requireMock('../../utils/db') as any;
+const authUtils = jest.requireMock('../../utils/authUtils') as any;
+const inviteUtils = jest.requireMock('../../utils/platformInviteUtils') as any;
+const billingEnforcement = jest.requireMock('../../utils/billing/enforcement') as any;
+
+const {
+	deactivateWorkspaceUser,
+	countActiveWorkspaceAdmins,
+	reactivateWorkspaceUser,
+	UserRemovalError,
+} = require('../../utils/userRemoval');
+const { getAuthenticatedUserContext } = require('../../utils/authenticatedUser');
+const { lambdaHandler: deleteUserHandler } = require('../../controllers/users/deleteUser');
+
+type CollectionMocks = Record<string, {
+	findOne: ReturnType<typeof jest.fn>;
+	updateOne: ReturnType<typeof jest.fn>;
+	updateMany: ReturnType<typeof jest.fn>;
+	deleteMany: ReturnType<typeof jest.fn>;
+	countDocuments: ReturnType<typeof jest.fn>;
+	find: ReturnType<typeof jest.fn>;
+}>;
+
+const workspaceId = new ObjectId();
+const actorUserId = new ObjectId();
+const targetUserId = new ObjectId();
+
+const createDb = () => {
+	const collections: CollectionMocks = {};
+
+	const getCollection = (name: string) => {
+		if (!collections[name]) {
+			collections[name] = {
+				findOne: jest.fn(),
+				updateOne: jest.fn(async () => ({ modifiedCount: 1 })),
+				updateMany: jest.fn(async () => ({ modifiedCount: 1 })),
+				deleteMany: jest.fn(async () => ({ deletedCount: 0 })),
+				countDocuments: jest.fn(async () => 0),
+				find: jest.fn(() => ({
+					toArray: jest.fn(async () => []),
+				})),
+			};
+		}
+		return collections[name];
+	};
+
+	dbModule.getDb.mockResolvedValue({
+		collection: getCollection,
+	});
+
+	const primeCollections = (...names: string[]) => {
+		names.forEach((name) => getCollection(name));
+	};
+
+	return { collections, getCollection, primeCollections };
+};
+
+const buildDeleteEvent = (targetId: string): APIGatewayProxyEvent => ({
+	httpMethod: 'DELETE',
+	path: `/users/${targetId}`,
+	headers: { Authorization: 'Bearer token' },
+	body: null,
+	pathParameters: { id: targetId },
+	queryStringParameters: null,
+	multiValueHeaders: {},
+	multiValueQueryStringParameters: null,
+	isBase64Encoded: false,
+	requestContext: { requestId: 'req-1' } as APIGatewayProxyEvent['requestContext'],
+	resource: '',
+	stageVariables: null,
+} as APIGatewayProxyEvent);
+
+describe('userRemoval', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		cognitoSend.mockResolvedValue({});
+		inviteUtils.cognitoUserExists.mockResolvedValue(true);
+	});
+
+	it('deactivates an active user and cleans up membership references', async () => {
+		const { collections, primeCollections } = createDb();
+		primeCollections('users', 'workspaces', 'departments', 'projects', 'bookmarks');
+		const activeUser = {
+			_id: targetUserId,
+			email: 'member@example.com',
+			name: 'Member',
+			status: 'active',
+			userType: 'user',
+			cognitoSub: 'sub-1',
+			workspaceId,
+		};
+
+		collections.users.findOne
+			.mockResolvedValueOnce(activeUser)
+			.mockResolvedValueOnce({ ...activeUser, status: 'inactive' });
+
+		await deactivateWorkspaceUser({
+			targetUserId,
+			workspaceId,
+			actorUserId,
+		});
+
+		expect(collections.workspaces.updateOne).toHaveBeenCalled();
+		expect(collections.departments.updateMany).toHaveBeenCalled();
+		expect(collections.projects.updateMany).toHaveBeenCalled();
+		expect(collections.bookmarks.deleteMany).toHaveBeenCalled();
+		expect(collections.users.updateOne).toHaveBeenCalledWith(
+			{ _id: targetUserId, workspaceId },
+			expect.objectContaining({
+				$set: expect.objectContaining({ status: 'inactive' }),
+			}),
+		);
+		expect(inviteUtils.deleteCognitoInviteUser).not.toHaveBeenCalled();
+	});
+
+	it('deletes Cognito for invited users being removed', async () => {
+		const { collections, primeCollections } = createDb();
+		primeCollections('users', 'workspaces', 'departments', 'projects', 'bookmarks');
+		const invitedUser = {
+			_id: targetUserId,
+			email: 'invited@example.com',
+			name: 'Invited',
+			status: 'invited',
+			userType: 'user',
+			cognitoSub: 'sub-2',
+			workspaceId,
+		};
+
+		collections.users.findOne
+			.mockResolvedValueOnce(invitedUser)
+			.mockResolvedValueOnce({ ...invitedUser, status: 'inactive' });
+
+		await deactivateWorkspaceUser({
+			targetUserId,
+			workspaceId,
+			actorUserId,
+		});
+
+		expect(inviteUtils.deleteCognitoInviteUser).toHaveBeenCalledWith('invited@example.com');
+	});
+
+	it('blocks removing the last active workspace admin', async () => {
+		const { collections, primeCollections } = createDb();
+		primeCollections('users');
+		collections.users.findOne.mockResolvedValue({
+			_id: targetUserId,
+			email: 'admin@example.com',
+			status: 'active',
+			userType: 'admin',
+			workspaceId,
+		});
+		collections.users.countDocuments.mockResolvedValue(1);
+
+		await expect(deactivateWorkspaceUser({
+			targetUserId,
+			workspaceId,
+			actorUserId,
+		})).rejects.toBeInstanceOf(UserRemovalError);
+	});
+
+	it('reactivates an inactive user after checking seat activation limits', async () => {
+		const { collections, primeCollections } = createDb();
+		primeCollections('users', 'workspaces');
+		const inactiveUser = {
+			_id: targetUserId,
+			email: 'member@example.com',
+			name: 'Member',
+			status: 'inactive',
+			userType: 'user',
+			cognitoSub: 'sub-1',
+			workspaceId,
+		};
+
+		collections.users.find.mockReturnValue({
+			toArray: jest.fn(async () => [inactiveUser]),
+		});
+
+		const result = await reactivateWorkspaceUser({
+			email: 'member@example.com',
+			name: 'Member',
+			workspaceId,
+			actorUserId,
+		});
+
+		expect(result.reactivated).toBe(true);
+		expect(billingEnforcement.assertSeatActivationAllowed).toHaveBeenCalledWith(workspaceId, 1);
+		expect(collections.workspaces.updateOne).toHaveBeenCalled();
+	});
+
+	it('rejects inactive users in authenticated user context', async () => {
+		const { collections, primeCollections } = createDb();
+		primeCollections('users');
+		collections.users.findOne.mockResolvedValue({
+			_id: targetUserId,
+			workspaceId,
+			status: 'inactive',
+		});
+
+		const context = await getAuthenticatedUserContext('sub-inactive');
+		expect(context).toBeNull();
+	});
+});
+
+describe('deleteUser handler', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		authUtils.authenticateRequest.mockResolvedValue({
+			isValid: true,
+			payload: { sub: 'admin-sub', 'cognito:groups': ['admin'] },
+		});
+	});
+
+	it('blocks self-removal', async () => {
+		const selfId = actorUserId.toString();
+		const { collections, primeCollections } = createDb();
+		primeCollections('users');
+		collections.users.findOne.mockResolvedValue({
+			_id: actorUserId,
+			workspaceId,
+			status: 'active',
+			cognitoSub: 'admin-sub',
+		});
+
+		const response = await deleteUserHandler(buildDeleteEvent(selfId));
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('returns forbidden for non-admin callers', async () => {
+		authUtils.authenticateRequest.mockResolvedValue({
+			isValid: true,
+			payload: { sub: 'user-sub', 'cognito:groups': ['user'] },
+		});
+		const { collections, primeCollections } = createDb();
+		primeCollections('users');
+		collections.users.findOne.mockResolvedValue({
+			_id: actorUserId,
+			workspaceId,
+			status: 'active',
+			cognitoSub: 'user-sub',
+		});
+
+		const response = await deleteUserHandler(buildDeleteEvent(targetUserId.toString()));
+		expect(response.statusCode).toBe(403);
+	});
+});

--- a/src/utils/authenticatedUser.ts
+++ b/src/utils/authenticatedUser.ts
@@ -20,10 +20,14 @@ export const getAuthenticatedUserContext = async (
 	const db = await getDb();
 	const user = await db.collection<User>('users').findOne(
 		{ cognitoSub },
-		{ projection: { _id: 1, workspaceId: 1 } },
+		{ projection: { _id: 1, workspaceId: 1, status: 1 } },
 	);
 
 	if (!user?._id || !(user.workspaceId instanceof ObjectId)) {
+		return null;
+	}
+
+	if (user.status === 'inactive') {
 		return null;
 	}
 

--- a/src/utils/billing/billingAccounts.ts
+++ b/src/utils/billing/billingAccounts.ts
@@ -1,0 +1,147 @@
+import { ObjectId } from 'mongodb';
+import {
+	BILLING_ACCOUNTS_COLLECTION,
+	type BillingAccount,
+	type DeprecatedIncludedLimits,
+	type UsageLimits,
+} from '../../models/billing';
+import { getDb } from '../db';
+import { defaultPeriodForCadence } from './billingPeriod';
+
+let hasEnsuredBillingIndexes = false;
+
+export const DEFAULT_USAGE_LIMITS: UsageLimits = {
+	seats: 5,
+	exports: 100,
+	uploadGb: 10,
+	ssoAllowed: false,
+};
+
+/** @deprecated Use DEFAULT_USAGE_LIMITS. */
+export const DEFAULT_INCLUDED_LIMITS: DeprecatedIncludedLimits = {
+	seatMonths: DEFAULT_USAGE_LIMITS.seats,
+	exports: DEFAULT_USAGE_LIMITS.exports,
+	uploadGb: DEFAULT_USAGE_LIMITS.uploadGb,
+	sso: DEFAULT_USAGE_LIMITS.ssoAllowed,
+};
+
+export const usageLimitsToIncluded = (usageLimits: UsageLimits): DeprecatedIncludedLimits => ({
+	seatMonths: usageLimits.seats,
+	exports: usageLimits.exports,
+	uploadGb: usageLimits.uploadGb,
+	sso: usageLimits.ssoAllowed,
+});
+
+export const normalizeUsageLimits = (account?: Pick<BillingAccount, 'usageLimits' | 'included'> | null): UsageLimits => {
+	const source = account?.usageLimits;
+	const legacy = account?.included;
+
+	return {
+		seats: typeof source?.seats === 'number'
+			? source.seats
+			: typeof legacy?.seatMonths === 'number'
+				? legacy.seatMonths
+				: DEFAULT_USAGE_LIMITS.seats,
+		exports: typeof source?.exports === 'number'
+			? source.exports
+			: typeof legacy?.exports === 'number'
+				? legacy.exports
+				: DEFAULT_USAGE_LIMITS.exports,
+		uploadGb: typeof source?.uploadGb === 'number'
+			? source.uploadGb
+			: typeof legacy?.uploadGb === 'number'
+				? legacy.uploadGb
+				: DEFAULT_USAGE_LIMITS.uploadGb,
+		ssoAllowed: typeof source?.ssoAllowed === 'boolean'
+			? source.ssoAllowed
+			: typeof legacy?.sso === 'boolean'
+				? legacy.sso
+				: DEFAULT_USAGE_LIMITS.ssoAllowed,
+	};
+};
+
+export const ensureBillingAccountIndexes = async (): Promise<void> => {
+	if (hasEnsuredBillingIndexes) return;
+
+	const db = await getDb();
+	const collection = db.collection<BillingAccount>(BILLING_ACCOUNTS_COLLECTION);
+
+	await Promise.all([
+		collection.createIndex({ workspaceId: 1 }, { unique: true }),
+		collection.createIndex({ status: 1 }),
+		collection.createIndex({ meteringEnabled: 1 }),
+		collection.createIndex({ pastDue: 1 }),
+	]);
+
+	hasEnsuredBillingIndexes = true;
+};
+
+export const createBillingAccountForWorkspace = async (
+	workspaceId: ObjectId,
+): Promise<BillingAccount & { _id: ObjectId }> => {
+	await ensureBillingAccountIndexes();
+
+	const db = await getDb();
+	const collection = db.collection<BillingAccount>(BILLING_ACCOUNTS_COLLECTION);
+	const existing = await collection.findOne({ workspaceId });
+	if (existing?._id) {
+		return existing as BillingAccount & { _id: ObjectId };
+	}
+
+	const now = new Date();
+	const { periodStart, periodEnd } = defaultPeriodForCadence('monthly', now);
+
+	const account: BillingAccount = {
+		workspaceId,
+		status: 'draft',
+		meteringEnabled: false,
+		billingCadence: 'monthly',
+		currency: 'USD',
+		netTermDays: 30,
+		paymentMode: 'offline_wire',
+		periodStart,
+		periodEnd,
+		usageLimits: { ...DEFAULT_USAGE_LIMITS },
+		included: { ...DEFAULT_INCLUDED_LIMITS },
+		workspacePreferences: { enforcementMode: 'overage' },
+		sso: { enabled: false },
+		pastDue: false,
+		createdAt: now,
+		updatedAt: now,
+	};
+
+	const result = await collection.insertOne(account);
+	return { ...account, _id: result.insertedId };
+};
+
+export const getBillingAccountByWorkspaceId = async (
+	workspaceId: ObjectId,
+): Promise<(BillingAccount & { _id: ObjectId }) | null> => {
+	await ensureBillingAccountIndexes();
+	const db = await getDb();
+	const account = await db.collection<BillingAccount>(BILLING_ACCOUNTS_COLLECTION).findOne({ workspaceId });
+	if (!account?._id) return null;
+	return account as BillingAccount & { _id: ObjectId };
+};
+
+export const backfillBillingAccounts = async (): Promise<{ created: number; existing: number }> => {
+	await ensureBillingAccountIndexes();
+	const db = await getDb();
+	const workspaces = await db.collection('workspaces').find({}, { projection: { _id: 1 } }).toArray();
+
+	let created = 0;
+	let existing = 0;
+
+	for (const workspace of workspaces) {
+		if (!(workspace._id instanceof ObjectId)) continue;
+		const account = await getBillingAccountByWorkspaceId(workspace._id);
+		if (account) {
+			existing += 1;
+			continue;
+		}
+		await createBillingAccountForWorkspace(workspace._id);
+		created += 1;
+	}
+
+	return { created, existing };
+};

--- a/src/utils/billing/billingPeriod.ts
+++ b/src/utils/billing/billingPeriod.ts
@@ -6,20 +6,43 @@ export const bytesToGb = (bytes: number): number => bytes / BYTES_PER_GB;
 
 export const gbToBytes = (gb: number): number => gb * BYTES_PER_GB;
 
+const daysInUtcMonth = (year: number, month: number): number =>
+	new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+
 export const addUtcMonths = (date: Date, months: number): Date => {
 	const year = date.getUTCFullYear();
 	const month = date.getUTCMonth();
 	const day = date.getUTCDate();
+	const totalMonths = month + months;
+	const targetYear = year + Math.floor(totalMonths / 12);
+	const targetMonth = ((totalMonths % 12) + 12) % 12;
+	const clampedDay = Math.min(day, daysInUtcMonth(targetYear, targetMonth));
 
 	return new Date(Date.UTC(
-		year,
-		month + months,
-		day,
+		targetYear,
+		targetMonth,
+		clampedDay,
 		date.getUTCHours(),
 		date.getUTCMinutes(),
 		date.getUTCSeconds(),
 		date.getUTCMilliseconds(),
 	));
+};
+
+export const parseOptionalIsoDate = (
+	value: unknown,
+	fieldName: string,
+): { ok: true; date: Date } | { ok: false; message: string } => {
+	if (typeof value !== 'string' || !value.trim()) {
+		return { ok: false, message: `${fieldName} must be a valid ISO date string` };
+	}
+
+	const date = new Date(value);
+	if (!Number.isFinite(date.getTime())) {
+		return { ok: false, message: `${fieldName} must be a valid ISO date string` };
+	}
+
+	return { ok: true, date };
 };
 
 const cadenceMonths = (cadence: BillingCadence): number => (cadence === 'yearly' ? 12 : 1);

--- a/src/utils/billing/billingPeriod.ts
+++ b/src/utils/billing/billingPeriod.ts
@@ -1,0 +1,66 @@
+import type { BillingAccount, BillingCadence } from '../../models/billing';
+
+const BYTES_PER_GB = 1024 * 1024 * 1024;
+
+export const bytesToGb = (bytes: number): number => bytes / BYTES_PER_GB;
+
+export const gbToBytes = (gb: number): number => gb * BYTES_PER_GB;
+
+export const addUtcMonths = (date: Date, months: number): Date => {
+	const year = date.getUTCFullYear();
+	const month = date.getUTCMonth();
+	const day = date.getUTCDate();
+
+	return new Date(Date.UTC(
+		year,
+		month + months,
+		day,
+		date.getUTCHours(),
+		date.getUTCMinutes(),
+		date.getUTCSeconds(),
+		date.getUTCMilliseconds(),
+	));
+};
+
+const cadenceMonths = (cadence: BillingCadence): number => (cadence === 'yearly' ? 12 : 1);
+
+export const endOfBillingPeriod = (periodStart: Date, cadence: BillingCadence): Date => {
+	const nextPeriodStart = addUtcMonths(periodStart, cadenceMonths(cadence));
+	return new Date(nextPeriodStart.getTime() - 1);
+};
+
+export const computeBillingPeriodFromAnchor = (
+	anchor: Date,
+	cadence: BillingCadence,
+	now: Date = new Date(),
+): { periodStart: Date; periodEnd: Date } => {
+	let periodStart = new Date(anchor);
+	let periodEnd = endOfBillingPeriod(periodStart, cadence);
+
+	while (now.getTime() > periodEnd.getTime()) {
+		periodStart = addUtcMonths(periodStart, cadenceMonths(cadence));
+		periodEnd = endOfBillingPeriod(periodStart, cadence);
+	}
+
+	return { periodStart, periodEnd };
+};
+
+export const resolveBillingPeriod = (
+	account: Pick<BillingAccount, 'billingCadence' | 'periodStart' | 'periodEnd' | 'createdAt'>,
+	now: Date = new Date(),
+): { periodStart: Date; periodEnd: Date } => {
+	const anchor = account.periodStart ?? account.createdAt;
+	return computeBillingPeriodFromAnchor(anchor, account.billingCadence, now);
+};
+
+export const calendarMonthKey = (date: Date): string =>
+	`${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+
+export const defaultPeriodForCadence = (
+	cadence: BillingCadence,
+	now: Date = new Date(),
+): { periodStart: Date; periodEnd: Date } => {
+	const periodStart = now;
+	const periodEnd = endOfBillingPeriod(periodStart, cadence);
+	return { periodStart, periodEnd };
+};

--- a/src/utils/billing/enforcement.ts
+++ b/src/utils/billing/enforcement.ts
@@ -3,6 +3,7 @@ import type { Workspace } from '../../models/workspace';
 import { getDb } from '../db';
 import { getBillingAccountByWorkspaceId, normalizeUsageLimits } from './billingAccounts';
 import { bytesToGb, gbToBytes, resolveBillingPeriod } from './billingPeriod';
+import { countActiveExportJobs } from '../exportJobs';
 import { aggregateUsageForPeriod, countActiveWorkspaceSeats } from './usageRecording';
 
 type EnforceableUsageMetric = 'completed_export' | 'upload_bytes';
@@ -94,7 +95,8 @@ export const checkMetricLimit = async (
 	let limit = 0;
 
 	if (metric === 'completed_export') {
-		used = usage.exports;
+		const pendingExports = await countActiveExportJobs({ workspaceId, periodStart, periodEnd });
+		used = usage.exports + pendingExports;
 		limit = usageLimits.exports;
 	} else {
 		used = usage.uploadBytes;
@@ -181,6 +183,24 @@ export const assertSeatActivationAllowed = async (
 
 	// Every future path that changes a workspace member to active must run this guard first.
 	if (projectedActiveSeats > usageLimits.seats) {
+		return { allowed: false, reason: 'Seat limit reached for this workspace' };
+	}
+
+	return { allowed: true };
+};
+
+export const verifySeatLimitAfterActivation = async (
+	workspaceId: ObjectId,
+): Promise<{ allowed: true } | { allowed: false; reason: string }> => {
+	const account = await getBillingAccountByWorkspaceId(workspaceId);
+	if (!account) return { allowed: true };
+	if (!account.meteringEnabled || account.workspacePreferences.enforcementMode === 'overage') {
+		return { allowed: true };
+	}
+
+	const usageLimits = normalizeUsageLimits(account);
+	const activeSeats = await countActiveWorkspaceSeats(workspaceId);
+	if (activeSeats > usageLimits.seats) {
 		return { allowed: false, reason: 'Seat limit reached for this workspace' };
 	}
 

--- a/src/utils/billing/enforcement.ts
+++ b/src/utils/billing/enforcement.ts
@@ -1,0 +1,195 @@
+import { ObjectId } from 'mongodb';
+import type { Workspace } from '../../models/workspace';
+import { getDb } from '../db';
+import { getBillingAccountByWorkspaceId, normalizeUsageLimits } from './billingAccounts';
+import { bytesToGb, gbToBytes, resolveBillingPeriod } from './billingPeriod';
+import { aggregateUsageForPeriod, countActiveWorkspaceSeats } from './usageRecording';
+
+type EnforceableUsageMetric = 'completed_export' | 'upload_bytes';
+
+export type MetricLimitCheck = {
+	allowed: boolean;
+	meteringEnabled: boolean;
+	enforcementMode: 'overage' | 'block';
+	overage: boolean;
+	used: number;
+	limit: number;
+	metric: EnforceableUsageMetric;
+	reason?: string;
+};
+
+export const isWorkspaceAccessFrozen = (workspace: Workspace): boolean =>
+	Boolean(workspace.workspaceAccessFreeze?.enabled);
+
+export const isWorkspaceUsageFrozen = (workspace: Workspace): boolean =>
+	Boolean(workspace.workspaceUsageFreeze?.enabled);
+
+export const getWorkspaceById = async (workspaceId: ObjectId): Promise<Workspace | null> => {
+	const db = await getDb();
+	return db.collection<Workspace>('workspaces').findOne({ _id: workspaceId });
+};
+
+export const assertWorkspaceAccessAllowed = async (
+	workspaceId: ObjectId,
+): Promise<{ allowed: true } | { allowed: false; reason: string }> => {
+	const workspace = await getWorkspaceById(workspaceId);
+	if (!workspace) return { allowed: false, reason: 'Workspace not found' };
+	if (isWorkspaceAccessFrozen(workspace)) {
+		return { allowed: false, reason: 'Workspace access is frozen' };
+	}
+	return { allowed: true };
+};
+
+export const assertUsageActionAllowed = async (
+	workspaceId: ObjectId,
+	action: 'invite' | 'export' | 'upload',
+	additionalQuantity?: number,
+): Promise<{ allowed: true } | { allowed: false; reason: string }> => {
+	const workspace = await getWorkspaceById(workspaceId);
+	if (!workspace) return { allowed: false, reason: 'Workspace not found' };
+	if (isWorkspaceAccessFrozen(workspace)) {
+		return { allowed: false, reason: 'Workspace access is frozen' };
+	}
+	if (isWorkspaceUsageFrozen(workspace)) {
+		return { allowed: false, reason: 'Workspace usage is frozen' };
+	}
+
+	if (action === 'export') {
+		const exportCheck = await checkMetricLimit(workspaceId, 'completed_export', additionalQuantity ?? 1);
+		if (!exportCheck.allowed) return { allowed: false, reason: exportCheck.reason ?? 'Export limit reached' };
+	}
+
+	if (action === 'upload') {
+		const uploadCheck = await checkMetricLimit(workspaceId, 'upload_bytes', additionalQuantity ?? 0);
+		if (!uploadCheck.allowed) return { allowed: false, reason: uploadCheck.reason ?? 'Upload limit reached' };
+	}
+
+	return { allowed: true };
+};
+
+export const checkMetricLimit = async (
+	workspaceId: ObjectId,
+	metric: EnforceableUsageMetric,
+	additionalQuantity = 0,
+): Promise<MetricLimitCheck> => {
+	const account = await getBillingAccountByWorkspaceId(workspaceId);
+	if (!account) {
+		return {
+			allowed: true,
+			meteringEnabled: false,
+			enforcementMode: 'overage',
+			overage: false,
+			used: 0,
+			limit: 0,
+			metric,
+		};
+	}
+
+	const { periodStart, periodEnd } = resolveBillingPeriod(account);
+	const usage = await aggregateUsageForPeriod({ workspaceId, periodStart, periodEnd });
+	const enforcementMode = account.workspacePreferences.enforcementMode;
+	const usageLimits = normalizeUsageLimits(account);
+
+	let used = 0;
+	let limit = 0;
+
+	if (metric === 'completed_export') {
+		used = usage.exports;
+		limit = usageLimits.exports;
+	} else {
+		used = usage.uploadBytes;
+		limit = gbToBytes(usageLimits.uploadGb);
+	}
+
+	const projected = used + additionalQuantity;
+	const overage = projected > limit;
+
+	if (!account.meteringEnabled) {
+		return {
+			allowed: true,
+			meteringEnabled: false,
+			enforcementMode,
+			overage,
+			used,
+			limit,
+			metric,
+		};
+	}
+
+	if (enforcementMode === 'overage') {
+		return {
+			allowed: true,
+			meteringEnabled: true,
+			enforcementMode,
+			overage,
+			used,
+			limit,
+			metric,
+		};
+	}
+
+	if (overage) {
+		const label = metric === 'completed_export'
+			? 'export'
+			: 'upload';
+		return {
+			allowed: false,
+			meteringEnabled: true,
+			enforcementMode,
+			overage: true,
+			used,
+			limit,
+			metric,
+			reason: `${label} limit reached for this billing period`,
+		};
+	}
+
+	return {
+		allowed: true,
+		meteringEnabled: true,
+		enforcementMode,
+		overage: false,
+		used,
+		limit,
+		metric,
+	};
+};
+
+export const assertSeatActivationAllowed = async (
+	workspaceId: ObjectId,
+	additionalActiveSeats = 1,
+): Promise<{ allowed: true } | { allowed: false; reason: string }> => {
+	const workspace = await getWorkspaceById(workspaceId);
+	if (!workspace) return { allowed: false, reason: 'Workspace not found' };
+	if (isWorkspaceAccessFrozen(workspace)) {
+		return { allowed: false, reason: 'Workspace access is frozen' };
+	}
+	if (isWorkspaceUsageFrozen(workspace)) {
+		return { allowed: false, reason: 'Workspace usage is frozen' };
+	}
+
+	const account = await getBillingAccountByWorkspaceId(workspaceId);
+	if (!account) return { allowed: true };
+
+	const usageLimits = normalizeUsageLimits(account);
+	const activeSeats = await countActiveWorkspaceSeats(workspaceId);
+	const projectedActiveSeats = activeSeats + additionalActiveSeats;
+
+	if (!account.meteringEnabled || account.workspacePreferences.enforcementMode === 'overage') {
+		return { allowed: true };
+	}
+
+	// Every future path that changes a workspace member to active must run this guard first.
+	if (projectedActiveSeats > usageLimits.seats) {
+		return { allowed: false, reason: 'Seat limit reached for this workspace' };
+	}
+
+	return { allowed: true };
+};
+
+export const checkUploadWouldExceedLimit = async (
+	workspaceId: ObjectId,
+	sizeBytes: number,
+): Promise<MetricLimitCheck> => checkMetricLimit(workspaceId, 'upload_bytes', sizeBytes);
+
+export const formatUploadLimit = (bytes: number): string => `${bytesToGb(bytes).toFixed(2)} GB`;

--- a/src/utils/billing/limitStatus.ts
+++ b/src/utils/billing/limitStatus.ts
@@ -1,0 +1,27 @@
+import type { LimitStatus, UsageLimits } from '../../models/billing';
+
+const buildMetricStatus = (used: number, limit: number) => {
+	const delta = Math.max(0, used - limit);
+	return {
+		used,
+		limit,
+		delta,
+		overLimit: delta > 0,
+	};
+};
+
+export const buildLimitStatus = ({
+	activeSeats,
+	exports,
+	uploadGb,
+	usageLimits,
+}: {
+	activeSeats: number;
+	exports: number;
+	uploadGb: number;
+	usageLimits: UsageLimits;
+}): LimitStatus => ({
+	seats: buildMetricStatus(activeSeats, usageLimits.seats),
+	exports: buildMetricStatus(exports, usageLimits.exports),
+	uploadGb: buildMetricStatus(uploadGb, usageLimits.uploadGb),
+});

--- a/src/utils/billing/reconciliation.ts
+++ b/src/utils/billing/reconciliation.ts
@@ -1,0 +1,49 @@
+import { ObjectId } from 'mongodb';
+import { BILLING_ACCOUNTS_COLLECTION, type BillingAccount } from '../../models/billing';
+import { getDb } from '../db';
+import { ensureBillingAccountIndexes } from './billingAccounts';
+import { recomputeUsageSnapshot } from './snapshots';
+
+export type ReconciliationRunResult = {
+	workspaceId: string;
+	status: 'ok' | 'mismatch' | 'skipped';
+	reconciliationStatus?: 'pending' | 'ok' | 'mismatch';
+};
+
+export const runBillingReconciliation = async ({
+	workspaceId,
+}: {
+	workspaceId?: ObjectId;
+} = {}): Promise<ReconciliationRunResult[]> => {
+	await ensureBillingAccountIndexes();
+	const db = await getDb();
+	const query = workspaceId ? { workspaceId } : {};
+	const accounts = await db.collection<BillingAccount>(BILLING_ACCOUNTS_COLLECTION).find(query).toArray();
+	const results: ReconciliationRunResult[] = [];
+	const now = new Date();
+
+	for (const account of accounts) {
+		if (!account._id || !(account.workspaceId instanceof ObjectId)) {
+			results.push({ workspaceId: 'unknown', status: 'skipped' });
+			continue;
+		}
+
+		const snapshot = await recomputeUsageSnapshot({
+			workspaceId: account.workspaceId,
+			billingAccount: account as BillingAccount & { _id: ObjectId },
+		});
+
+		await db.collection<BillingAccount>(BILLING_ACCOUNTS_COLLECTION).updateOne(
+			{ _id: account._id },
+			{ $set: { lastReconciledAt: now, updatedAt: now } },
+		);
+
+		results.push({
+			workspaceId: account.workspaceId.toString(),
+			status: snapshot.reconciliationStatus === 'ok' ? 'ok' : 'mismatch',
+			reconciliationStatus: snapshot.reconciliationStatus,
+		});
+	}
+
+	return results;
+};

--- a/src/utils/billing/serializers.ts
+++ b/src/utils/billing/serializers.ts
@@ -1,0 +1,152 @@
+import { ObjectId } from 'mongodb';
+import type {
+	BillingAccount,
+	UsageAdjustment,
+	UsageEvent,
+	UsageSnapshot,
+} from '../../models/billing';
+import type { Workspace } from '../../models/workspace';
+import { bytesToGb, resolveBillingPeriod } from './billingPeriod';
+import { normalizeUsageLimits, usageLimitsToIncluded } from './billingAccounts';
+import { buildLimitStatus } from './limitStatus';
+import { aggregateUsageForPeriod } from './usageRecording';
+
+export const serializeBillingAccount = (account: BillingAccount & { _id: ObjectId }) => ({
+	id: account._id.toString(),
+	workspaceId: account.workspaceId.toString(),
+	status: account.status,
+	meteringEnabled: account.meteringEnabled,
+	limitsEnabled: account.meteringEnabled,
+	billingCadence: account.billingCadence,
+	currency: account.currency,
+	netTermDays: account.netTermDays,
+	paymentMode: account.paymentMode,
+	periodStart: account.periodStart?.toISOString() ?? null,
+	periodEnd: account.periodEnd?.toISOString() ?? null,
+	usageLimits: normalizeUsageLimits(account),
+	included: usageLimitsToIncluded(normalizeUsageLimits(account)),
+	workspacePreferences: account.workspacePreferences,
+	sso: {
+		enabled: account.sso.enabled,
+		enabledAt: account.sso.enabledAt?.toISOString() ?? null,
+		disabledAt: account.sso.disabledAt?.toISOString() ?? null,
+	},
+	pastDue: account.pastDue,
+	lastReconciledAt: account.lastReconciledAt?.toISOString() ?? null,
+	createdAt: account.createdAt.toISOString(),
+	updatedAt: account.updatedAt.toISOString(),
+});
+
+export const serializeWorkspaceBillingPreview = (account: BillingAccount | null) => {
+	if (!account) {
+		return {
+			status: 'not_set' as const,
+			meteringEnabled: null,
+			limitsEnabled: null,
+			billingCadence: null,
+			currency: null,
+			pastDue: null,
+		};
+	}
+
+	return {
+		status: account.status,
+		meteringEnabled: account.meteringEnabled,
+		limitsEnabled: account.meteringEnabled,
+		billingCadence: account.billingCadence,
+		currency: account.currency,
+		pastDue: account.pastDue,
+	};
+};
+
+export const serializeWorkspaceFreezes = (workspace: Workspace) => ({
+	usageFreeze: workspace.workspaceUsageFreeze
+		? {
+			enabled: workspace.workspaceUsageFreeze.enabled,
+			updatedAt: workspace.workspaceUsageFreeze.updatedAt.toISOString(),
+		}
+		: { enabled: false, updatedAt: null },
+	accessFreeze: workspace.workspaceAccessFreeze
+		? {
+			enabled: workspace.workspaceAccessFreeze.enabled,
+			updatedAt: workspace.workspaceAccessFreeze.updatedAt.toISOString(),
+		}
+		: { enabled: false, updatedAt: null },
+});
+
+export const buildBillingSummary = async ({
+	account,
+	workspaceId,
+}: {
+	account: BillingAccount & { _id: ObjectId };
+	workspaceId: ObjectId;
+}) => {
+	const { periodStart, periodEnd } = resolveBillingPeriod(account);
+	const usage = await aggregateUsageForPeriod({ workspaceId, periodStart, periodEnd });
+	const uploadGb = bytesToGb(usage.uploadBytes);
+	const usageLimits = normalizeUsageLimits(account);
+	const limitStatus = buildLimitStatus({
+		activeSeats: usage.activeSeats,
+		exports: usage.exports,
+		uploadGb,
+		usageLimits,
+	});
+
+	return {
+		account: serializeBillingAccount(account),
+		period: {
+			start: periodStart.toISOString(),
+			end: periodEnd.toISOString(),
+		},
+		usage: {
+			activeSeats: usage.activeSeats,
+			exports: usage.exports,
+			uploadBytes: usage.uploadBytes,
+			uploadGb,
+		},
+		usageLimits,
+		included: usageLimitsToIncluded(usageLimits),
+		limitStatus,
+		addOns: {
+			ssoEnabled: account.sso.enabled,
+		},
+		enforcementMode: account.workspacePreferences.enforcementMode,
+		meteringEnabled: account.meteringEnabled,
+		limitsEnabled: account.meteringEnabled,
+	};
+};
+
+export const serializeUsageEvent = (event: UsageEvent & { _id: ObjectId }) => ({
+	id: event._id.toString(),
+	metric: event.metric,
+	quantity: event.quantity,
+	unit: event.unit,
+	source: event.source,
+	sourceId: event.sourceId,
+	occurredAt: event.occurredAt.toISOString(),
+	billingPeriodStart: event.billingPeriodStart.toISOString(),
+	billingPeriodEnd: event.billingPeriodEnd.toISOString(),
+});
+
+export const serializeUsageSnapshot = (snapshot: UsageSnapshot & { _id: ObjectId }) => ({
+	id: snapshot._id.toString(),
+	periodStart: snapshot.periodStart.toISOString(),
+	periodEnd: snapshot.periodEnd.toISOString(),
+	usage: snapshot.usage,
+	usageLimits: snapshot.usageLimits,
+	included: usageLimitsToIncluded(snapshot.usageLimits),
+	limitStatus: snapshot.limitStatus,
+	reconciliationStatus: snapshot.reconciliationStatus,
+	approvedForBillingAt: snapshot.approvedForBillingAt?.toISOString() ?? null,
+	updatedAt: snapshot.updatedAt.toISOString(),
+});
+
+export const serializeUsageAdjustment = (adjustment: UsageAdjustment & { _id: ObjectId }) => ({
+	id: adjustment._id.toString(),
+	metric: adjustment.metric,
+	quantityDelta: adjustment.quantityDelta,
+	unit: adjustment.unit,
+	billingPeriodStart: adjustment.billingPeriodStart.toISOString(),
+	billingPeriodEnd: adjustment.billingPeriodEnd.toISOString(),
+	createdAt: adjustment.createdAt.toISOString(),
+});

--- a/src/utils/billing/snapshots.ts
+++ b/src/utils/billing/snapshots.ts
@@ -1,0 +1,161 @@
+import { ObjectId } from 'mongodb';
+import {
+	USAGE_SNAPSHOTS_COLLECTION,
+	type BillingAccount,
+	type LimitStatus,
+	type UsageSnapshot,
+	type UsageLimits,
+} from '../../models/billing';
+import { getDb } from '../db';
+import { bytesToGb, resolveBillingPeriod } from './billingPeriod';
+import { normalizeUsageLimits } from './billingAccounts';
+import { buildLimitStatus } from './limitStatus';
+import {
+	aggregateUploadReconciliationBreakdown,
+	aggregateUsageForPeriod,
+} from './usageRecording';
+
+let hasEnsuredSnapshotIndexes = false;
+
+const isCurrentSnapshotShape = (
+	snapshot: Partial<UsageSnapshot> | null,
+): snapshot is UsageSnapshot & { usage: UsageSnapshot['usage']; usageLimits: UsageLimits; limitStatus: LimitStatus } =>
+	Boolean(
+		snapshot?.usage
+		&& typeof snapshot.usage.activeSeats === 'number'
+		&& snapshot.usageLimits
+		&& typeof snapshot.usageLimits.seats === 'number'
+		&& snapshot.limitStatus
+		&& typeof snapshot.limitStatus.seats?.used === 'number',
+	);
+
+export const ensureUsageSnapshotIndexes = async (): Promise<void> => {
+	if (hasEnsuredSnapshotIndexes) return;
+
+	const db = await getDb();
+	await db.collection<UsageSnapshot>(USAGE_SNAPSHOTS_COLLECTION).createIndex(
+		{ workspaceId: 1, periodStart: 1, periodEnd: 1 },
+		{ unique: true },
+	);
+
+	hasEnsuredSnapshotIndexes = true;
+};
+
+export const recomputeUsageSnapshot = async ({
+	workspaceId,
+	billingAccount,
+}: {
+	workspaceId: ObjectId;
+	billingAccount: BillingAccount & { _id: ObjectId };
+}): Promise<UsageSnapshot & { _id: ObjectId }> => {
+	await ensureUsageSnapshotIndexes();
+	const db = await getDb();
+	const { periodStart, periodEnd } = resolveBillingPeriod(billingAccount);
+	const usage = await aggregateUsageForPeriod({ workspaceId, periodStart, periodEnd });
+	const uploadGb = bytesToGb(usage.uploadBytes);
+	const usageLimits = normalizeUsageLimits(billingAccount);
+	const limitStatus = buildLimitStatus({
+		activeSeats: usage.activeSeats,
+		exports: usage.exports,
+		uploadGb,
+		usageLimits,
+	});
+
+	const reconciliationStatus = await computeReconciliationStatus({
+		workspaceId,
+		periodStart,
+		periodEnd,
+		expectedUploadBytes: usage.uploadBytes,
+	});
+
+	const now = new Date();
+	const snapshot: UsageSnapshot = {
+		workspaceId,
+		billingAccountId: billingAccount._id,
+		periodStart,
+		periodEnd,
+		usage: {
+			activeSeats: usage.activeSeats,
+			exports: usage.exports,
+			uploadBytes: usage.uploadBytes,
+			uploadGb,
+		},
+		usageLimits,
+		limitStatus,
+		reconciliationStatus,
+		createdAt: now,
+		updatedAt: now,
+	};
+
+	const { createdAt, ...snapshotUpdates } = snapshot;
+
+	const result = await db.collection<UsageSnapshot>(USAGE_SNAPSHOTS_COLLECTION).findOneAndUpdate(
+		{ workspaceId, periodStart, periodEnd },
+		{
+			$set: snapshotUpdates,
+			$setOnInsert: { createdAt },
+		},
+		{ upsert: true, returnDocument: 'after' },
+	);
+
+	if (!result) {
+		throw new Error('Failed to persist usage snapshot');
+	}
+
+	return result as UsageSnapshot & { _id: ObjectId };
+};
+
+export const getCurrentUsageSnapshot = async ({
+	workspaceId,
+	billingAccount,
+	recomputeIfStale = true,
+}: {
+	workspaceId: ObjectId;
+	billingAccount: BillingAccount & { _id: ObjectId };
+	recomputeIfStale?: boolean;
+}): Promise<(UsageSnapshot & { _id: ObjectId }) | null> => {
+	await ensureUsageSnapshotIndexes();
+	const db = await getDb();
+	const { periodStart, periodEnd } = resolveBillingPeriod(billingAccount);
+
+	const existing = await db.collection<UsageSnapshot>(USAGE_SNAPSHOTS_COLLECTION).findOne({
+		workspaceId,
+		periodStart,
+		periodEnd,
+	});
+
+	if (
+		recomputeIfStale &&
+		(!existing || existing.reconciliationStatus === 'pending' || !isCurrentSnapshotShape(existing))
+	) {
+		return recomputeUsageSnapshot({ workspaceId, billingAccount });
+	}
+
+	if (!existing?._id) return null;
+	return existing as UsageSnapshot & { _id: ObjectId };
+};
+
+const computeReconciliationStatus = async ({
+	workspaceId,
+	periodStart,
+	periodEnd,
+	expectedUploadBytes,
+}: {
+	workspaceId: ObjectId;
+	periodStart: Date;
+	periodEnd: Date;
+	expectedUploadBytes: number;
+}): Promise<'ok' | 'mismatch'> => {
+	const breakdown = await aggregateUploadReconciliationBreakdown({
+		workspaceId,
+		periodStart,
+		periodEnd,
+	});
+
+	const recordedBytes = breakdown.commitBytes + breakdown.adjustmentBytes;
+
+	if (expectedUploadBytes === 0 && recordedBytes === 0) return 'ok';
+	if (breakdown.totalBytes !== expectedUploadBytes) return 'mismatch';
+	if (recordedBytes !== expectedUploadBytes) return 'mismatch';
+	return 'ok';
+};

--- a/src/utils/billing/uploadCommit.ts
+++ b/src/utils/billing/uploadCommit.ts
@@ -1,0 +1,186 @@
+import { ObjectId } from 'mongodb';
+import { USAGE_EVENTS_COLLECTION } from '../../models/billing';
+import type { UsageEvent } from '../../models/billing';
+import { getDb } from '../db';
+import { getBillingAccountByWorkspaceId } from './billingAccounts';
+import { resolveBillingPeriod } from './billingPeriod';
+import { checkUploadWouldExceedLimit } from './enforcement';
+import { recordUsageEvent } from './usageRecording';
+
+export const normalizeSizeBytes = (value: unknown): number | undefined => {
+	if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+		return undefined;
+	}
+
+	return Math.floor(value);
+};
+
+export const isNewUploadKey = (previousKey: string | undefined, newKey: string): boolean => {
+	const normalizedNew = newKey.trim();
+	if (!normalizedNew || !normalizedNew.startsWith('uploads/')) return false;
+	return normalizedNew !== (previousKey ?? '').trim();
+};
+
+export const recordCommittedUploadBytes = async ({
+	workspaceId,
+	uploadKey,
+	sizeBytes,
+	metadata,
+	occurredAt,
+}: {
+	workspaceId: ObjectId;
+	uploadKey: string;
+	sizeBytes: number;
+	metadata?: Record<string, unknown>;
+	occurredAt?: Date;
+}): Promise<void> => {
+	const normalizedKey = uploadKey.trim();
+	const normalizedBytes = normalizeSizeBytes(sizeBytes);
+	if (!normalizedKey.startsWith('uploads/') || !normalizedBytes) return;
+
+	const account = await getBillingAccountByWorkspaceId(workspaceId);
+	if (!account) return;
+
+	const now = occurredAt ?? new Date();
+	const { periodStart, periodEnd } = resolveBillingPeriod(account, now);
+
+	await recordUsageEvent({
+		workspaceId,
+		billingAccountId: account._id,
+		metric: 'upload_bytes',
+		quantity: normalizedBytes,
+		unit: 'bytes',
+		source: 'upload_commit',
+		sourceId: normalizedKey,
+		idempotencyKey: `upload:${normalizedKey}`,
+		occurredAt: now,
+		billingPeriodStart: periodStart,
+		billingPeriodEnd: periodEnd,
+		metadata,
+	});
+};
+
+export const recordCommittedUploadIfNew = async ({
+	workspaceId,
+	previousKey,
+	newKey,
+	sizeBytes,
+	metadata,
+}: {
+	workspaceId: ObjectId;
+	previousKey?: string;
+	newKey: string;
+	sizeBytes: unknown;
+	metadata?: Record<string, unknown>;
+}): Promise<void> => {
+	if (!isNewUploadKey(previousKey, newKey)) return;
+
+	const normalizedBytes = normalizeSizeBytes(sizeBytes);
+	if (!normalizedBytes) return;
+
+	await recordCommittedUploadBytes({
+		workspaceId,
+		uploadKey: newKey.trim(),
+		sizeBytes: normalizedBytes,
+		metadata,
+	});
+};
+
+export type UploadCommitInput = {
+	key: string;
+	sizeBytes: number;
+};
+
+export const collectUploadCommitsFromValue = (
+	value: unknown,
+	commits: UploadCommitInput[] = [],
+): UploadCommitInput[] => {
+	if (!value || typeof value !== 'object') return commits;
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectUploadCommitsFromValue(item, commits);
+		}
+		return commits;
+	}
+
+	const record = value as Record<string, unknown>;
+	const key = typeof record.key === 'string' ? record.key.trim() : '';
+	const taggedImageKey = typeof record.tagged_image_key === 'string'
+		? record.tagged_image_key.trim()
+		: '';
+	const uploadKey = key.startsWith('uploads/') ? key : taggedImageKey;
+	const sizeBytes = normalizeSizeBytes(record.sizeBytes);
+
+	if (uploadKey.startsWith('uploads/') && sizeBytes) {
+		commits.push({ key: uploadKey, sizeBytes });
+	}
+
+	for (const nested of Object.values(record)) {
+		if (nested && typeof nested === 'object') {
+			collectUploadCommitsFromValue(nested, commits);
+		}
+	}
+
+	return commits;
+};
+
+const uploadIdempotencyKey = (uploadKey: string): string => `upload:${uploadKey.trim()}`;
+
+export const sumNewUploadCommitBytes = async (
+	workspaceId: ObjectId,
+	data: unknown,
+): Promise<number> => {
+	const commits = collectUploadCommitsFromValue(data);
+	const seen = new Set<string>();
+	let totalBytes = 0;
+
+	const db = await getDb();
+	const events = db.collection<UsageEvent>(USAGE_EVENTS_COLLECTION);
+
+	for (const commit of commits) {
+		if (seen.has(commit.key)) continue;
+		seen.add(commit.key);
+
+		const existing = await events.findOne({ idempotencyKey: uploadIdempotencyKey(commit.key) });
+		if (existing) continue;
+
+		totalBytes += commit.sizeBytes;
+	}
+
+	return totalBytes;
+};
+
+export const assertNewUploadCommitsAllowed = async (
+	workspaceId: ObjectId,
+	data: unknown,
+): Promise<{ allowed: true } | { allowed: false; reason: string }> => {
+	const newBytes = await sumNewUploadCommitBytes(workspaceId, data);
+	if (newBytes <= 0) return { allowed: true };
+
+	const limitCheck = await checkUploadWouldExceedLimit(workspaceId, newBytes);
+	if (!limitCheck.allowed) {
+		return { allowed: false, reason: limitCheck.reason ?? 'Upload limit reached' };
+	}
+
+	return { allowed: true };
+};
+
+export const recordUploadCommitsFromPayload = async (
+	workspaceId: ObjectId,
+	data: unknown,
+): Promise<void> => {
+	const commits = collectUploadCommitsFromValue(data);
+	const seen = new Set<string>();
+
+	for (const commit of commits) {
+		if (seen.has(commit.key)) continue;
+		seen.add(commit.key);
+
+		await recordCommittedUploadBytes({
+			workspaceId,
+			uploadKey: commit.key,
+			sizeBytes: commit.sizeBytes,
+		});
+	}
+};

--- a/src/utils/billing/usageRecording.ts
+++ b/src/utils/billing/usageRecording.ts
@@ -1,0 +1,287 @@
+import { ObjectId } from 'mongodb';
+import {
+	BILLING_ADDON_EVENTS_COLLECTION,
+	BILLING_ACCOUNTS_COLLECTION,
+	USAGE_EVENTS_COLLECTION,
+	type BillingAccount,
+	type BillingAddOnEvent,
+	type BillingUsageMetric,
+	type UsageEvent,
+	type UsageEventSource,
+	type UsageUnit,
+} from '../../models/billing';
+import { getDb } from '../db';
+import { resolveBillingPeriod } from './billingPeriod';
+import { getBillingAccountByWorkspaceId } from './billingAccounts';
+import { recordCommittedUploadBytes } from './uploadCommit';
+
+let hasEnsuredUsageIndexes = false;
+
+export const ensureUsageEventIndexes = async (): Promise<void> => {
+	if (hasEnsuredUsageIndexes) return;
+
+	const db = await getDb();
+	const collection = db.collection<UsageEvent>(USAGE_EVENTS_COLLECTION);
+
+	await Promise.all([
+		collection.createIndex({ idempotencyKey: 1 }, { unique: true }),
+		collection.createIndex({ workspaceId: 1, occurredAt: -1 }),
+		collection.createIndex({ workspaceId: 1, billingPeriodStart: 1, billingPeriodEnd: 1 }),
+		collection.createIndex({ workspaceId: 1, metric: 1, billingPeriodStart: 1 }),
+		db.collection<BillingAddOnEvent>(BILLING_ADDON_EVENTS_COLLECTION).createIndex({ idempotencyKey: 1 }, { unique: true }),
+	]);
+
+	hasEnsuredUsageIndexes = true;
+};
+
+export type PeriodUsageTotals = {
+	activeSeats: number;
+	exports: number;
+	uploadBytes: number;
+};
+
+export const recordUsageEvent = async ({
+	workspaceId,
+	billingAccountId,
+	metric,
+	quantity,
+	unit,
+	source,
+	sourceId,
+	idempotencyKey,
+	occurredAt,
+	billingPeriodStart,
+	billingPeriodEnd,
+	metadata,
+}: {
+	workspaceId: ObjectId;
+	billingAccountId?: ObjectId;
+	metric: BillingUsageMetric;
+	quantity: number;
+	unit: UsageUnit;
+	source: UsageEventSource;
+	sourceId: string;
+	idempotencyKey: string;
+	occurredAt?: Date;
+	billingPeriodStart: Date;
+	billingPeriodEnd: Date;
+	metadata?: Record<string, unknown>;
+}): Promise<UsageEvent | null> => {
+	if (!Number.isFinite(quantity) || quantity === 0) return null;
+	if (source !== 'platform_adjustment' && quantity < 0) return null;
+
+	await ensureUsageEventIndexes();
+	const db = await getDb();
+	const now = occurredAt ?? new Date();
+
+	const event: UsageEvent = {
+		workspaceId,
+		billingAccountId,
+		metric,
+		quantity,
+		unit,
+		source,
+		sourceId,
+		idempotencyKey,
+		occurredAt: now,
+		billingPeriodStart,
+		billingPeriodEnd,
+		metadata,
+		createdAt: now,
+		updatedAt: now,
+	};
+
+	try {
+		const result = await db.collection<UsageEvent>(USAGE_EVENTS_COLLECTION).insertOne(event);
+		return { ...event, _id: result.insertedId };
+	} catch (error) {
+		if (error && typeof error === 'object' && 'code' in error && error.code === 11000) {
+			return null;
+		}
+		throw error;
+	}
+};
+
+export type UploadReconciliationBreakdown = {
+	commitBytes: number;
+	adjustmentBytes: number;
+	totalBytes: number;
+};
+
+export const aggregateUploadReconciliationBreakdown = async ({
+	workspaceId,
+	periodStart,
+	periodEnd,
+}: {
+	workspaceId: ObjectId;
+	periodStart: Date;
+	periodEnd: Date;
+}): Promise<UploadReconciliationBreakdown> => {
+	await ensureUsageEventIndexes();
+	const db = await getDb();
+
+	const events = await db.collection<UsageEvent>(USAGE_EVENTS_COLLECTION).find({
+		workspaceId,
+		billingPeriodStart: periodStart,
+		billingPeriodEnd: periodEnd,
+		metric: 'upload_bytes',
+	}).toArray();
+
+	return events.reduce<UploadReconciliationBreakdown>(
+		(totals, event) => {
+			totals.totalBytes += event.quantity;
+
+			if (event.source === 'platform_adjustment') {
+				totals.adjustmentBytes += event.quantity;
+			} else if (event.source === 'upload_commit' || event.source === 'reconciliation_backfill') {
+				totals.commitBytes += event.quantity;
+			}
+
+			return totals;
+		},
+		{ commitBytes: 0, adjustmentBytes: 0, totalBytes: 0 },
+	);
+};
+
+export const aggregateUsageForPeriod = async ({
+	workspaceId,
+	periodStart,
+	periodEnd,
+}: {
+	workspaceId: ObjectId;
+	periodStart: Date;
+	periodEnd: Date;
+}): Promise<PeriodUsageTotals> => {
+	await ensureUsageEventIndexes();
+	const db = await getDb();
+
+	const events = await db.collection<UsageEvent>(USAGE_EVENTS_COLLECTION).find({
+		workspaceId,
+		billingPeriodStart: periodStart,
+		billingPeriodEnd: periodEnd,
+	}).toArray();
+
+	const eventTotals = events.reduce<Omit<PeriodUsageTotals, 'activeSeats'>>(
+		(totals, event) => {
+			if (event.metric === 'completed_export') {
+				totals.exports += event.quantity;
+			} else if (event.metric === 'upload_bytes') {
+				totals.uploadBytes += event.quantity;
+			}
+			return totals;
+		},
+		{ exports: 0, uploadBytes: 0 },
+	);
+
+	const activeSeats = await countActiveWorkspaceSeats(workspaceId);
+
+	return {
+		activeSeats,
+		...eventTotals,
+	};
+};
+
+export const countActiveWorkspaceSeats = async (workspaceId: ObjectId): Promise<number> => {
+	const db = await getDb();
+	return db.collection('users').countDocuments({ workspaceId, status: 'active' });
+};
+
+export const recordCompletedExport = async ({
+	workspaceId,
+	jobId,
+	occurredAt,
+}: {
+	workspaceId: ObjectId;
+	jobId: ObjectId;
+	occurredAt?: Date;
+}): Promise<void> => {
+	const account = await getBillingAccountByWorkspaceId(workspaceId);
+	if (!account) return;
+
+	const now = occurredAt ?? new Date();
+	const { periodStart, periodEnd } = resolveBillingPeriod(account, now);
+
+	await recordUsageEvent({
+		workspaceId,
+		billingAccountId: account._id,
+		metric: 'completed_export',
+		quantity: 1,
+		unit: 'count',
+		source: 'export_job',
+		sourceId: jobId.toString(),
+		idempotencyKey: `export:${jobId.toString()}`,
+		occurredAt: now,
+		billingPeriodStart: periodStart,
+		billingPeriodEnd: periodEnd,
+	});
+};
+
+export { recordCommittedUploadBytes, recordCommittedUploadIfNew, recordUploadCommitsFromPayload } from './uploadCommit';
+
+/** @deprecated Prefer recordCommittedUploadBytes with the S3 upload key. */
+export const recordUploadBytes = async ({
+	workspaceId,
+	sourceFileId,
+	uploadKey,
+	sizeBytes,
+	occurredAt,
+}: {
+	workspaceId: ObjectId;
+	sourceFileId?: ObjectId;
+	uploadKey?: string;
+	sizeBytes: number;
+	occurredAt?: Date;
+}): Promise<void> => {
+	const resolvedKey = uploadKey?.trim()
+		|| (sourceFileId ? `legacy:source-file:${sourceFileId.toString()}` : '');
+	if (!resolvedKey) return;
+
+	await recordCommittedUploadBytes({
+		workspaceId,
+		uploadKey: resolvedKey,
+		sizeBytes,
+		occurredAt,
+		metadata: sourceFileId ? { sourceFileId: sourceFileId.toString() } : undefined,
+	});
+};
+
+export const recordSsoAddOnEvent = async ({
+	workspaceId,
+	billingAccountId,
+	action,
+	occurredAt,
+}: {
+	workspaceId: ObjectId;
+	billingAccountId: ObjectId;
+	action: 'enabled' | 'disabled';
+	occurredAt?: Date;
+}): Promise<void> => {
+	await ensureUsageEventIndexes();
+	const db = await getDb();
+	const account = await db.collection<BillingAccount>(BILLING_ACCOUNTS_COLLECTION).findOne({ _id: billingAccountId });
+	if (!account) return;
+
+	const now = occurredAt ?? new Date();
+	const { periodStart, periodEnd } = resolveBillingPeriod(account, now);
+
+	const event: BillingAddOnEvent = {
+		workspaceId,
+		billingAccountId,
+		addOn: 'sso',
+		action,
+		occurredAt: now,
+		billingPeriodStart: periodStart,
+		billingPeriodEnd: periodEnd,
+		idempotencyKey: `sso:${workspaceId.toString()}:${action}:${periodStart.toISOString()}`,
+		createdAt: now,
+	};
+
+	try {
+		await db.collection<BillingAddOnEvent>(BILLING_ADDON_EVENTS_COLLECTION).insertOne(event);
+	} catch (error) {
+		if (error && typeof error === 'object' && 'code' in error && error.code === 11000) {
+			return;
+		}
+		throw error;
+	}
+};

--- a/src/utils/exportJobs.ts
+++ b/src/utils/exportJobs.ts
@@ -15,7 +15,7 @@ import { recordCompletedExport } from './billing/usageRecording';
 const DEFAULT_EXPORT_FILE_TTL_HOURS = 24;
 const EXPORT_JOBS_PAGE_LIMIT = 10;
 const TERMINAL_EXPORT_JOB_STATUSES: ExportJobStatus[] = ['completed', 'failed'];
-const ACTIVE_EXPORT_JOB_STATUSES: ExportJobStatus[] = ['queued', 'processing'];
+export const ACTIVE_EXPORT_JOB_STATUSES: ExportJobStatus[] = ['queued', 'processing'];
 
 let hasEnsuredExportJobIndexes = false;
 
@@ -259,6 +259,23 @@ export const markExportJobFailed = async ({
 		},
 		{ returnDocument: 'after' },
 	);
+};
+
+export const countActiveExportJobs = async ({
+	workspaceId,
+	periodStart,
+	periodEnd,
+}: {
+	workspaceId: ObjectId;
+	periodStart: Date;
+	periodEnd: Date;
+}): Promise<number> => {
+	const collection = await getCollection();
+	return collection.countDocuments({
+		workspaceId,
+		status: { $in: ACTIVE_EXPORT_JOB_STATUSES },
+		createdAt: { $gte: periodStart, $lte: periodEnd },
+	});
 };
 
 export const getExportJobById = async ({

--- a/src/utils/exportJobs.ts
+++ b/src/utils/exportJobs.ts
@@ -10,6 +10,7 @@ import {
 } from '../models/exportJob';
 import type { PersistedReportExportRequest } from '../types/reports';
 import { getDb } from './db';
+import { recordCompletedExport } from './billing/usageRecording';
 
 const DEFAULT_EXPORT_FILE_TTL_HOURS = 24;
 const EXPORT_JOBS_PAGE_LIMIT = 10;
@@ -195,7 +196,7 @@ export const markExportJobCompleted = async ({
 	const collection = await getCollection();
 	const now = completedAt ?? new Date();
 
-	return collection.findOneAndUpdate(
+	const completedJob = await collection.findOneAndUpdate(
 		{
 			_id: jobId,
 			status: { $nin: TERMINAL_EXPORT_JOB_STATUSES },
@@ -216,6 +217,16 @@ export const markExportJobCompleted = async ({
 		},
 		{ returnDocument: 'after' },
 	);
+
+	if (completedJob?.workspaceId) {
+		await recordCompletedExport({
+			workspaceId: completedJob.workspaceId,
+			jobId,
+			occurredAt: now,
+		});
+	}
+
+	return completedJob;
 };
 
 export const markExportJobFailed = async ({

--- a/src/utils/platformAdminSerializers.ts
+++ b/src/utils/platformAdminSerializers.ts
@@ -1,24 +1,12 @@
 import { ObjectId } from 'mongodb';
 import type { PlatformAdmin } from '../models/platformAdmin';
 import type { PlatformAuditLog } from '../models/platformAuditLog';
+import type { BillingAccount } from '../models/billing';
 import type { Workspace } from '../models/workspace';
 import type { User } from '../models/user';
+import { serializeWorkspaceBillingPreview } from './billing/serializers';
 
-export type WorkspaceBillingPreview = {
-	status: 'not_set';
-	meteringEnabled: null;
-	billingCadence: null;
-	currency: null;
-	pastDue: null;
-};
-
-export const emptyBillingPreview = (): WorkspaceBillingPreview => ({
-	status: 'not_set',
-	meteringEnabled: null,
-	billingCadence: null,
-	currency: null,
-	pastDue: null,
-});
+export type WorkspaceBillingPreview = ReturnType<typeof serializeWorkspaceBillingPreview>;
 
 export const serializePlatformOperator = (operator: PlatformAdmin) => ({
 	id: operator._id?.toString(),
@@ -31,6 +19,7 @@ export const serializePlatformOperator = (operator: PlatformAdmin) => ({
 
 export const serializeWorkspaceListItem = (
 	workspace: Workspace & { _id: ObjectId; memberCount?: number },
+	billingAccount?: BillingAccount | null,
 ) => ({
 	id: workspace._id.toString(),
 	workspaceName: workspace.workspaceName,
@@ -38,7 +27,7 @@ export const serializeWorkspaceListItem = (
 	logo: workspace.logo || null,
 	planName: workspace.planName || null,
 	memberCount: workspace.memberCount ?? workspace.userIds?.length ?? 0,
-	billing: emptyBillingPreview(),
+	billing: serializeWorkspaceBillingPreview(billingAccount ?? null),
 });
 
 export const serializeWorkspaceAdmin = (user: User & { _id: ObjectId }) => ({

--- a/src/utils/platformInviteUtils.ts
+++ b/src/utils/platformInviteUtils.ts
@@ -95,6 +95,53 @@ export const assertEmailAvailableForWorkspaceAdminInvite = async (
 	throw new InviteEmailConflictError('This email is already a member of this workspace.');
 };
 
+/**
+ * Rejects emails tied to a different workspace for member invites.
+ * Inactive members in the same workspace are allowed (reactivation path).
+ */
+export const assertEmailAvailableForWorkspaceMemberInvite = async (
+	db: Db,
+	email: string,
+	workspaceId: ObjectId,
+): Promise<void> => {
+	const normalizedEmail = normalizeInviteEmail(email);
+	const existingUser = await db.collection<User>('users').findOne({ email: normalizedEmail })
+		?? await db.collection<User>('users').findOne({
+			email: { $regex: new RegExp(`^${normalizedEmail.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i') },
+		});
+
+	if (!existingUser) {
+		if (await cognitoUserExists(normalizedEmail)) {
+			throw new InviteEmailConflictError(
+				'This email is reserved for organization provisioning and cannot be invited to a workspace yet.',
+			);
+		}
+		return;
+	}
+
+	if (!existingUser.workspaceId) {
+		throw new InviteEmailConflictError(
+			'This email is reserved for organization provisioning and cannot be invited to a workspace yet.',
+		);
+	}
+
+	if (!existingUser.workspaceId.equals(workspaceId)) {
+		throw new InviteEmailConflictError(
+			'This email belongs to a different workspace and cannot be invited here.',
+		);
+	}
+
+	if (existingUser.status === 'inactive') {
+		return;
+	}
+
+	if (existingUser.userType === 'admin') {
+		throw new InviteEmailConflictError('This email is already a workspace admin in this workspace.');
+	}
+
+	throw new InviteEmailConflictError('This email is already a member of this workspace.');
+};
+
 export type CreateInvitedCognitoUserInput = {
 	email: string;
 	name: string;

--- a/src/utils/tenantContext.ts
+++ b/src/utils/tenantContext.ts
@@ -2,6 +2,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { ObjectId } from 'mongodb';
 import { authenticateRequest, type AuthResult } from './authUtils';
 import { getAuthenticatedUserContext } from './authenticatedUser';
+import { assertWorkspaceAccessAllowed } from './billing/enforcement';
 import { ResponseWrapper } from './responseWrapper';
 
 export type TenantContext = {
@@ -32,8 +33,14 @@ const parseCognitoGroups = (groups: unknown): string[] => {
  * @param {APIGatewayProxyEvent} event - API Gateway event
  * @return {Promise<TenantContextResult>} Tenant context result
 */
+export type RequireTenantContextOptions = {
+	/** Allow read-only access when workspace access is frozen (e.g. billing summary). */
+	allowAccessFrozen?: boolean;
+};
+
 export const requireTenantContext = async (
 	event: APIGatewayProxyEvent,
+	options: RequireTenantContextOptions = {},
 ): Promise<TenantContextResult> => {
 	const auth = await authenticateRequest(event);
 	if (!auth.isValid) {
@@ -51,6 +58,16 @@ export const requireTenantContext = async (
 			ok: false,
 			response: ResponseWrapper.unauthorized('Unable to resolve authenticated user context'),
 		};
+	}
+
+	if (!options.allowAccessFrozen) {
+		const accessCheck = await assertWorkspaceAccessAllowed(userContext.workspaceId);
+		if (!accessCheck.allowed) {
+			return {
+				ok: false,
+				response: ResponseWrapper.forbidden(accessCheck.reason),
+			};
+		}
 	}
 
 	return {

--- a/src/utils/userRemoval.ts
+++ b/src/utils/userRemoval.ts
@@ -18,7 +18,7 @@ import {
 	deleteCognitoInviteUser,
 	normalizeInviteEmail,
 } from './platformInviteUtils';
-import { assertSeatActivationAllowed } from './billing/enforcement';
+import { assertSeatActivationAllowed, verifySeatLimitAfterActivation } from './billing/enforcement';
 
 const cognito = new CognitoIdentityProviderClient({ region: process.env.AWS_REGION || 'us-east-1' });
 
@@ -239,60 +239,123 @@ export const reactivateWorkspaceUser = async (
 
 	let cognitoSub = existingUser.cognitoSub;
 	const hasCognitoAccount = await cognitoUserExists(normalizedEmail);
+	let createdNewCognito = false;
 
-	if (!cognitoSub || !hasCognitoAccount) {
-		const created = await createInvitedCognitoUser({
-			email: normalizedEmail,
-			name: input.name,
-			groupName,
-			customAttributes: [
-				{ Name: 'custom:userId', Value: userId.toString() },
-				{ Name: 'custom:workspaceId', Value: workspaceId.toString() },
-				{ Name: 'custom:status', Value: 'active' },
-			],
-		});
-		cognitoSub = created.cognitoSub;
-	} else {
-		await enableCognitoUser(normalizedEmail);
-		await cognito.send(new AdminUpdateUserAttributesCommand({
-			UserPoolId: process.env.USER_POOL_ID!,
-			Username: normalizedEmail,
-			UserAttributes: [
-				{ Name: 'name', Value: input.name },
-				{ Name: 'custom:userId', Value: userId.toString() },
-				{ Name: 'custom:workspaceId', Value: workspaceId.toString() },
-				{ Name: 'custom:status', Value: 'active' },
-			],
-		}));
+	const rollbackCognito = async (): Promise<void> => {
+		if (createdNewCognito) {
+			await deleteCognitoInviteUser(normalizedEmail);
+			return;
+		}
 
-		await cognito.send(new AdminAddUserToGroupCommand({
-			UserPoolId: process.env.USER_POOL_ID!,
-			Username: normalizedEmail,
-			GroupName: groupName,
-		}));
-	}
+		if (hasCognitoAccount) {
+			await disableCognitoUser(normalizedEmail);
+			await setCognitoStatus(normalizedEmail, 'inactive');
+			await removeCognitoGroup(normalizedEmail, groupName);
+		}
+	};
 
-	await db.collection<User>('users').updateOne(
-		{ _id: userId },
-		{
-			$set: {
-				name: input.name,
+	const rollbackDbActivation = async (): Promise<void> => {
+		await db.collection<User>('users').updateOne(
+			{ _id: userId },
+			{
+				$set: {
+					name: existingUser.name,
+					email: existingUser.email,
+					status: 'inactive',
+					userType: existingUser.userType ?? userType,
+					removedAt: existingUser.removedAt ?? new Date(),
+					removedByUserId: existingUser.removedByUserId ?? input.actorUserId,
+					...(existingUser.cognitoSub ? { cognitoSub: existingUser.cognitoSub } : {}),
+				},
+				...(createdNewCognito && !existingUser.cognitoSub ? { $unset: { cognitoSub: '' } } : {}),
+			},
+		);
+		await db.collection<Workspace>('workspaces').updateOne(
+			{ _id: workspaceId },
+			{ $pull: { userIds: userId } },
+		);
+	};
+
+	try {
+		if (!cognitoSub || !hasCognitoAccount) {
+			const created = await createInvitedCognitoUser({
 				email: normalizedEmail,
-				cognitoSub,
-				status: 'active',
-				userType,
-			},
-			$unset: {
-				removedAt: '',
-				removedByUserId: '',
-			},
-		},
-	);
+				name: input.name,
+				groupName,
+				customAttributes: [
+					{ Name: 'custom:userId', Value: userId.toString() },
+					{ Name: 'custom:workspaceId', Value: workspaceId.toString() },
+					{ Name: 'custom:status', Value: 'active' },
+				],
+			});
+			cognitoSub = created.cognitoSub;
+			createdNewCognito = true;
+		} else {
+			await enableCognitoUser(normalizedEmail);
+			await cognito.send(new AdminUpdateUserAttributesCommand({
+				UserPoolId: process.env.USER_POOL_ID!,
+				Username: normalizedEmail,
+				UserAttributes: [
+					{ Name: 'name', Value: input.name },
+					{ Name: 'custom:userId', Value: userId.toString() },
+					{ Name: 'custom:workspaceId', Value: workspaceId.toString() },
+					{ Name: 'custom:status', Value: 'active' },
+				],
+			}));
 
-	await db.collection<Workspace>('workspaces').updateOne(
-		{ _id: workspaceId },
-		{ $addToSet: { userIds: userId } },
-	);
+			await cognito.send(new AdminAddUserToGroupCommand({
+				UserPoolId: process.env.USER_POOL_ID!,
+				Username: normalizedEmail,
+				GroupName: groupName,
+			}));
+		}
 
-	return { userId, reactivated: true };
+		await db.collection<User>('users').updateOne(
+			{ _id: userId },
+			{
+				$set: {
+					name: input.name,
+					email: normalizedEmail,
+					cognitoSub,
+					status: 'active',
+					userType,
+				},
+				$unset: {
+					removedAt: '',
+					removedByUserId: '',
+				},
+			},
+		);
+
+		await db.collection<Workspace>('workspaces').updateOne(
+			{ _id: workspaceId },
+			{ $addToSet: { userIds: userId } },
+		);
+
+		const postActivationCheck = await verifySeatLimitAfterActivation(workspaceId);
+		if (!postActivationCheck.allowed) {
+			await rollbackDbActivation();
+			await rollbackCognito();
+			throw new UserReactivationError(postActivationCheck.reason);
+		}
+
+		return { userId, reactivated: true };
+	} catch (error) {
+		if (!(error instanceof UserReactivationError)) {
+			try {
+				await rollbackDbActivation();
+			} catch {
+				// Best-effort DB rollback after a partial activation.
+			}
+			try {
+				await rollbackCognito();
+			} catch {
+				// Best-effort Cognito rollback after a partial activation.
+			}
+			throw new UserReactivationError(
+				error instanceof Error ? error.message : 'Failed to reactivate workspace user',
+			);
+		}
+		throw error;
+	}
 };

--- a/src/utils/userRemoval.ts
+++ b/src/utils/userRemoval.ts
@@ -1,0 +1,298 @@
+import {
+	AdminAddUserToGroupCommand,
+	AdminDisableUserCommand,
+	AdminEnableUserCommand,
+	AdminRemoveUserFromGroupCommand,
+	AdminUpdateUserAttributesCommand,
+	CognitoIdentityProviderClient,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { Db, ObjectId } from 'mongodb';
+import type { Department } from '../models/department';
+import type { Project } from '../models/project';
+import type { User } from '../models/user';
+import type { Workspace } from '../models/workspace';
+import { getDb } from './db';
+import {
+	cognitoUserExists,
+	createInvitedCognitoUser,
+	deleteCognitoInviteUser,
+	normalizeInviteEmail,
+} from './platformInviteUtils';
+import { assertSeatActivationAllowed } from './billing/enforcement';
+
+const cognito = new CognitoIdentityProviderClient({ region: process.env.AWS_REGION || 'us-east-1' });
+
+export class UserRemovalError extends Error {
+	constructor(
+		message: string,
+		public readonly code: 'not_found' | 'already_inactive' | 'last_admin' | 'invalid_status',
+	) {
+		super(message);
+		this.name = 'UserRemovalError';
+	}
+}
+
+export class UserReactivationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'UserReactivationError';
+	}
+};
+
+const disableCognitoUser = async (email: string): Promise<void> => {
+	await cognito.send(new AdminDisableUserCommand({
+		UserPoolId: process.env.USER_POOL_ID!,
+		Username: email,
+	}));
+};
+
+const enableCognitoUser = async (email: string): Promise<void> => {
+	await cognito.send(new AdminEnableUserCommand({
+		UserPoolId: process.env.USER_POOL_ID!,
+		Username: email,
+	}));
+};
+
+const removeCognitoGroup = async (email: string, groupName: 'admin' | 'user'): Promise<void> => {
+	try {
+		await cognito.send(new AdminRemoveUserFromGroupCommand({
+			UserPoolId: process.env.USER_POOL_ID!,
+			Username: email,
+			GroupName: groupName,
+		}));
+	} catch {
+		// Group membership may already be absent.
+	}
+};
+
+const setCognitoStatus = async (email: string, status: string): Promise<void> => {
+	await cognito.send(new AdminUpdateUserAttributesCommand({
+		UserPoolId: process.env.USER_POOL_ID!,
+		Username: email,
+		UserAttributes: [{ Name: 'custom:status', Value: status }],
+	}));
+};
+
+const cleanupMembershipReferences = async (
+	db: Db,
+	workspaceId: ObjectId,
+	targetUserId: ObjectId,
+	reassignAdminToUserId: ObjectId,
+): Promise<void> => {
+	await db.collection<Workspace>('workspaces').updateOne(
+		{ _id: workspaceId },
+		{ $pull: { userIds: targetUserId } },
+	);
+
+	await db.collection<Department>('departments').updateMany(
+		{ workspace_id: workspaceId },
+		{ $pull: { users: targetUserId } },
+	);
+
+	await db.collection<Department>('departments').updateMany(
+		{ workspace_id: workspaceId, admin_id: targetUserId },
+		{ $set: { admin_id: reassignAdminToUserId } },
+	);
+
+	await db.collection<Project>('projects').updateMany(
+		{ workspace_id: workspaceId },
+		{ $pull: { users: targetUserId } },
+	);
+
+	await db.collection<Project>('projects').updateMany(
+		{ workspace_id: workspaceId, admin_id: targetUserId },
+		{ $set: { admin_id: reassignAdminToUserId } },
+	);
+
+	await db.collection('bookmarks').deleteMany({
+		user_id: targetUserId,
+		workspace_id: workspaceId,
+	});
+};
+
+export const countActiveWorkspaceAdmins = async (
+	db: Db,
+	workspaceId: ObjectId,
+): Promise<number> =>
+	db.collection<User>('users').countDocuments({
+		workspaceId,
+		userType: 'admin',
+		status: 'active',
+	});
+
+export const deactivateWorkspaceUser = async ({
+	targetUserId,
+	workspaceId,
+	actorUserId,
+}: {
+	targetUserId: ObjectId;
+	workspaceId: ObjectId;
+	actorUserId: ObjectId;
+}): Promise<User> => {
+	const db = await getDb();
+
+	const targetUser = await db.collection<User>('users').findOne({
+		_id: targetUserId,
+		workspaceId,
+	});
+
+	if (!targetUser) {
+		throw new UserRemovalError('User not found', 'not_found');
+	}
+
+	if (targetUser.status === 'inactive') {
+		throw new UserRemovalError('User is already removed from this workspace', 'already_inactive');
+	}
+
+	if (targetUser.status !== 'active' && targetUser.status !== 'invited') {
+		throw new UserRemovalError('User cannot be removed in their current state', 'invalid_status');
+	}
+
+	if (targetUser.userType === 'admin' && targetUser.status === 'active') {
+		const activeAdminCount = await countActiveWorkspaceAdmins(db, workspaceId);
+		if (activeAdminCount <= 1) {
+			throw new UserRemovalError(
+				'Cannot remove the last active workspace admin. Promote another admin first.',
+				'last_admin',
+			);
+		}
+	}
+
+	const now = new Date();
+
+	if (targetUser.status === 'invited') {
+		await deleteCognitoInviteUser(targetUser.email);
+	} else {
+		await disableCognitoUser(targetUser.email);
+		await setCognitoStatus(targetUser.email, 'inactive');
+		const groupName = targetUser.userType === 'admin' ? 'admin' : 'user';
+		await removeCognitoGroup(targetUser.email, groupName);
+	}
+
+	await cleanupMembershipReferences(db, workspaceId, targetUserId, actorUserId);
+
+	await db.collection<User>('users').updateOne(
+		{ _id: targetUserId, workspaceId },
+		{
+			$set: {
+				status: 'inactive',
+				removedAt: now,
+				removedByUserId: actorUserId,
+			},
+		},
+	);
+
+	const updatedUser = await db.collection<User>('users').findOne({ _id: targetUserId });
+	if (!updatedUser) {
+		throw new UserRemovalError('User not found after deactivation', 'not_found');
+	}
+
+	return updatedUser;
+};
+
+export type ReactivateWorkspaceUserInput = {
+	email: string;
+	name: string;
+	workspaceId: ObjectId;
+	actorUserId: ObjectId;
+	userType?: 'user' | 'admin';
+};
+
+export type ReactivateWorkspaceUserResult = {
+	userId: ObjectId;
+	reactivated: true;
+};
+
+export const findInactiveWorkspaceUserByEmail = async (
+	db: Db,
+	email: string,
+	workspaceId: ObjectId,
+): Promise<User | null> => {
+	const normalizedEmail = normalizeInviteEmail(email);
+	const candidates = await db.collection<User>('users').find({
+		workspaceId,
+		status: 'inactive',
+	}).toArray();
+
+	return candidates.find((user) => normalizeInviteEmail(user.email) === normalizedEmail) ?? null;
+};
+
+export const reactivateWorkspaceUser = async (
+	input: ReactivateWorkspaceUserInput,
+): Promise<ReactivateWorkspaceUserResult> => {
+	const db = await getDb();
+	const normalizedEmail = normalizeInviteEmail(input.email);
+	const workspaceId = input.workspaceId;
+
+	const existingUser = await findInactiveWorkspaceUserByEmail(db, normalizedEmail, workspaceId);
+	if (!existingUser?._id) {
+		throw new UserReactivationError('No removed member found with this email in this workspace');
+	}
+
+	const userType = input.userType ?? existingUser.userType ?? 'user';
+	const groupName = userType === 'admin' ? 'admin' : 'user';
+	const userId = existingUser._id;
+	const seatCheck = await assertSeatActivationAllowed(workspaceId, 1);
+	if (!seatCheck.allowed) {
+		throw new UserReactivationError(seatCheck.reason);
+	}
+
+	let cognitoSub = existingUser.cognitoSub;
+	const hasCognitoAccount = await cognitoUserExists(normalizedEmail);
+
+	if (!cognitoSub || !hasCognitoAccount) {
+		const created = await createInvitedCognitoUser({
+			email: normalizedEmail,
+			name: input.name,
+			groupName,
+			customAttributes: [
+				{ Name: 'custom:userId', Value: userId.toString() },
+				{ Name: 'custom:workspaceId', Value: workspaceId.toString() },
+				{ Name: 'custom:status', Value: 'active' },
+			],
+		});
+		cognitoSub = created.cognitoSub;
+	} else {
+		await enableCognitoUser(normalizedEmail);
+		await cognito.send(new AdminUpdateUserAttributesCommand({
+			UserPoolId: process.env.USER_POOL_ID!,
+			Username: normalizedEmail,
+			UserAttributes: [
+				{ Name: 'name', Value: input.name },
+				{ Name: 'custom:userId', Value: userId.toString() },
+				{ Name: 'custom:workspaceId', Value: workspaceId.toString() },
+				{ Name: 'custom:status', Value: 'active' },
+			],
+		}));
+
+		await cognito.send(new AdminAddUserToGroupCommand({
+			UserPoolId: process.env.USER_POOL_ID!,
+			Username: normalizedEmail,
+			GroupName: groupName,
+		}));
+	}
+
+	await db.collection<User>('users').updateOne(
+		{ _id: userId },
+		{
+			$set: {
+				name: input.name,
+				email: normalizedEmail,
+				cognitoSub,
+				status: 'active',
+				userType,
+			},
+			$unset: {
+				removedAt: '',
+				removedByUserId: '',
+			},
+		},
+	);
+
+	await db.collection<Workspace>('workspaces').updateOne(
+		{ _id: workspaceId },
+		{ $addToSet: { userIds: userId } },
+	);
+
+	return { userId, reactivated: true };
+};

--- a/template.yaml
+++ b/template.yaml
@@ -1492,6 +1492,176 @@ Resources:
         <<: *EsbuildProps
         EntryPoints: [controllers/platformAdmin/inviteWorkspaceAdmin.ts]
 
+  BillingGetSummaryFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/billing/getSummary.lambdaHandler
+      Events:
+        BillingGetSummary:
+          Type: Api
+          Properties:
+            Path: /billing/summary
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/billing/getSummary.ts]
+
+  BillingUpdatePreferencesFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/billing/updatePreferences.lambdaHandler
+      Events:
+        BillingUpdatePreferences:
+          Type: Api
+          Properties:
+            Path: /billing/preferences
+            Method: put
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/billing/updatePreferences.ts]
+
+  PlatformAdminGetBillingAccountFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/platformAdmin/getBillingAccount.lambdaHandler
+      Events:
+        PlatformAdminGetBillingAccount:
+          Type: Api
+          Properties:
+            Path: /platform-admin/workspaces/{workspaceId}/billing-account
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/platformAdmin/getBillingAccount.ts]
+
+  PlatformAdminUpdateBillingAccountFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/platformAdmin/updateBillingAccount.lambdaHandler
+      Events:
+        PlatformAdminUpdateBillingAccount:
+          Type: Api
+          Properties:
+            Path: /platform-admin/workspaces/{workspaceId}/billing-account
+            Method: put
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/platformAdmin/updateBillingAccount.ts]
+
+  PlatformAdminCreateBillingAccountFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/platformAdmin/createBillingAccount.lambdaHandler
+      Events:
+        PlatformAdminCreateBillingAccount:
+          Type: Api
+          Properties:
+            Path: /platform-admin/workspaces/{workspaceId}/billing-account
+            Method: post
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/platformAdmin/createBillingAccount.ts]
+
+  PlatformAdminCreateUsageAdjustmentFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/platformAdmin/createUsageAdjustment.lambdaHandler
+      Events:
+        PlatformAdminCreateUsageAdjustment:
+          Type: Api
+          Properties:
+            Path: /platform-admin/workspaces/{workspaceId}/usage-adjustments
+            Method: post
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/platformAdmin/createUsageAdjustment.ts]
+
+  PlatformAdminRecomputeUsageSnapshotFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/platformAdmin/recomputeUsageSnapshot.lambdaHandler
+      Events:
+        PlatformAdminRecomputeUsageSnapshot:
+          Type: Api
+          Properties:
+            Path: /platform-admin/workspaces/{workspaceId}/usage-snapshots/recompute
+            Method: post
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/platformAdmin/recomputeUsageSnapshot.ts]
+
+  PlatformAdminUpdateFreezesFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/platformAdmin/updateFreezes.lambdaHandler
+      Events:
+        PlatformAdminUpdateFreezes:
+          Type: Api
+          Properties:
+            Path: /platform-admin/workspaces/{workspaceId}/freezes
+            Method: post
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/platformAdmin/updateFreezes.ts]
+
+  PlatformAdminRunReconciliationFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/platformAdmin/runReconciliation.lambdaHandler
+      Events:
+        PlatformAdminRunReconciliation:
+          Type: Api
+          Properties:
+            Path: /platform-admin/billing/reconciliation-runs
+            Method: post
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/platformAdmin/runReconciliation.ts]
+
+  PlatformAdminListUsageEventsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/platformAdmin/listUsageEvents.lambdaHandler
+      Events:
+        PlatformAdminListUsageEvents:
+          Type: Api
+          Properties:
+            Path: /platform-admin/workspaces/{workspaceId}/usage-events
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/platformAdmin/listUsageEvents.ts]
+
   # ──────────────────────────────────────────────────────────────────────────
   # S3 STORAGE
   # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- Add billing accounts, usage events, snapshots, and limit enforcement utilities
- Track activated seats, completed exports, and upload bytes across API handlers
- Add workspace billing summary/preferences endpoints and platform-admin billing controls
- Support workspace access and usage freezes with inactive-user rejection
- Replace hard user delete with soft removal and seat-aware reactivation
- Add billing backfill scripts and unit tests for billing, user removal, and platform admin

Closes #137