### PR TITLE
Add dashboard activity stats and API updates for revamped UI

### DIFF
--- a/src/controllers/auditLogs/getAuditLogs.ts
+++ b/src/controllers/auditLogs/getAuditLogs.ts
@@ -9,6 +9,7 @@ import {
 	type AuditScopeType,
 } from '../../models/auditLogV2';
 import { getDb } from '../../utils/db';
+import { enrichUsersWithProfileAvatarUrls } from '../../utils/s3-storage';
 import { logError, logInfo } from '../../utils/logger';
 import { ResponseWrapper } from '../../utils/responseWrapper';
 import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
@@ -182,20 +183,33 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			collection.countDocuments(query),
 		]);
 
+		const signingOptions = {
+			workspaceId: context.workspaceId,
+			pendingOwnerId: context.cognitoSub,
+		};
+		const signedActors = await enrichUsersWithProfileAvatarUrls(
+			logs.map((log) => log.actor),
+			signingOptions,
+		);
+		const logsWithSignedAvatars = logs.map((log, index) => ({
+			...log,
+			actor: signedActors[index] ?? log.actor,
+		}));
+
 		logInfo('✅ auditLogs/getAuditLogs result', {
 			page,
 			limit,
 			totalCount,
-			returnedCount: logs.length,
-			firstLogId: logs[0]?._id?.toString(),
-			lastLogId: logs.length ? logs[logs.length - 1]?._id?.toString() : undefined,
+			returnedCount: logsWithSignedAvatars.length,
+			firstLogId: logsWithSignedAvatars[0]?._id?.toString(),
+			lastLogId: logsWithSignedAvatars.length ? logsWithSignedAvatars[logsWithSignedAvatars.length - 1]?._id?.toString() : undefined,
 			requestId: event.requestContext?.requestId,
 		});
 
 		return ResponseWrapper.success({
 			message: 'Audit logs fetched successfully',
 			result: {
-				logs,
+				logs: logsWithSignedAvatars,
 				pagination: {
 					page,
 					limit,

--- a/src/controllers/bookmarks/getAllBookmarkedProducts.ts
+++ b/src/controllers/bookmarks/getAllBookmarkedProducts.ts
@@ -97,7 +97,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		if (listQueryResult.error) return listQueryResult.error;
 
 		const { limit, page, skip, sort, order, filters } = listQueryResult.value!;
-		const isLatest = event.queryStringParameters?.isLatest || 'true';
+		const isLatest = event.queryStringParameters?.isLatest !== 'false';
 		const statusFilter = event.queryStringParameters?.status;
 		const filterParam = event.queryStringParameters?.filter;
 		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;

--- a/src/controllers/bookmarks/getAllBookmarkedProducts.ts
+++ b/src/controllers/bookmarks/getAllBookmarkedProducts.ts
@@ -1,0 +1,284 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import { getDb } from '../../utils/db';
+import { Product } from '../../models/product';
+import { UserBookmarks } from '../../models/bookmarks';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { logError } from '../../utils/logger';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
+import { buildLegacyAuditLookupStage } from '../../utils/auditLogV2Aggregation';
+import { buildListFiltersMatch, ListFilterField, parseListQuery } from '../../utils/listQuery';
+
+const ALLOWED_SORT_FIELDS = [
+	'product_name',
+	'product_plan_number',
+	'product_description',
+	'project_name',
+	'department_name',
+	'version',
+	'status',
+	'target_date',
+	'complete_count',
+	'createdBy',
+	'createdOn',
+	'modifiedBy',
+	'modifiedOn',
+	'archivedBy',
+	'archivedOn',
+	'actionBy',
+	'actionAt',
+	'_id',
+];
+
+const ACTIVE_FILTER_FIELDS: Record<string, ListFilterField> = {
+	product_name: { path: 'product_name', type: 'text' },
+	product_plan_number: { path: 'product_plan_number', type: 'text' },
+	project_name: { path: 'project_name', type: 'text' },
+	department_name: { path: 'department_name', type: 'text' },
+	status: { path: 'status', type: 'text' },
+	version: { path: 'version', type: 'number' },
+	complete_count: { path: 'complete_count', type: 'number' },
+	progress: { path: 'complete_count', type: 'number' },
+	createdBy: { path: 'createdBy', type: 'text' },
+	createdOn: { path: 'createdOn', type: 'date' },
+	modifiedBy: { path: 'modifiedBy', type: 'text' },
+	modifiedOn: { path: 'modifiedOn', type: 'date' },
+};
+
+const ARCHIVE_FILTER_FIELDS: Record<string, ListFilterField> = {
+	product_name: { path: 'product_name', type: 'text' },
+	product_plan_number: { path: 'product_plan_number', type: 'text' },
+	project_name: { path: 'project_name', type: 'text' },
+	department_name: { path: 'department_name', type: 'text' },
+	version: { path: 'version', type: 'number' },
+	complete_count: { path: 'complete_count', type: 'number' },
+	progress: { path: 'complete_count', type: 'number' },
+	archivedBy: { path: 'archivedBy', type: 'text' },
+	archivedOn: { path: 'archivedOn', type: 'date' },
+};
+
+/**
+ * Returns a success response with an empty products array when no bookmarked products are found.
+ * @param {number} page - The current page number.
+ * @param {number} limit - The number of items per page.
+ * @return {APIGatewayProxyResult} A success response with an empty products array.
+ */
+function emptyProductsResult(page: number, limit: number): APIGatewayProxyResult {
+	return ResponseWrapper.success({
+		message: 'No bookmarked products found',
+		result: {
+			products: [],
+			pagination: {
+				currentPage: page,
+				totalPages: 0,
+				totalCount: 0,
+				limit,
+				hasNextPage: false,
+				hasPrevPage: false,
+			},
+		},
+	});
+}
+
+
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
+		const db = await getDb();
+
+		const listQueryResult = parseListQuery({
+			query: event.queryStringParameters,
+			allowedSortFields: ALLOWED_SORT_FIELDS,
+			defaultSort: 'product_name',
+		});
+		if (listQueryResult.error) return listQueryResult.error;
+
+		const { limit, page, skip, sort, order, filters } = listQueryResult.value!;
+		const isLatest = event.queryStringParameters?.isLatest || 'true';
+		const statusFilter = event.queryStringParameters?.status;
+		const filterParam = event.queryStringParameters?.filter;
+		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;
+		const projectId = event.queryStringParameters?.projectId;
+		const departmentId = event.queryStringParameters?.departmentId;
+
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) {
+				return ResponseWrapper.badRequest('Invalid workspaceId');
+			}
+
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
+
+		const bookmarks = await db.collection<UserBookmarks>('bookmarks').findOne({
+			user_id: context.userId,
+			workspace_id: context.workspaceId,
+		});
+
+		const bookmarkedProductIds = new Set<ObjectId>();
+		for (const folder of bookmarks?.product_folders ?? []) {
+			for (const productId of folder.products ?? []) {
+				bookmarkedProductIds.add(productId);
+			}
+		}
+
+		if (bookmarkedProductIds.size === 0) {
+			return emptyProductsResult(page, limit);
+		}
+
+		const filter: Record<string, unknown> = {
+			workspace_id: context.workspaceId,
+			_id: { $in: Array.from(bookmarkedProductIds) },
+		};
+		let statusValues: string[] | null = null;
+
+		if (projectId) {
+			if (!ObjectId.isValid(projectId)) return ResponseWrapper.badRequest('Invalid projectId');
+			filter.project_id = new ObjectId(projectId);
+		}
+
+		if (departmentId) {
+			if (!ObjectId.isValid(departmentId)) return ResponseWrapper.badRequest('Invalid departmentId');
+			filter.department_id = new ObjectId(departmentId);
+		}
+
+		if (statusFilter) {
+			try {
+				const statusArray = JSON.parse(statusFilter);
+				if (Array.isArray(statusArray) && statusArray.length > 0) {
+					const statusStrings = statusArray.filter(
+						(status): status is string => typeof status === 'string',
+					);
+					if (statusStrings.length > 0) {
+						filter.status = { $in: statusStrings };
+						statusValues = statusStrings;
+					}
+				}
+			} catch {
+				filter.status = statusFilter;
+				statusValues = [statusFilter];
+			}
+		} else {
+			filter.status = { $in: ['draft', 'submitted'] };
+			statusValues = ['draft', 'submitted'];
+		}
+
+		const isArchiveOnlyStatus = statusValues?.length === 1 && statusValues[0] === 'archived';
+
+		if (filterParam) {
+			filter.$or = [
+				{ product_name: { $regex: filterParam, $options: 'i' } },
+				{ product_plan_number: { $regex: filterParam, $options: 'i' } },
+				{ product_description: { $regex: filterParam, $options: 'i' } },
+			];
+		}
+
+		if (isLatest) {
+			filter.is_latest = true;
+		}
+
+		const pipeline: any[] = [
+			{ $match: filter },
+			buildLegacyAuditLookupStage(
+				isArchiveOnlyStatus
+					? { scopeType: 'product', mode: 'archive' }
+					: {
+						scopeType: 'product',
+						updateActions: ['update', 'submit', 'delete', 'move', 'link', 'unlink', 'restore'],
+					}
+			),
+			{
+				$lookup: {
+					from: 'departments',
+					localField: 'department_id',
+					foreignField: '_id',
+					as: 'department',
+					pipeline: [{ $project: { department_name: 1 } }],
+				},
+			},
+			{
+				$lookup: {
+					from: 'projects',
+					localField: 'project_id',
+					foreignField: '_id',
+					as: 'project',
+					pipeline: [{ $project: { project_name: 1 } }],
+				},
+			},
+		];
+
+		pipeline.push({
+			$addFields: {
+				project_name: { $arrayElemAt: ['$project.project_name', 0] },
+				department_name: { $arrayElemAt: ['$department.department_name', 0] },
+				actionBy: { $arrayElemAt: ['$auditLogs.actionBy', 0] },
+				actionAt: { $arrayElemAt: ['$auditLogs.actionAt', 0] },
+				createdAudit: {
+					$first: {
+						$filter: { input: '$auditLogs', as: 'auditLog', cond: { $eq: ['$$auditLog.action', 'create'] } },
+					},
+				},
+				modifiedAudit: {
+					$first: {
+						$filter: { input: '$auditLogs', as: 'auditLog', cond: { $eq: ['$$auditLog.action', 'update'] } },
+					},
+				},
+			},
+		});
+		pipeline.push({
+			$addFields: {
+				createdBy: '$createdAudit.actionBy',
+				createdOn: '$createdAudit.actionAt',
+				modifiedBy: '$modifiedAudit.actionBy',
+				modifiedOn: '$modifiedAudit.actionAt',
+				archivedBy: '$actionBy',
+				archivedOn: '$actionAt',
+			},
+		});
+
+		const filtersMatch = buildListFiltersMatch(
+			filters,
+			isArchiveOnlyStatus ? ARCHIVE_FILTER_FIELDS : ACTIVE_FILTER_FIELDS,
+		);
+		if (filtersMatch.error) return filtersMatch.error;
+		if (filtersMatch.match) pipeline.push({ $match: filtersMatch.match });
+
+		const sortObj: { [key: string]: 1 | -1 } = {};
+		sortObj[sort] = order === 'desc' ? -1 : 1;
+		pipeline.push({ $sort: sortObj });
+
+		pipeline.push({ $skip: skip });
+		pipeline.push({ $limit: limit });
+
+		const countPipeline = pipeline.slice(0, -3).concat({ $count: 'total' });
+
+		const [products, countResult] = await Promise.all([
+			db.collection<Product>('products').aggregate(pipeline).toArray(),
+			db.collection<Product>('products').aggregate(countPipeline).toArray(),
+		]);
+
+		const totalCount = countResult.length > 0 ? countResult[0].total : 0;
+		const totalPages = Math.ceil(totalCount / limit);
+
+		return ResponseWrapper.success({
+			message: 'Bookmarked products fetched successfully',
+			result: {
+				products,
+				pagination: {
+					currentPage: page,
+					totalPages,
+					totalCount,
+					limit,
+					hasNextPage: page < totalPages,
+					hasPrevPage: page > 1,
+				},
+			},
+		});
+	} catch (error) {
+		logError('Get all bookmarked products handler failed', error);
+		return ResponseWrapper.internalServerError('Failed to get bookmarked products');
+	}
+};

--- a/src/controllers/bookmarks/getBookmarkedSourceFileFolders.ts
+++ b/src/controllers/bookmarks/getBookmarkedSourceFileFolders.ts
@@ -1,14 +1,15 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ResponseWrapper } from "../../utils/responseWrapper";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { requireTenantContext } from "../../utils/tenantContext";
-import { getDb } from "../../utils/db";
-import { ObjectId } from "mongodb";
-import { SourceFile } from "../../models/sourceFiles";
-import { UserBookmarks } from "../../models/bookmarks";
+import { requireTenantContext } from '../../utils/tenantContext';
+import { getDb } from '../../utils/db';
+import { ObjectId } from 'mongodb';
+import { SourceFile } from '../../models/sourceFiles';
+import { UserBookmarks } from '../../models/bookmarks';
+import { attachSourceFolderFileCounts } from '../../utils/sourceFolderFileCounts';
 
 /**
- * @param {APIGatewayProxyEvent} event 
+ * @param {APIGatewayProxyEvent} event
  * @return {Promise<APIGatewayProxyResult>}
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
@@ -20,27 +21,40 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 
 		const db = await getDb();
 		const userIdObj = context.userId;
+		const sourceFilesCollection = db.collection<SourceFile>('sourceFiles');
 
 		const bookmarks = await db.collection<UserBookmarks>('bookmarks').findOne({
 			user_id: userIdObj,
 			workspace_id: context.workspaceId,
 		});
-		const bookmarkedFolderIds = bookmarks ? bookmarks.sourceFile_folders.map(id => id.toString()) : [];
-        
+		const bookmarkedFolderIds = bookmarks ? bookmarks.sourceFile_folders.map((id) => id.toString()) : [];
 
-		const allBookmarkedFolders = await db.collection<SourceFile>('sourceFiles').find({
-			_id: { $in: bookmarkedFolderIds.map(id => new ObjectId(id)) },
-			workspace_id: context.workspaceId,
-		}).toArray();
+		if (bookmarkedFolderIds.length === 0) {
+			return ResponseWrapper.success({
+				message: 'No bookmarked source file folders found.',
+				result: [],
+			});
+		}
 
+		const allBookmarkedFolders = await sourceFilesCollection
+			.find({
+				_id: { $in: bookmarkedFolderIds.map((id) => new ObjectId(id)) },
+				workspace_id: context.workspaceId,
+			})
+			.toArray();
+
+		const bookmarkedFoldersWithFileCounts = await attachSourceFolderFileCounts(
+			sourceFilesCollection,
+			allBookmarkedFolders,
+			context.workspaceId,
+		);
 
 		return ResponseWrapper.success({
 			message: 'Source file folders fetched successfully.',
-			result: allBookmarkedFolders
+			result: bookmarkedFoldersWithFileCounts,
 		});
-        
 	} catch (error) {
 		logError('Get bookmarked source file folders handler failed', error);
 		return ResponseWrapper.internalServerError('Failed to get bookmarked source file folders');
 	}
-}
+};

--- a/src/controllers/dashboard/getDashboardActivityStats.ts
+++ b/src/controllers/dashboard/getDashboardActivityStats.ts
@@ -1,0 +1,43 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ObjectId } from 'mongodb';
+import { getDb } from '../../utils/db';
+import { getDashboardActivityStats } from '../../utils/dashboardActivityStats';
+import { logError } from '../../utils/logger';
+import { ResponseWrapper } from '../../utils/responseWrapper';
+import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantContext';
+
+/**
+ * API endpoint to get 30-day dashboard activity statistics for a workspace.
+ *
+ * @param {APIGatewayProxyEvent} event - API Gateway Lambda Proxy Input Format
+ * @return {Promise<APIGatewayProxyResult>} Activity breakdowns for departments, projects, products, source files, and archives
+ */
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+	try {
+		const tenantResult = await requireTenantContext(event);
+		if (!tenantResult.ok) return tenantResult.response;
+
+		const { context } = tenantResult;
+		const requestedWorkspaceId = event.queryStringParameters?.id;
+
+		if (requestedWorkspaceId) {
+			if (!ObjectId.isValid(requestedWorkspaceId)) {
+				return ResponseWrapper.badRequest('Invalid workspace id');
+			}
+
+			const workspaceMismatch = assertWorkspaceMatch(requestedWorkspaceId, context.workspaceId);
+			if (workspaceMismatch) return workspaceMismatch;
+		}
+
+		const db = await getDb();
+		const activityStats = await getDashboardActivityStats(db, context.workspaceId);
+
+		return ResponseWrapper.success({
+			message: 'Dashboard activity statistics retrieved successfully',
+			data: activityStats,
+		});
+	} catch (err) {
+		logError('Get dashboard activity stats handler failed', err);
+		return ResponseWrapper.internalServerError('Failed to get dashboard activity stats');
+	}
+};

