### PR TITLE
Add AdminGetUser IAM permission for Cognito user management

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -279,6 +279,7 @@ Resources:
         - Statement:
             - Effect: Allow
               Action:
+                - cognito-idp:AdminGetUser
                 - cognito-idp:AdminUpdateUserAttributes
                 - cognito-idp:AdminAddUserToGroup
               Resource: !Sub "arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${UserPoolId}"
@@ -309,6 +310,7 @@ Resources:
         - Statement:
             - Effect: Allow
               Action:
+                - cognito-idp:AdminGetUser
                 - cognito-idp:AdminCreateUser
                 - cognito-idp:AdminUpdateUserAttributes
                 - cognito-idp:AdminAddUserToGroup


### PR DESCRIPTION
## Summary

- Add `cognito-idp:AdminGetUser` to IAM policies in `template.yaml` for user management Lambdas

Closes #151

## Test plan

- [ ] Deploy SAM template successfully
- [ ] User invite/reactivation flows can read existing Cognito users without permission errors