### PR TITLE
Fix deploy ESLint JSDoc errors on billing handlers

### DIFF
--- a/src/controllers/platformAdmin/listUsageEvents.ts
+++ b/src/controllers/platformAdmin/listUsageEvents.ts
@@ -9,6 +9,8 @@ import { serializeUsageEvent } from '../../utils/billing/serializers';
 
 /**
  * Lists usage events for a workspace.
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Paginated usage events payload
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {

--- a/src/controllers/platformAdmin/recomputeUsageSnapshot.ts
+++ b/src/controllers/platformAdmin/recomputeUsageSnapshot.ts
@@ -11,6 +11,8 @@ import { serializeUsageSnapshot } from '../../utils/billing/serializers';
 
 /**
  * Recomputes the current billing period usage snapshot for a workspace.
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Recomputed usage snapshot payload
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {

--- a/src/controllers/platformAdmin/runReconciliation.ts
+++ b/src/controllers/platformAdmin/runReconciliation.ts
@@ -7,6 +7,8 @@ import { runBillingReconciliation } from '../../utils/billing/reconciliation';
 
 /**
  * Runs billing reconciliation across all workspaces or a single workspace.
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Reconciliation run summary payload
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {

--- a/src/controllers/platformAdmin/updateBillingAccount.ts
+++ b/src/controllers/platformAdmin/updateBillingAccount.ts
@@ -50,6 +50,8 @@ type UpdateBillingInput = {
 
 /**
  * Updates billing account fields for platform operators.
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Updated billing account payload
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {

--- a/src/controllers/platformAdmin/updateFreezes.ts
+++ b/src/controllers/platformAdmin/updateFreezes.ts
@@ -15,6 +15,8 @@ type FreezeInput = {
 
 /**
  * Updates workspace usage and access freeze flags.
+ * @param {APIGatewayProxyEvent} event API Gateway request event
+ * @return {Promise<APIGatewayProxyResult>} Updated workspace freeze state payload
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
 	try {


### PR DESCRIPTION
- Add missing @param and @return JSDoc tags to five platform-admin billing Lambda handlers
- Fixes valid-jsdoc ESLint failures blocking Deploy Backend to AWS on develop