--- a/src/controllers/dashboard/getDashboardStats.ts
+++ b/src/controllers/dashboard/getDashboardStats.ts
@@ -8,7 +8,7 @@ import { assertWorkspaceMatch, requireTenantContext } from '../../utils/tenantCo
 /**
  * API endpoint to get dashboard statistics for a workspace
  * @param event - API Gateway Lambda Proxy Input Format
- * @returns Dashboard statistics including counts for departments, projects, products, and source files
+ * @returns Dashboard statistics including counts for departments, projects, products, source files, and archives
  */
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
@@ -40,6 +40,21 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const sourceFilesPromise = db.collection('sourceFiles').countDocuments({
 			workspace_id: workspaceObjectId,
 			type: 'file',
+		});
+
+		const archivedDepartmentsPromise = db.collection('departments').countDocuments({
+			workspace_id: workspaceObjectId,
+			isArchived: true,
+		});
+
+		const archivedProjectsPromise = db.collection('projects').countDocuments({
+			workspace_id: workspaceObjectId,
+			isArchived: true,
+		});
+
+		const archivedProductsPromise = db.collection('products').countDocuments({
+			workspace_id: workspaceObjectId,
+			status: 'archived',
 		});
 
 		const projectAndProductStatsPromise = db.collection('projects').aggregate([
@@ -79,10 +94,20 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				}
 			}
 		]).toArray();
-			
-		const [totalDepartments, totalSourceFiles, projectAndProductStats] = await Promise.all([
+
+		const [
+			totalDepartments,
+			totalSourceFiles,
+			archivedDepartments,
+			archivedProjects,
+			archivedProducts,
+			projectAndProductStats,
+		] = await Promise.all([
 			departmentsPromise,
 			sourceFilesPromise,
+			archivedDepartmentsPromise,
+			archivedProjectsPromise,
+			archivedProductsPromise,
 			projectAndProductStatsPromise,
 		]);
 
@@ -95,6 +120,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 				total_projects: stats.totalProjects,
 				total_products: stats.totalProducts,
 				total_source_files: totalSourceFiles,
+				total_archives: archivedDepartments + archivedProjects + archivedProducts,
 			},
 		});
 	} catch (err) {

--- a/src/controllers/sourceFiles/createSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/createSourceFileAndFolder.ts
@@ -5,9 +5,10 @@ import { requireTenantContext, tenantObjectIdFilter } from "../../utils/tenantCo
 import { validateAllObjectIds, validateEnum, validateMissingFields } from "../../utils/validationUtils";
 import { getDb } from "../../utils/db";
 import { SourceFile } from "../../models/sourceFiles";
-import type { Product } from "../../models/product";
 import { ObjectId } from "mongodb";
 import { recordAuditEvent } from "../../utils/auditLogV2";
+import type { AuditLogV2Change } from "../../models/auditLogV2";
+import { resolveWorkspaceProductName } from "../../utils/sourceFilesAudit";
 import { assertUsageActionAllowed, checkUploadWouldExceedLimit } from "../../utils/billing/enforcement";
 import { getBillingAccountByWorkspaceId, normalizeLimits } from "../../utils/billing/billingAccounts";
 import { recordCommittedUploadBytes } from "../../utils/billing/uploadCommit";
@@ -81,11 +82,10 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.badRequest('product_id can only be set on top-level folders.');
 		}
 
+		let linkedProductName: string | null = null;
 		if (productId) {
-			const product = await db.collection<Product>('products').findOne(
-				tenantObjectIdFilter(productId, workspaceId),
-			);
-			if (!product) return ResponseWrapper.notFound('Product not found.');
+			linkedProductName = await resolveWorkspaceProductName(db, productId, workspaceId);
+			if (!linkedProductName) return ResponseWrapper.notFound('Product not found.');
 		}
 
 		const trimmedName = input.name.trim();
@@ -134,30 +134,57 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		}
 
 		const isFolder = newSourceFile.type === 'folder';
