### PR TITLE
Fix ESLint unused import blocking deploy

### DIFF
--- a/src/controllers/sourceFiles/createSourceFileAndFolder.ts
+++ b/src/controllers/sourceFiles/createSourceFileAndFolder.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ResponseWrapper } from "../../utils/responseWrapper";
 import { logError } from '../../utils/logger';
-import { requireTenantContext, tenantObjectIdFilter } from "../../utils/tenantContext";
+import { requireTenantContext } from "../../utils/tenantContext";
 import { validateAllObjectIds, validateEnum, validateMissingFields } from "../../utils/validationUtils";
 import { getDb } from "../../utils/db";
 import { SourceFile } from "../../models/sourceFiles";


### PR DESCRIPTION
- Remove unused `tenantObjectIdFilter` import from `createSourceFileAndFolder.ts` that caused the deploy workflow lint step to fail
Deploy Backend to AWS failed on develop after merging PR #158:
- Job: Lint Code → Run ESLint
- Error: `'tenantObjectIdFilter' is defined but never used` in `createSourceFileAndFolder.ts`