-		await recordAuditEvent({
-			workspaceId: workspaceId.toString(),
-			scope: { type: 'source-files', id: workspaceId.toString() },
-			entity: { type: isFolder ? 'source_folder' : 'source_file', id: newSourceFile._id.toString() },
-			action: 'create',
-			eventKey: isFolder ? 'source_files.folder.created' : 'source_files.file.uploaded',
-			visibility: 'all',
-			where: {
-				module: 'source-files',
-				parentId: parentId?.toString() ?? undefined,
-			},
-			auth: auth.payload,
-			after: {
-				name: newSourceFile.name,
-				type: newSourceFile.type,
-				url: newSourceFile.url,
-				key: newSourceFile.key,
-				product_id: newSourceFile.product_id?.toString() ?? null,
-			},
-			changedPaths: ['name', 'type', 'url', 'key', 'product_id'],
-			meta: isFolder
-				? { folderName: newSourceFile.name }
-				: { fileName: newSourceFile.name },
-		});
+
+		if (isFolder) {
+			const changes: AuditLogV2Change[] = [{
+				path: 'name',
+				from: null,
+				to: newSourceFile.name,
+			}];
+
+			if (linkedProductName) {
+				changes.push({
+					path: 'product',
+					from: null,
+					to: linkedProductName,
+				});
+			}
+
+			await recordAuditEvent({
+				workspaceId: workspaceId.toString(),
+				scope: { type: 'source-files', id: workspaceId.toString() },
+				entity: { type: 'source_folder', id: newSourceFile._id.toString() },
+				action: 'create',
+				eventKey: 'source_files.folder.created',
+				visibility: 'all',
+				where: {
+					module: 'source-files',
+					parentId: parentId?.toString() ?? undefined,
+				},
+				auth: auth.payload,
+				changes,
+				meta: {
+					folderName: newSourceFile.name,
+					...(linkedProductName && { productName: linkedProductName }),
+				},
+			});
+		} else {
+			await recordAuditEvent({
+				workspaceId: workspaceId.toString(),
+				scope: { type: 'source-files', id: workspaceId.toString() },
+				entity: { type: 'source_file', id: newSourceFile._id.toString() },
+				action: 'create',
+				eventKey: 'source_files.file.uploaded',
+				visibility: 'all',
+				where: {
+					module: 'source-files',
+					parentId: parentId?.toString() ?? undefined,
+				},
+				auth: auth.payload,
+				changes: [],
+				meta: { fileName: newSourceFile.name },
+			});
+		}
 
 		return ResponseWrapper.created({
 			message: input.type === 'file'  ? 'Source file created successfully.' : 'Source folder created successfully.',

--- a/src/controllers/sourceFiles/deleteSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/deleteSourceFileAndFolder.ts
@@ -7,6 +7,8 @@ import { validateAllObjectIds } from "../../utils/validationUtils";
 import { Collection, ObjectId } from "mongodb";
 import { SourceFile } from "../../models/sourceFiles";
 import { recordAuditEvent } from "../../utils/auditLogV2";
+import type { AuditLogV2Change } from "../../models/auditLogV2";
+import { resolveWorkspaceProductName } from "../../utils/sourceFilesAudit";
 import { deleteObjectByKey } from "../../utils/s3-storage";
 
 /**
@@ -90,29 +92,64 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			workspace_id: context.workspaceId,
 		});
 
-		await recordAuditEvent({
-			workspaceId: fileOrFolder.workspace_id.toString(),
-			scope: { type: 'source-files', id: fileOrFolder.workspace_id.toString() },
-			entity: { type: fileOrFolder.type === 'folder' ? 'source_folder' : 'source_file', id },
-			action: 'delete',
-			eventKey: fileOrFolder.type === 'folder' ? 'source_files.folder.deleted' : 'source_files.file.deleted',
-			visibility: 'all',
-			where: {
-				module: 'source-files',
-				parentId: fileOrFolder.parentId?.toString() ?? undefined,
-			},
-			auth: auth.payload,
-			before: {
-				name: fileOrFolder.name,
-				type: fileOrFolder.type,
-				url: fileOrFolder.url,
-				product_id: fileOrFolder.product_id?.toString() ?? null,
-			},
-			changedPaths: ['name', 'type', 'url', 'product_id'],
-			meta: fileOrFolder.type === 'folder'
-				? { folderName: fileOrFolder.name }
-				: { fileName: fileOrFolder.name },
-		});
+		const isFolder = fileOrFolder.type === 'folder';
+		let linkedProductName: string | null = null;
+
+		if (isFolder && fileOrFolder.product_id) {
+			linkedProductName = await resolveWorkspaceProductName(
+				db,
+				fileOrFolder.product_id,
+				context.workspaceId,
+			);
+		}
+
+		if (isFolder) {
+			const changes: AuditLogV2Change[] = [{
+				path: 'name',
+				from: fileOrFolder.name,
+				to: null,
+			}];
+
+			if (linkedProductName) {
+				changes.push({
+					path: 'product',
+					from: linkedProductName,
+					to: null,
+				});
+			}
+
+			await recordAuditEvent({
+				workspaceId: fileOrFolder.workspace_id.toString(),
+				scope: { type: 'source-files', id: fileOrFolder.workspace_id.toString() },
+				entity: { type: 'source_folder', id },
+				action: 'delete',
+				eventKey: 'source_files.folder.deleted',
+				visibility: 'all',
+				where: {
+					module: 'source-files',
+					parentId: fileOrFolder.parentId?.toString() ?? undefined,
+				},
+				auth: auth.payload,
+				changes,
+				meta: { folderName: fileOrFolder.name },
+			});
+		} else {
+			await recordAuditEvent({
+				workspaceId: fileOrFolder.workspace_id.toString(),
+				scope: { type: 'source-files', id: fileOrFolder.workspace_id.toString() },
+				entity: { type: 'source_file', id },
+				action: 'delete',
+				eventKey: 'source_files.file.deleted',
+				visibility: 'all',
+				where: {
+					module: 'source-files',
+					parentId: fileOrFolder.parentId?.toString() ?? undefined,
+				},
+				auth: auth.payload,
+				changes: [],
+				meta: { fileName: fileOrFolder.name },
+			});
+		}
 
 		return ResponseWrapper.success({
 			message: 'Source file or folder and its contents deleted successfully.',

--- a/src/controllers/sourceFiles/getAllSourceFilesFolders.ts
+++ b/src/controllers/sourceFiles/getAllSourceFilesFolders.ts
@@ -1,15 +1,23 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ResponseWrapper } from "../../utils/responseWrapper";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
-import { assertWorkspaceMatch, requireTenantContext, tenantObjectIdFilter } from "../../utils/tenantContext";
-import { getDb } from "../../utils/db";
-import { validateAllObjectIds } from "../../utils/validationUtils";
-import { ObjectId } from "mongodb";
-import { SourceFile } from "../../models/sourceFiles";
-import type { Product } from "../../models/product";
+import { assertWorkspaceMatch, requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
+import { getDb } from '../../utils/db';
+import { validateAllObjectIds } from '../../utils/validationUtils';
+import { ObjectId } from 'mongodb';
+import { SourceFile } from '../../models/sourceFiles';
+import type { Product } from '../../models/product';
+import { buildListFiltersMatch, ListFilterField, parseListQuery } from '../../utils/listQuery';
+import { attachSourceFolderFileCounts } from '../../utils/sourceFolderFileCounts';
+
+const ALLOWED_SORT_FIELDS = ['name', '_id'];
+
+const SOURCE_FILES_FILTER_FIELDS: Record<string, ListFilterField> = {
+	name: { path: 'name', type: 'text' },
+};
 
 /**
- * @param {APIGatewayProxyEvent} event 
+ * @param {APIGatewayProxyEvent} event
  * @return {Promise<APIGatewayProxyResult>}
  */
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
@@ -20,6 +28,15 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 		const { context } = tenantResult;
 		const requestedWorkspaceId = event.queryStringParameters?.workspaceId;
 		const productId = event.queryStringParameters?.productId;
+
+		const listQueryResult = parseListQuery({
+			query: event.queryStringParameters,
+			allowedSortFields: ALLOWED_SORT_FIELDS,
+			defaultSort: 'name',
+		});
+		if (listQueryResult.error) return listQueryResult.error;
+
+		const { limit, page, skip, sort, order, filters } = listQueryResult.value!;
 
 		if (requestedWorkspaceId) {
 			if (!ObjectId.isValid(requestedWorkspaceId)) {
@@ -45,32 +62,57 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			if (!product) return ResponseWrapper.notFound('Product not found.');
 		}
 
-		const query: Record<string, unknown> = {
+		const match: Record<string, unknown> = {
 			workspace_id: context.workspaceId,
 			type: 'folder',
 			parentId: { $eq: null },
 		};
 
 		if (productId) {
-			query.product_id = new ObjectId(productId);
+			match.product_id = new ObjectId(productId);
 		}
 
-		const sourceFileFolders = await sourceFilesCollection.find(query).toArray();
-
-		if(!sourceFileFolders || sourceFileFolders.length === 0) {
-			return ResponseWrapper.success({
-				message: 'No source file folders found for the given workspace.',
-				result: []
-			});
+		const filtersMatch = buildListFiltersMatch(filters, SOURCE_FILES_FILTER_FIELDS);
+		if (filtersMatch.error) return filtersMatch.error;
+		if (filtersMatch.match) {
+			Object.assign(match, filtersMatch.match);
 		}
+
+		const sortObj: { [key: string]: 1 | -1 } = {};
+		sortObj[sort] = order === 'desc' ? -1 : 1;
+
+		const [sourceFileFolders, totalCount] = await Promise.all([
+			sourceFilesCollection.find(match).sort(sortObj).skip(skip).limit(limit).toArray(),
+			sourceFilesCollection.countDocuments(match),
+		]);
+
+		const foldersWithFileCounts = await attachSourceFolderFileCounts(
+			sourceFilesCollection,
+			sourceFileFolders,
+			context.workspaceId,
+		);
+
+		const totalPages = Math.ceil(totalCount / limit);
 
 		return ResponseWrapper.success({
-			message: 'Source file folders fetched successfully.',
-			result: sourceFileFolders
-		})
-        
+			message:
+				totalCount === 0
+					? 'No source file folders found for the given workspace.'
+					: 'Source file folders fetched successfully.',
+			result: {
+				folders: foldersWithFileCounts,
+				pagination: {
+					currentPage: page,
+					totalPages,
+					totalCount,
+					limit,
+					hasNextPage: page < totalPages,
+					hasPrevPage: page > 1,
+				},
+			},
+		});
 	} catch (error) {
 		logError('Get all source files folders handler failed', error);
 		return ResponseWrapper.internalServerError('Failed to get source file folders');
 	}
-}
+};

--- a/src/controllers/sourceFiles/updateSourceFilesFolder.ts
+++ b/src/controllers/sourceFiles/updateSourceFilesFolder.ts
@@ -1,12 +1,14 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { ResponseWrapper } from "../../utils/responseWrapper";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ResponseWrapper } from '../../utils/responseWrapper';
 import { logError } from '../../utils/logger';
 import { requireTenantContext, tenantObjectIdFilter } from '../../utils/tenantContext';
-import { getDb } from "../../utils/db";
-import { validateAllObjectIds } from "../../utils/validationUtils";
-import { ObjectId } from "mongodb";
-import { SourceFile } from "../../models/sourceFiles";
-import { recordAuditEvent } from "../../utils/auditLogV2";
+import { getDb } from '../../utils/db';
+import { validateAllObjectIds } from '../../utils/validationUtils';
+import { ObjectId } from 'mongodb';
+import { SourceFile } from '../../models/sourceFiles';
+import type { AuditLogV2Change } from '../../models/auditLogV2';
+import { recordAuditEvent } from '../../utils/auditLogV2';
+import { resolveWorkspaceProductName } from '../../utils/sourceFilesAudit';
 
 /**
  * @param {APIGatewayProxyEvent} event 
@@ -37,9 +39,9 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.badRequest('product_id must be a valid ObjectId string or null.');
 		}
 
-		const  validateFolderId = validateAllObjectIds({
+		const validateFolderId = validateAllObjectIds({
 			folderId,
-			...(typeof input.product_id === 'string' && { product_id: input.product_id })
+			...(typeof input.product_id === 'string' && { product_id: input.product_id }),
 		});
 		if (validateFolderId) return validateFolderId;
 
@@ -49,28 +51,43 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			...tenantObjectIdFilter(folderId, context.workspaceId),
 			type: 'folder' as const,
 		};
+
+		const beforeFolder = await sourceFilesCollection.findOne(folderFilter);
+		if (!beforeFolder) {
+			return ResponseWrapper.notFound('Folder not found.');
+		}
+
 		const updateFields: Partial<SourceFile> = {};
 
 		if (hasName) {
 			const trimmedFolderName = input.name.trim();
 			if (!trimmedFolderName) return ResponseWrapper.badRequest('Folder name cannot be empty.');
-			updateFields.name = trimmedFolderName;
+			if (trimmedFolderName !== beforeFolder.name) {
+				updateFields.name = trimmedFolderName;
+			}
 		}
 
 		if (hasProductId) {
-			const folder = await sourceFilesCollection.findOne(folderFilter);
-			if (!folder) {
-				return ResponseWrapper.notFound('Folder not found.');
-			}
-			if (folder.parentId) {
+			if (beforeFolder.parentId) {
 				return ResponseWrapper.badRequest('product_id can only be set on top-level folders.');
 			}
-			updateFields.product_id = typeof input.product_id === 'string'
-				? ObjectId.createFromHexString(input.product_id)
-				: null;
+
+			const nextProductId = typeof input.product_id === 'string' ? input.product_id : null;
+			const currentProductId = beforeFolder.product_id?.toString() ?? null;
+
+			if (nextProductId !== currentProductId) {
+				updateFields.product_id = nextProductId
+					? ObjectId.createFromHexString(nextProductId)
+					: null;
+			}
 		}
 
-		const beforeFolder = await sourceFilesCollection.findOne(folderFilter);
+		if (!Object.keys(updateFields).length) {
+			return ResponseWrapper.success({
+				message: 'Source file folder updated successfully.',
+				result: beforeFolder,
+			});
+		}
 
 		const updatedFolder = await sourceFilesCollection.findOneAndUpdate(
 			folderFilter,
@@ -82,40 +99,56 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 			return ResponseWrapper.notFound('Folder not found.');
 		}
 
-		const hasNameChange = Object.prototype.hasOwnProperty.call(updateFields, 'name');
-		const hasProductChange = Object.prototype.hasOwnProperty.call(updateFields, 'product_id');
-
 		const auditEvents: Array<{
 			action: 'update' | 'link' | 'unlink';
 			eventKey: string;
-			changedPaths: string[];
+			changes: AuditLogV2Change[];
 			meta: Record<string, unknown>;
 		}> = [];
 
-		if (hasNameChange) {
+		if (Object.prototype.hasOwnProperty.call(updateFields, 'name')) {
 			auditEvents.push({
 				action: 'update',
 				eventKey: 'source_files.folder.renamed',
-				changedPaths: ['name'],
+				changes: [{
+					path: 'name',
+					from: beforeFolder.name,
+					to: updatedFolder.name,
+				}],
 				meta: {
 					folderName: updatedFolder.name,
-					fromName: beforeFolder?.name,
+					fromName: beforeFolder.name,
 					toName: updatedFolder.name,
 				},
 			});
 		}
 
-		if (hasProductChange) {
+		if (Object.prototype.hasOwnProperty.call(updateFields, 'product_id')) {
+			const fromProductName = await resolveWorkspaceProductName(
+				db,
+				beforeFolder.product_id,
+				context.workspaceId,
+			);
+			const toProductName = await resolveWorkspaceProductName(
+				db,
+				updatedFolder.product_id,
+				context.workspaceId,
+			);
+
 			auditEvents.push({
-				action: updateFields.product_id ? 'link' : 'unlink',
-				eventKey: updateFields.product_id
+				action: updatedFolder.product_id ? 'link' : 'unlink',
+				eventKey: updatedFolder.product_id
 					? 'source_files.folder.product_linked'
 					: 'source_files.folder.product_unlinked',
-				changedPaths: ['product_id'],
+				changes: [{
+					path: 'product',
+					from: fromProductName,
+					to: toProductName,
+				}],
 				meta: {
 					folderName: updatedFolder.name,
-					fromProductId: beforeFolder?.product_id?.toString() ?? null,
-					toProductId: updatedFolder.product_id?.toString() ?? null,
+					fromProductName,
+					toProductName,
 				},
 			});
 		}
@@ -133,20 +166,17 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
 					parentId: updatedFolder.parentId?.toString() ?? undefined,
 				},
 				auth: auth.payload,
-				before: beforeFolder as unknown as Record<string, unknown>,
-				after: updatedFolder as unknown as Record<string, unknown>,
-				changedPaths: auditEvent.changedPaths,
+				changes: auditEvent.changes,
 				meta: auditEvent.meta,
 			});
 		}
 
 		return ResponseWrapper.success({
 			message: 'Source file folder updated successfully.',
-			result: updatedFolder
-		})
-        
+			result: updatedFolder,
+		});
 	} catch (error) {
 		logError('Update source files folder handler failed', error);
 		return ResponseWrapper.internalServerError('Failed to update source file folder');
 	}
-}
+};

--- a/src/models/auditLogV2.ts
+++ b/src/models/auditLogV2.ts
@@ -39,6 +39,7 @@ export type AuditLogV2 = {
 		userId?: string;
 		name: string;
 		email?: string;
+		profileAvatar?: string;
 		role?: 'admin' | 'user';
 	};
 	where: {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "src",
-	"version": "0.4.0",
+	"version": "0.5.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.4.0",
+			"version": "0.5.1",
 			"dependencies": {
 				"@aws-sdk/client-cognito-identity-provider": "^3.679.0",
 				"@aws-sdk/client-s3": "^3.990.0",
@@ -36,7 +36,7 @@
 				"prettier": "^2.5.1",
 				"ts-jest": "^29.0.5",
 				"ts-node": "^10.9.1",
-				"typescript": "^4.8.4"
+				"typescript": "^5.9.2"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -10321,9 +10321,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -10331,7 +10331,7 @@
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/undici-types": {

--- a/src/package.json
+++ b/src/package.json
@@ -43,6 +43,6 @@
 		"prettier": "^2.5.1",
 		"ts-jest": "^29.0.5",
 		"ts-node": "^10.9.1",
-		"typescript": "^4.8.4"
+		"typescript": "^5.9.2"
 	}
 }

--- a/src/scripts/backfillAuditLogV2.ts
+++ b/src/scripts/backfillAuditLogV2.ts
@@ -60,13 +60,12 @@ const toEventKey = (scopeType: AuditLogV2['scope']['type'], action: AuditAction)
 	return `${scopeType}.updated`;
 };
 
-const createSummary = (actorName: string, eventKey: string, action: AuditAction) =>
+const createSummary = (eventKey: string, action: AuditAction) =>
 	buildAuditEventSummary({
 		eventKey,
 		action,
 		changes: [],
 		meta: { name: 'legacy record' },
-		actorName,
 	});
 
 const inferVisibility = (scopeType: AuditLogV2['scope']['type']): AuditLogV2['visibility'] =>
@@ -150,7 +149,7 @@ async function run() {
 			},
 			action,
 			eventKey,
-			summary: createSummary(actorName, eventKey, action),
+			summary: createSummary(eventKey, action),
 			actor: {
 				name: actorName,
 				role: 'user',

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,12 +5,12 @@
       "preserveConstEnums": true,
       "noEmit": true,
       "sourceMap": false,
-      "module":"es2015",
-      "moduleResolution":"node",
-      "esModuleInterop": true, 
+      "module": "es2015",
+      "moduleResolution": "bundler",
+      "esModuleInterop": true,
       "skipLibCheck": true,
       "forceConsistentCasingInFileNames": true,
-      "ignoreDeprecations": "5.0"
+      "types": ["node"]
     },
     "exclude": ["node_modules", "**/*.test.ts"]
   }

--- a/src/utils/auditEventCatalog.ts
+++ b/src/utils/auditEventCatalog.ts
@@ -5,7 +5,6 @@ type SummaryContext = {
 	action: AuditAction;
 	changes: AuditLogV2Change[];
 	meta?: Record<string, unknown>;
-	actorName: string;
 };
 
 type SummaryBuilder = (context: SummaryContext) => string;
@@ -48,164 +47,165 @@ const subjectForScope = (eventKey: string) => {
 	return 'record';
 };
 
-const withActor = (actorName: string, message: string) => `${actorName} ${message}`;
-
 const productItemSummary = (
-	actorName: string,
 	verb: 'added' | 'updated' | 'deleted',
 	label: string,
 	changes: AuditLogV2Change[],
-) => withActor(actorName, `${verb} ${label}${verb === 'updated' ? listChangedFields(changes) : ''}`);
+) => `${verb} ${label}${verb === 'updated' ? listChangedFields(changes) : ''}`;
 
 const summaryBuilders: Record<string, SummaryBuilder> = {
-	'department.created': ({ actorName, meta }) => {
+	'department.created': ({ meta }) => {
 		const name = pickText(meta, ['departmentName', 'name']);
-		return withActor(actorName, `created department${name ? ` "${name}"` : ''}`);
+		return `created department${name ? ` "${name}"` : ''}`;
 	},
-	'department.updated': ({ actorName, meta, changes }) => {
+	'department.updated': ({ meta, changes }) => {
 		const name = pickText(meta, ['departmentName', 'name']);
-		return withActor(actorName, `updated department${name ? ` "${name}"` : ''}${listChangedFields(changes)}`);
+		return `updated department${name ? ` "${name}"` : ''}${listChangedFields(changes)}`;
 	},
-	'department.archived': ({ actorName, meta }) => {
+	'department.archived': ({ meta }) => {
 		const name = pickText(meta, ['departmentName', 'name']);
-		return withActor(actorName, `archived department${name ? ` "${name}"` : ''}`);
+		return `archived department${name ? ` "${name}"` : ''}`;
 	},
-	'department.restored': ({ actorName, meta }) => {
+	'department.restored': ({ meta }) => {
 		const name = pickText(meta, ['departmentName', 'name']);
-		return withActor(actorName, `restored department${name ? ` "${name}"` : ''}`);
+		return `restored department${name ? ` "${name}"` : ''}`;
 	},
-	'project.created': ({ actorName, meta }) => {
+	'project.created': ({ meta }) => {
 		const name = pickText(meta, ['projectName', 'name']);
-		return withActor(actorName, `created project${name ? ` "${name}"` : ''}`);
+		return `created project${name ? ` "${name}"` : ''}`;
 	},
-	'project.updated': ({ actorName, meta, changes }) => {
+	'project.updated': ({ meta, changes }) => {
 		const name = pickText(meta, ['projectName', 'name']);
-		return withActor(actorName, `updated project${name ? ` "${name}"` : ''}${listChangedFields(changes)}`);
+		return `updated project${name ? ` "${name}"` : ''}${listChangedFields(changes)}`;
 	},
-	'project.archived': ({ actorName, meta }) => {
+	'project.archived': ({ meta }) => {
 		const name = pickText(meta, ['projectName', 'name']);
-		return withActor(actorName, `archived project${name ? ` "${name}"` : ''}`);
+		return `archived project${name ? ` "${name}"` : ''}`;
 	},
-	'project.restored': ({ actorName, meta }) => {
+	'project.restored': ({ meta }) => {
 		const name = pickText(meta, ['projectName', 'name']);
-		return withActor(actorName, `restored project${name ? ` "${name}"` : ''}`);
+		return `restored project${name ? ` "${name}"` : ''}`;
 	},
-	'product.created': ({ actorName, meta }) => {
+	'product.created': ({ meta }) => {
 		const name = pickText(meta, ['productName', 'name']);
-		return withActor(actorName, `created product${name ? ` "${name}"` : ''}`);
+		return `created product${name ? ` "${name}"` : ''}`;
 	},
-	'product.updated': ({ actorName, meta, changes }) => {
+	'product.updated': ({ meta, changes }) => {
 		const name = pickText(meta, ['productName', 'name']);
-		return withActor(actorName, `updated product${name ? ` "${name}"` : ''}${listChangedFields(changes)}`);
+		return `updated product${name ? ` "${name}"` : ''}${listChangedFields(changes)}`;
 	},
-	'product.submitted': ({ actorName, meta }) => {
+	'product.submitted': ({ meta }) => {
 		const name = pickText(meta, ['productName', 'name']);
-		return withActor(actorName, `submitted product${name ? ` "${name}"` : ''}`);
+		return `submitted product${name ? ` "${name}"` : ''}`;
 	},
-	'product.archived': ({ actorName, meta }) => {
+	'product.archived': ({ meta }) => {
 		const name = pickText(meta, ['productName', 'name']);
-		return withActor(actorName, `archived product${name ? ` "${name}"` : ''}`);
+		return `archived product${name ? ` "${name}"` : ''}`;
 	},
-	'product.restored': ({ actorName, meta }) => {
+	'product.restored': ({ meta }) => {
 		const name = pickText(meta, ['productName', 'name']);
-		return withActor(actorName, `restored product${name ? ` "${name}"` : ''}`);
+		return `restored product${name ? ` "${name}"` : ''}`;
 	},
-	'product.version.created': ({ actorName, meta }) => {
+	'product.version.created': ({ meta }) => {
 		const name = pickText(meta, ['productName', 'name']);
 		const fromVersion = meta?.fromVersion;
 		const toVersion = meta?.toVersion;
 		const versionText = typeof fromVersion === 'number' && typeof toVersion === 'number'
 			? ` from v${fromVersion} to v${toVersion}`
 			: '';
-		return withActor(actorName, `created a new version${versionText}${name ? ` for product "${name}"` : ''}`);
+		return `created a new version${versionText}${name ? ` for product "${name}"` : ''}`;
 	},
-	'product.product_information.updated': ({ actorName, changes }) =>
-		withActor(actorName, `updated product information${listChangedFields(changes)}`),
-	'product.product_information.custom_field.added': ({ actorName }) =>
-		withActor(actorName, 'added custom field in product information'),
-	'product.product_information.custom_field.updated': ({ actorName, changes }) =>
-		withActor(actorName, `updated custom field in product information${listChangedFields(changes)}`),
-	'product.product_information.custom_field.deleted': ({ actorName }) =>
-		withActor(actorName, 'deleted custom field from product information'),
-	'product.product_information.completion.updated': ({ actorName, meta }) =>
-		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} product information tab as complete`),
-	'product.compliance_item.added': ({ actorName }) => productItemSummary(actorName, 'added', 'compliance item', []),
-	'product.compliance_item.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'compliance item', changes),
-	'product.compliance_item.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'compliance item', []),
-	'product.compliance_information.completion.updated': ({ actorName, meta }) =>
-		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} compliance information tab as complete`),
-	'product.languages_information.updated': ({ actorName, changes }) =>
-		withActor(actorName, `updated languages information${listChangedFields(changes)}`),
-	'product.label_component.added': ({ actorName }) => productItemSummary(actorName, 'added', 'label component', []),
-	'product.label_component.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'label component', changes),
-	'product.label_component.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'label component', []),
-	'product.label_components.completion.updated': ({ actorName, meta }) =>
-		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} label components tab as complete`),
-	'product.symbol_graphic.added': ({ actorName }) => productItemSummary(actorName, 'added', 'symbol/graphic item', []),
-	'product.symbol_graphic.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'symbol/graphic item', changes),
-	'product.symbol_graphic.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'symbol/graphic item', []),
-	'product.symbol_graphics.completion.updated': ({ actorName, meta }) =>
-		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} symbols and graphics tab as complete`),
-	'product.product_specification.added': ({ actorName }) => productItemSummary(actorName, 'added', 'product specification data', []),
-	'product.product_specification.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'product specification data', changes),
-	'product.product_specification.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'product specification data', []),
-	'product.product_specifications.completion.updated': ({ actorName, meta }) =>
-		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} product specifications tab as complete`),
-	'product.operational_parameter.added': ({ actorName }) => productItemSummary(actorName, 'added', 'operational parameter data', []),
-	'product.operational_parameter.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'operational parameter data', changes),
-	'product.operational_parameter.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'operational parameter data', []),
-	'product.operational_parameters.completion.updated': ({ actorName, meta }) =>
-		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} operational parameters tab as complete`),
-	'product.label_tag.added': ({ actorName }) => productItemSummary(actorName, 'added', 'label tag', []),
-	'product.label_tag.updated': ({ actorName, changes }) => productItemSummary(actorName, 'updated', 'label tag', changes),
-	'product.label_tag.deleted': ({ actorName }) => productItemSummary(actorName, 'deleted', 'label tag', []),
-	'product.label_tag.tagged_image.updated': ({ actorName, changes }) =>
-		withActor(actorName, `updated label tag tagged image${listChangedFields(changes)}`),
-	'product.label_tag.legend.updated': ({ actorName, changes }) =>
-		withActor(actorName, `updated label tag legend${listChangedFields(changes)}`),
-	'product.label_tags.completion.updated': ({ actorName, meta }) =>
-		withActor(actorName, `${meta?.tabCompleted ? 'marked' : 'unmarked'} label tags tab as complete`),
-	'source_files.folder.created': ({ actorName, meta }) => withActor(actorName, `created folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''}`),
-	'source_files.folder.renamed': ({ actorName, meta }) => {
+	'product.product_information.updated': ({ changes }) =>
+		`updated product information${listChangedFields(changes)}`,
+	'product.product_information.custom_field.added': () =>
+		'added custom field in product information',
+	'product.product_information.custom_field.updated': ({ changes }) =>
+		`updated custom field in product information${listChangedFields(changes)}`,
+	'product.product_information.custom_field.deleted': () =>
+		'deleted custom field from product information',
+	'product.product_information.completion.updated': ({ meta }) =>
+		`${meta?.tabCompleted ? 'marked' : 'unmarked'} product information tab as complete`,
+	'product.compliance_item.added': () => productItemSummary('added', 'compliance item', []),
+	'product.compliance_item.updated': ({ changes }) => productItemSummary('updated', 'compliance item', changes),
+	'product.compliance_item.deleted': () => productItemSummary('deleted', 'compliance item', []),
+	'product.compliance_information.completion.updated': ({ meta }) =>
+		`${meta?.tabCompleted ? 'marked' : 'unmarked'} compliance information tab as complete`,
+	'product.languages_information.updated': ({ changes }) =>
+		`updated languages information${listChangedFields(changes)}`,
+	'product.label_component.added': () => productItemSummary('added', 'label component', []),
+	'product.label_component.updated': ({ changes }) => productItemSummary('updated', 'label component', changes),
+	'product.label_component.deleted': () => productItemSummary('deleted', 'label component', []),
+	'product.label_components.completion.updated': ({ meta }) =>
+		`${meta?.tabCompleted ? 'marked' : 'unmarked'} label components tab as complete`,
+	'product.symbol_graphic.added': () => productItemSummary('added', 'symbol/graphic item', []),
+	'product.symbol_graphic.updated': ({ changes }) => productItemSummary('updated', 'symbol/graphic item', changes),
+	'product.symbol_graphic.deleted': () => productItemSummary('deleted', 'symbol/graphic item', []),
+	'product.symbol_graphics.completion.updated': ({ meta }) =>
+		`${meta?.tabCompleted ? 'marked' : 'unmarked'} symbols and graphics tab as complete`,
+	'product.product_specification.added': () => productItemSummary('added', 'product specification data', []),
+	'product.product_specification.updated': ({ changes }) => productItemSummary('updated', 'product specification data', changes),
+	'product.product_specification.deleted': () => productItemSummary('deleted', 'product specification data', []),
+	'product.product_specifications.completion.updated': ({ meta }) =>
+		`${meta?.tabCompleted ? 'marked' : 'unmarked'} product specifications tab as complete`,
+	'product.operational_parameter.added': () => productItemSummary('added', 'operational parameter data', []),
+	'product.operational_parameter.updated': ({ changes }) => productItemSummary('updated', 'operational parameter data', changes),
+	'product.operational_parameter.deleted': () => productItemSummary('deleted', 'operational parameter data', []),
+	'product.operational_parameters.completion.updated': ({ meta }) =>
+		`${meta?.tabCompleted ? 'marked' : 'unmarked'} operational parameters tab as complete`,
+	'product.label_tag.added': () => productItemSummary('added', 'label tag', []),
+	'product.label_tag.updated': ({ changes }) => productItemSummary('updated', 'label tag', changes),
+	'product.label_tag.deleted': () => productItemSummary('deleted', 'label tag', []),
+	'product.label_tag.tagged_image.updated': ({ changes }) =>
+		`updated label tag tagged image${listChangedFields(changes)}`,
+	'product.label_tag.legend.updated': ({ changes }) =>
+		`updated label tag legend${listChangedFields(changes)}`,
+	'product.label_tags.completion.updated': ({ meta }) =>
+		`${meta?.tabCompleted ? 'marked' : 'unmarked'} label tags tab as complete`,
+	'source_files.folder.created': ({ meta }) => `created folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''}`,
+	'source_files.folder.renamed': ({ meta }) => {
 		const from = pickText(meta, ['fromName']);
 		const to = pickText(meta, ['toName', 'folderName', 'name']);
-		if (from && to) return withActor(actorName, `renamed folder from "${from}" to "${to}"`);
-		return withActor(actorName, `renamed folder${to ? ` to "${to}"` : ''}`);
+		if (from && to) return `renamed folder from "${from}" to "${to}"`;
+		return `renamed folder${to ? ` to "${to}"` : ''}`;
 	},
-	'source_files.folder.deleted': ({ actorName, meta }) => withActor(actorName, `deleted folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''}`),
-	'source_files.folder.product_linked': ({ actorName, meta }) => withActor(actorName, `linked folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''} to a product`),
-	'source_files.folder.product_unlinked': ({ actorName, meta }) => withActor(actorName, `unlinked folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''} from product`),
-	'source_files.file.uploaded': ({ actorName, meta }) => withActor(actorName, `uploaded file${pickText(meta, ['fileName', 'name']) ? ` "${pickText(meta, ['fileName', 'name'])}"` : ''}`),
-	'source_files.file.deleted': ({ actorName, meta }) => withActor(actorName, `deleted file${pickText(meta, ['fileName', 'name']) ? ` "${pickText(meta, ['fileName', 'name'])}"` : ''}`),
+	'source_files.folder.deleted': ({ meta }) => `deleted folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''}`,
+	'source_files.folder.product_linked': ({ meta }) => `linked folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''} to a product`,
+	'source_files.folder.product_unlinked': ({ meta }) => `unlinked folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''} from product`,
+	'source_files.file.uploaded': ({ meta }) => `uploaded file${pickText(meta, ['fileName', 'name']) ? ` "${pickText(meta, ['fileName', 'name'])}"` : ''}`,
+	'source_files.file.deleted': ({ meta }) => `deleted file${pickText(meta, ['fileName', 'name']) ? ` "${pickText(meta, ['fileName', 'name'])}"` : ''}`,
 };
 
 export const buildAuditEventSummary = (context: SummaryContext): string => {
 	const builder = summaryBuilders[context.eventKey];
-	if (builder) return builder(context);
+	const summary = builder
+		? builder(context)
+		: (() => {
+			const subject = subjectForScope(context.eventKey);
+			const changed = listChangedFields(context.changes);
 
-	const subject = subjectForScope(context.eventKey);
-	const changed = listChangedFields(context.changes);
+			switch (context.action) {
+			case 'create':
+				return `created ${subject}`;
+			case 'update':
+				return `updated ${subject}${changed}`;
+			case 'delete':
+				return `deleted ${subject}`;
+			case 'archive':
+				return `archived ${subject}`;
+			case 'restore':
+				return `restored ${subject}`;
+			case 'submit':
+				return `submitted ${subject}`;
+			case 'move':
+				return `moved ${subject}`;
+			case 'link':
+				return `linked ${subject}`;
+			case 'unlink':
+				return `unlinked ${subject}`;
+			default:
+				return `updated ${subject}`;
+			}
+		})();
 
-	switch (context.action) {
-	case 'create':
-		return withActor(context.actorName, `created ${subject}`);
-	case 'update':
-		return withActor(context.actorName, `updated ${subject}${changed}`);
-	case 'delete':
-		return withActor(context.actorName, `deleted ${subject}`);
-	case 'archive':
-		return withActor(context.actorName, `archived ${subject}`);
-	case 'restore':
-		return withActor(context.actorName, `restored ${subject}`);
-	case 'submit':
-		return withActor(context.actorName, `submitted ${subject}`);
-	case 'move':
-		return withActor(context.actorName, `moved ${subject}`);
-	case 'link':
-		return withActor(context.actorName, `linked ${subject}`);
-	case 'unlink':
-		return withActor(context.actorName, `unlinked ${subject}`);
-	default:
-		return withActor(context.actorName, `updated ${subject}`);
-	}
+	return summary.charAt(0).toUpperCase() + summary.slice(1);
 };

--- a/src/utils/auditEventCatalog.ts
+++ b/src/utils/auditEventCatalog.ts
@@ -20,6 +20,18 @@ const pickText = (meta: Record<string, unknown> | undefined, keys: string[]): st
 	return undefined;
 };
 
+const pickChangeText = (
+	changes: AuditLogV2Change[],
+	paths: string[],
+	side: 'from' | 'to',
+): string | undefined => {
+	const change = changes.find((entry) => paths.includes(entry.path));
+	if (!change) return undefined;
+
+	const value = side === 'from' ? change.from : change.to;
+	return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+};
+
 const formatFieldName = (path: string) => {
 	const normalized = path
 		.split('.')
@@ -161,7 +173,12 @@ const summaryBuilders: Record<string, SummaryBuilder> = {
 		`updated label tag legend${listChangedFields(changes)}`,
 	'product.label_tags.completion.updated': ({ meta }) =>
 		`${meta?.tabCompleted ? 'marked' : 'unmarked'} label tags tab as complete`,
-	'source_files.folder.created': ({ meta }) => `created folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''}`,
+	'source_files.folder.created': ({ meta }) => {
+		const folder = pickText(meta, ['folderName', 'name']);
+		const product = pickText(meta, ['productName']);
+		if (folder && product) return `created folder "${folder}" linked to "${product}"`;
+		return `created folder${folder ? ` "${folder}"` : ''}`;
+	},
 	'source_files.folder.renamed': ({ meta }) => {
 		const from = pickText(meta, ['fromName']);
 		const to = pickText(meta, ['toName', 'folderName', 'name']);
@@ -169,8 +186,20 @@ const summaryBuilders: Record<string, SummaryBuilder> = {
 		return `renamed folder${to ? ` to "${to}"` : ''}`;
 	},
 	'source_files.folder.deleted': ({ meta }) => `deleted folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''}`,
-	'source_files.folder.product_linked': ({ meta }) => `linked folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''} to a product`,
-	'source_files.folder.product_unlinked': ({ meta }) => `unlinked folder${pickText(meta, ['folderName', 'name']) ? ` "${pickText(meta, ['folderName', 'name'])}"` : ''} from product`,
+	'source_files.folder.product_linked': ({ meta, changes }) => {
+		const folder = pickText(meta, ['folderName', 'name']);
+		const product = pickText(meta, ['toProductName', 'productName'])
+			?? pickChangeText(changes, ['product', 'product_id'], 'to');
+		if (folder && product) return `linked folder "${folder}" to "${product}"`;
+		return `linked folder${folder ? ` "${folder}"` : ''} to a product`;
+	},
+	'source_files.folder.product_unlinked': ({ meta, changes }) => {
+		const folder = pickText(meta, ['folderName', 'name']);
+		const product = pickText(meta, ['fromProductName', 'productName'])
+			?? pickChangeText(changes, ['product', 'product_id'], 'from');
+		if (folder && product) return `unlinked folder "${folder}" from "${product}"`;
+		return `unlinked folder${folder ? ` "${folder}"` : ''} from product`;
+	},
 	'source_files.file.uploaded': ({ meta }) => `uploaded file${pickText(meta, ['fileName', 'name']) ? ` "${pickText(meta, ['fileName', 'name'])}"` : ''}`,
 	'source_files.file.deleted': ({ meta }) => `deleted file${pickText(meta, ['fileName', 'name']) ? ` "${pickText(meta, ['fileName', 'name'])}"` : ''}`,
 };

--- a/src/utils/auditLogV2.ts
+++ b/src/utils/auditLogV2.ts
@@ -156,7 +156,14 @@ const getValueByPath = (source: Record<string, unknown> | null | undefined, path
 	return normalizeValue(current);
 };
 
-const valuesDiffer = (first: unknown, second: unknown) => JSON.stringify(first) !== JSON.stringify(second);
+const normalizeEmptyValue = (value: unknown): unknown => {
+	if (value === null || value === undefined) return null;
+	if (typeof value === 'string' && value.trim() === '') return null;
+	return value;
+};
+
+const valuesDiffer = (first: unknown, second: unknown) =>
+	JSON.stringify(normalizeEmptyValue(first)) !== JSON.stringify(normalizeEmptyValue(second));
 
 export const buildChangesFromPaths = ({
 	before,

--- a/src/utils/auditLogV2.ts
+++ b/src/utils/auditLogV2.ts
@@ -15,7 +15,13 @@ import { buildAuditEventSummary } from './auditEventCatalog';
 import { logError } from './logger';
 
 let hasEnsuredAuditLogV2Indexes = false;
-const actorEmailCache = new Map<string, string | null>();
+
+type ResolvedActorProfile = {
+	email?: string;
+	profileAvatar?: string;
+};
+
+const actorProfileCache = new Map<string, ResolvedActorProfile | null>();
 
 type AuditWhere = {
 	module: 'products' | 'projects' | 'departments' | 'source-files' | 'archive';
@@ -64,7 +70,7 @@ const getClaimString = (claims: Partial<CognitoAccessTokenPayload>, keys: string
 
 const isLikelyEmail = (value: string) => /^\S+@\S+\.\S+$/.test(value);
 
-const resolveActorEmail = async ({
+const resolveActorProfile = async ({
 	db,
 	workspaceId,
 	auth,
@@ -72,19 +78,25 @@ const resolveActorEmail = async ({
 	db: Db;
 	workspaceId: string;
 	auth: Partial<CognitoAccessTokenPayload>;
-}): Promise<string | undefined> => {
+}): Promise<ResolvedActorProfile> => {
 	const emailClaim = getClaimString(auth, ['email']);
-	if (emailClaim) return emailClaim;
-
 	const usernameClaim = getClaimString(auth, ['username', 'cognito:username']);
-	if (usernameClaim && isLikelyEmail(usernameClaim)) return usernameClaim;
+	const emailFromUsername = usernameClaim && isLikelyEmail(usernameClaim) ? usernameClaim : undefined;
+	const fallbackEmail = emailClaim ?? emailFromUsername;
 
 	const sub = getClaimString(auth, ['sub']);
-	if (!sub || !ObjectId.isValid(workspaceId)) return undefined;
+	if (!sub || !ObjectId.isValid(workspaceId)) {
+		return { email: fallbackEmail };
+	}
 
 	const cacheKey = `${workspaceId}:${sub}`;
-	if (actorEmailCache.has(cacheKey)) {
-		return actorEmailCache.get(cacheKey) ?? undefined;
+	if (actorProfileCache.has(cacheKey)) {
+		const cached = actorProfileCache.get(cacheKey);
+		if (!cached) return { email: fallbackEmail };
+		return {
+			email: cached.email ?? fallbackEmail,
+			profileAvatar: cached.profileAvatar,
+		};
 	}
 
 	try {
@@ -94,15 +106,25 @@ const resolveActorEmail = async ({
 				workspaceId: new ObjectId(workspaceId),
 			},
 			{
-				projection: { email: 1 },
+				projection: { email: 1, profileAvatar: 1 },
 			},
 		);
 
-		const resolvedEmail = typeof user?.email === 'string' && user.email.trim() ? user.email.trim() : undefined;
-		actorEmailCache.set(cacheKey, resolvedEmail ?? null);
-		return resolvedEmail;
+		const resolvedEmail = typeof user?.email === 'string' && user.email.trim()
+			? user.email.trim()
+			: fallbackEmail;
+		const resolvedProfileAvatar = typeof user?.profileAvatar === 'string' && user.profileAvatar.trim()
+			? user.profileAvatar.trim()
+			: undefined;
+		const profile: ResolvedActorProfile = {
+			email: resolvedEmail,
+			profileAvatar: resolvedProfileAvatar,
+		};
+
+		actorProfileCache.set(cacheKey, profile);
+		return profile;
 	} catch {
-		return undefined;
+		return { email: fallbackEmail };
 	}
 };
 
@@ -196,12 +218,12 @@ export const recordAuditEvent = async (input: RecordAuditEventInput) => {
 		const groups = parseGroups(input.auth['cognito:groups']);
 		const actorRole: 'admin' | 'user' = groups.includes('admin') ? 'admin' : 'user';
 		const usernameClaim = getClaimString(input.auth, ['username', 'cognito:username']);
-		const actorEmail = await resolveActorEmail({
+		const actorProfile = await resolveActorProfile({
 			db,
 			workspaceId: input.workspaceId,
 			auth: input.auth,
 		});
-		const actorName = getClaimString(input.auth, ['name']) ?? actorEmail ?? usernameClaim ?? 'Unknown User';
+		const actorName = getClaimString(input.auth, ['name']) ?? actorProfile.email ?? usernameClaim ?? 'Unknown User';
 
 		const computedChanges = input.changes ?? buildChangesFromPaths({
 			before: input.before,
@@ -214,7 +236,6 @@ export const recordAuditEvent = async (input: RecordAuditEventInput) => {
 			action: input.action,
 			changes: computedChanges,
 			meta: input.meta,
-			actorName,
 		});
 
 		const payload: AuditLogV2 = {
@@ -228,7 +249,8 @@ export const recordAuditEvent = async (input: RecordAuditEventInput) => {
 			actor: {
 				userId: input.auth.sub,
 				name: actorName,
-				email: actorEmail,
+				email: actorProfile.email,
+				profileAvatar: actorProfile.profileAvatar,
 				role: actorRole,
 			},
 			where: input.where,

--- a/src/utils/dashboardActivityStats.ts
+++ b/src/utils/dashboardActivityStats.ts
@@ -108,7 +108,19 @@ async function aggregateProductActivity(
 						'update',
 					],
 				},
-				productObjectId: { $toObjectId: '$scope.id' },
+				productObjectId: {
+					$convert: {
+						input: '$scope.id',
+						to: 'objectId',
+						onError: null,
+						onNull: null,
+					},
+				},
+			},
+		},
+		{
+			$match: {
+				productObjectId: { $ne: null },
 			},
 		},
 		{
@@ -251,7 +263,19 @@ async function aggregateSourceFileActivity(
 				activityType: {
 					$cond: [{ $eq: ['$action', 'create'] }, 'create', 'update'],
 				},
-				fileObjectId: { $toObjectId: '$entity.id' },
+				fileObjectId: {
+					$convert: {
+						input: '$entity.id',
+						to: 'objectId',
+						onError: null,
+						onNull: null,
+					},
+				},
+			},
+		},
+		{
+			$match: {
+				fileObjectId: { $ne: null },
 			},
 		},
 		{

--- a/src/utils/dashboardActivityStats.ts
+++ b/src/utils/dashboardActivityStats.ts
@@ -1,0 +1,385 @@
+/* eslint-disable require-jsdoc */
+import { Db, ObjectId } from 'mongodb';
+import { AUDIT_LOG_V2_COLLECTION } from '../models/auditLogV2';
+
+export const DASHBOARD_ACTIVITY_WINDOW_DAYS = 30;
+
+const PRODUCT_CREATION_EVENT_KEYS = ['product.created', 'product.version.created'] as const;
+
+export type ActivityBreakdown = {
+	created_only: number;
+	updated_only: number;
+	both: number;
+	total: number;
+};
+
+export type ArchiveActivityBreakdown = {
+	departments: number;
+	projects: number;
+	products: number;
+	total: number;
+};
+
+export type DashboardActivityStats = {
+	window_days: number;
+	departments: ActivityBreakdown;
+	projects: ActivityBreakdown;
+	products: ActivityBreakdown;
+	source_files: ActivityBreakdown;
+	archives: ArchiveActivityBreakdown;
+};
+
+function emptyBreakdown(): ActivityBreakdown {
+	return { created_only: 0, updated_only: 0, both: 0, total: 0 };
+}
+
+function emptyArchiveBreakdown(): ArchiveActivityBreakdown {
+	return { departments: 0, projects: 0, products: 0, total: 0 };
+}
+
+function breakdownFromFacetSets(
+	createdIds: unknown[] | undefined,
+	updatedIds: unknown[] | undefined,
+): ActivityBreakdown {
+	const createdSet = new Set((createdIds ?? []).map(String));
+	const updatedSet = new Set((updatedIds ?? []).map(String));
+
+	let createdOnly = 0;
+	let both = 0;
+
+	for (const id of createdSet) {
+		if (updatedSet.has(id)) {
+			both += 1;
+		} else {
+			createdOnly += 1;
+		}
+	}
+
+	let updatedOnly = 0;
+	for (const id of updatedSet) {
+		if (!createdSet.has(id)) {
+			updatedOnly += 1;
+		}
+	}
+
+	return {
+		created_only: createdOnly,
+		updated_only: updatedOnly,
+		both,
+		total: createdOnly + updatedOnly + both,
+	};
+}
+
+export function getActivityWindowStart(days = DASHBOARD_ACTIVITY_WINDOW_DAYS): Date {
+	const since = new Date();
+	since.setDate(since.getDate() - days);
+	return since;
+}
+
+async function aggregateProductActivity(
+	db: Db,
+	workspaceId: ObjectId,
+	since: Date,
+): Promise<Pick<DashboardActivityStats, 'departments' | 'projects' | 'products'>> {
+	const results = await db.collection(AUDIT_LOG_V2_COLLECTION).aggregate([
+		{
+			$match: {
+				workspaceId,
+				occurredAt: { $gte: since },
+				'scope.type': 'product',
+				$or: [
+					{ action: 'update' },
+					{ action: 'create' },
+					{ eventKey: { $in: PRODUCT_CREATION_EVENT_KEYS } },
+				],
+			},
+		},
+		{
+			$addFields: {
+				activityType: {
+					$cond: [
+						{
+							$or: [
+								{ $eq: ['$action', 'create'] },
+								{ $in: ['$eventKey', PRODUCT_CREATION_EVENT_KEYS] },
+							],
+						},
+						'create',
+						'update',
+					],
+				},
+				productObjectId: { $toObjectId: '$scope.id' },
+			},
+		},
+		{
+			$group: {
+				_id: {
+					productId: '$productObjectId',
+					activityType: '$activityType',
+				},
+			},
+		},
+		{
+			$lookup: {
+				from: 'products',
+				localField: '_id.productId',
+				foreignField: '_id',
+				as: 'product',
+			},
+		},
+		{ $unwind: '$product' },
+		{
+			$match: {
+				'product.workspace_id': workspaceId,
+			},
+		},
+		{
+			$addFields: {
+				isActiveProduct: { $ne: ['$product.status', 'archived'] },
+			},
+		},
+		{
+			$lookup: {
+				from: 'departments',
+				localField: 'product.department_id',
+				foreignField: '_id',
+				as: 'department',
+			},
+		},
+		{
+			$lookup: {
+				from: 'projects',
+				localField: 'product.project_id',
+				foreignField: '_id',
+				as: 'project',
+			},
+		},
+		{
+			$addFields: {
+				departmentId: {
+					$cond: [
+						{
+							$and: [
+								'$isActiveProduct',
+								{ $gt: [{ $size: '$department' }, 0] },
+								{ $eq: [{ $arrayElemAt: ['$department.isArchived', 0] }, false] },
+							],
+						},
+						{ $arrayElemAt: ['$department._id', 0] },
+						null,
+					],
+				},
+				projectId: {
+					$cond: [
+						{
+							$and: [
+								'$isActiveProduct',
+								{ $gt: [{ $size: '$project' }, 0] },
+								{ $eq: [{ $arrayElemAt: ['$project.isArchived', 0] }, false] },
+							],
+						},
+						{ $arrayElemAt: ['$project._id', 0] },
+						null,
+					],
+				},
+			},
+		},
+		{
+			$facet: {
+				productsCreated: [
+					{ $match: { '_id.activityType': 'create' } },
+					{ $group: { _id: null, ids: { $addToSet: '$_id.productId' } } },
+				],
+				productsUpdated: [
+					{ $match: { '_id.activityType': 'update' } },
+					{ $group: { _id: null, ids: { $addToSet: '$_id.productId' } } },
+				],
+				departmentsCreated: [
+					{ $match: { '_id.activityType': 'create', departmentId: { $ne: null } } },
+					{ $group: { _id: null, ids: { $addToSet: '$departmentId' } } },
+				],
+				departmentsUpdated: [
+					{ $match: { '_id.activityType': 'update', departmentId: { $ne: null } } },
+					{ $group: { _id: null, ids: { $addToSet: '$departmentId' } } },
+				],
+				projectsCreated: [
+					{ $match: { '_id.activityType': 'create', projectId: { $ne: null } } },
+					{ $group: { _id: null, ids: { $addToSet: '$projectId' } } },
+				],
+				projectsUpdated: [
+					{ $match: { '_id.activityType': 'update', projectId: { $ne: null } } },
+					{ $group: { _id: null, ids: { $addToSet: '$projectId' } } },
+				],
+			},
+		},
+	]).toArray();
+
+	const facet = results[0] ?? {};
+
+	return {
+		products: breakdownFromFacetSets(
+			facet.productsCreated?.[0]?.ids,
+			facet.productsUpdated?.[0]?.ids,
+		),
+		departments: breakdownFromFacetSets(
+			facet.departmentsCreated?.[0]?.ids,
+			facet.departmentsUpdated?.[0]?.ids,
+		),
+		projects: breakdownFromFacetSets(
+			facet.projectsCreated?.[0]?.ids,
+			facet.projectsUpdated?.[0]?.ids,
+		),
+	};
+}
+
+async function aggregateSourceFileActivity(
+	db: Db,
+	workspaceId: ObjectId,
+	since: Date,
+): Promise<ActivityBreakdown> {
+	const results = await db.collection(AUDIT_LOG_V2_COLLECTION).aggregate([
+		{
+			$match: {
+				workspaceId,
+				occurredAt: { $gte: since },
+				'entity.type': 'source_file',
+				action: { $in: ['create', 'update'] },
+			},
+		},
+		{
+			$addFields: {
+				activityType: {
+					$cond: [{ $eq: ['$action', 'create'] }, 'create', 'update'],
+				},
+				fileObjectId: { $toObjectId: '$entity.id' },
+			},
+		},
+		{
+			$group: {
+				_id: {
+					fileId: '$fileObjectId',
+					activityType: '$activityType',
+				},
+			},
+		},
+		{
+			$lookup: {
+				from: 'sourceFiles',
+				localField: '_id.fileId',
+				foreignField: '_id',
+				as: 'sourceFile',
+			},
+		},
+		{ $unwind: '$sourceFile' },
+		{
+			$match: {
+				'sourceFile.workspace_id': workspaceId,
+				'sourceFile.type': 'file',
+			},
+		},
+		{
+			$facet: {
+				created: [
+					{ $match: { '_id.activityType': 'create' } },
+					{ $group: { _id: null, ids: { $addToSet: '$_id.fileId' } } },
+				],
+				updated: [
+					{ $match: { '_id.activityType': 'update' } },
+					{ $group: { _id: null, ids: { $addToSet: '$_id.fileId' } } },
+				],
+			},
+		},
+	]).toArray();
+
+	const facet = results[0] ?? {};
+
+	return breakdownFromFacetSets(
+		facet.created?.[0]?.ids,
+		facet.updated?.[0]?.ids,
+	);
+}
+
+async function aggregateArchiveActivity(
+	db: Db,
+	workspaceId: ObjectId,
+	since: Date,
+): Promise<ArchiveActivityBreakdown> {
+	const results = await db.collection(AUDIT_LOG_V2_COLLECTION).aggregate([
+		{
+			$match: {
+				workspaceId,
+				occurredAt: { $gte: since },
+				action: 'archive',
+				'scope.type': { $in: ['department', 'project', 'product'] },
+			},
+		},
+		{
+			$group: {
+				_id: {
+					type: '$scope.type',
+					id: '$scope.id',
+				},
+			},
+		},
+		{
+			$facet: {
+				departments: [
+					{ $match: { '_id.type': 'department' } },
+					{ $count: 'count' },
+				],
+				projects: [
+					{ $match: { '_id.type': 'project' } },
+					{ $count: 'count' },
+				],
+				products: [
+					{ $match: { '_id.type': 'product' } },
+					{ $count: 'count' },
+				],
+			},
+		},
+	]).toArray();
+
+	const facet = results[0] ?? {};
+	const departments = facet.departments?.[0]?.count ?? 0;
+	const projects = facet.projects?.[0]?.count ?? 0;
+	const products = facet.products?.[0]?.count ?? 0;
+
+	return {
+		departments,
+		projects,
+		products,
+		total: departments + projects + products,
+	};
+}
+
+export async function getDashboardActivityStats(
+	db: Db,
+	workspaceId: ObjectId,
+	since = getActivityWindowStart(),
+): Promise<DashboardActivityStats> {
+	const [productActivity, sourceFileActivity, archiveActivity] = await Promise.all([
+		aggregateProductActivity(db, workspaceId, since),
+		aggregateSourceFileActivity(db, workspaceId, since),
+		aggregateArchiveActivity(db, workspaceId, since),
+	]);
+
+	return {
+		window_days: DASHBOARD_ACTIVITY_WINDOW_DAYS,
+		departments: productActivity.departments,
+		projects: productActivity.projects,
+		products: productActivity.products,
+		source_files: sourceFileActivity,
+		archives: archiveActivity,
+	};
+}
+
+export function emptyDashboardActivityStats(): DashboardActivityStats {
+	return {
+		window_days: DASHBOARD_ACTIVITY_WINDOW_DAYS,
+		departments: emptyBreakdown(),
+		projects: emptyBreakdown(),
+		products: emptyBreakdown(),
+		source_files: emptyBreakdown(),
+		archives: emptyArchiveBreakdown(),
+	};
+}

--- a/src/utils/sourceFilesAudit.ts
+++ b/src/utils/sourceFilesAudit.ts
@@ -1,0 +1,19 @@
+import type { Db, ObjectId } from 'mongodb';
+import type { Product } from '../models/product';
+import { tenantObjectIdFilter } from './tenantContext';
+
+export const resolveWorkspaceProductName = async (
+	db: Db,
+	productId: ObjectId | null | undefined,
+	workspaceId: ObjectId,
+): Promise<string | null> => {
+	if (!productId) return null;
+
+	const product = await db.collection<Product>('products').findOne(
+		tenantObjectIdFilter(productId, workspaceId),
+		{ projection: { product_name: 1 } },
+	);
+
+	const name = product?.product_name;
+	return typeof name === 'string' && name.trim() ? name.trim() : null;
+};

--- a/src/utils/sourceFolderFileCounts.ts
+++ b/src/utils/sourceFolderFileCounts.ts
@@ -1,0 +1,52 @@
+import { Collection, ObjectId } from 'mongodb';
+import { SourceFile } from '../models/sourceFiles';
+
+type FolderWithId = {
+	_id: ObjectId;
+};
+
+/**
+ * Attaches direct child file counts to source file folders via one aggregation.
+ *
+ * @param {Collection<SourceFile>} collection Source files collection.
+ * @param {Array<{ _id: ObjectId }>} folders Folders to enrich.
+ * @param {ObjectId} workspaceId Workspace scope for the count query.
+ * @return {Promise<Array>} Folders with fileCount (default 0).
+ */
+export async function attachSourceFolderFileCounts<T extends FolderWithId>(
+	collection: Collection<SourceFile>,
+	folders: T[],
+	workspaceId: ObjectId,
+): Promise<Array<T & { fileCount: number }>> {
+	if (folders.length === 0) return [];
+
+	const folderIds = folders.map((folder) => folder._id);
+
+	const countResults = await collection
+		.aggregate<{ _id: ObjectId; fileCount: number }>([
+			{
+				$match: {
+					workspace_id: workspaceId,
+					type: 'file',
+					parentId: { $in: folderIds },
+				},
+			},
+			{
+				$group: {
+					_id: '$parentId',
+					fileCount: { $sum: 1 },
+				},
+			},
+		])
+		.toArray();
+
+	const countByFolderId = new Map<string, number>();
+	for (const result of countResults) {
+		countByFolderId.set(result._id.toString(), result.fileCount);
+	}
+
+	return folders.map((folder) => ({
+		...folder,
+		fileCount: countByFolderId.get(folder._id.toString()) ?? 0,
+	}));
+}

--- a/template.yaml
+++ b/template.yaml
@@ -1163,6 +1163,23 @@ Resources:
         <<: *EsbuildProps
         EntryPoints: [controllers/dashboard/getDashboardStats.ts]
 
+  GetDashboardActivityStatsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/dashboard/getDashboardActivityStats.lambdaHandler
+      Events:
+        GetDashboardActivityStats:
+          Type: Api
+          Properties:
+            Path: /dashboard/activity
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/dashboard/getDashboardActivityStats.ts]
+
   # ──────────────────────────────────────────────────────────────────────────
   # SOURCE FILES
   # ──────────────────────────────────────────────────────────────────────────

--- a/template.yaml
+++ b/template.yaml
@@ -1074,6 +1074,23 @@ Resources:
         <<: *EsbuildProps
         EntryPoints: [controllers/bookmarks/deleteProductFromBookmark.ts]
 
+  GetAllBookmarkedProductsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: controllers/bookmarks/getAllBookmarkedProducts.lambdaHandler
+      Events:
+        GetAllBookmarkedProducts:
+          Type: Api
+          Properties:
+            Path: /bookmarks/products/all
+            Method: get
+    Metadata:
+      <<: *EsbuildBase
+      BuildProperties:
+        <<: *EsbuildProps
+        EntryPoints: [controllers/bookmarks/getAllBookmarkedProducts.ts]
+
   GetProductsFromBookmarkFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
- Add dashboard activity stats endpoint for the revamped dashboard UI
- Include archived department, project, and product counts in dashboard stats
- Add get-all bookmarked products endpoint for the products bookmarks tab
- Return file counts on bookmark and source file folder listings
- Enrich audit logs with user avatars and source file product linkage details

Closes #157