### PR TITLE
Fix Cognito status after user onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md
+
+This guide provides instructions and conventions for agents operating in the uprevit-backend repository.
+
+- Use npm, not Bun or npx.
+- Use Git Flow for branching.
+- Keep Lambda handlers, API routes, environment variables, and IAM permissions aligned in `template.yaml`.
+- Tenant-scoped endpoints must derive workspace and user identity from `requireTenantContext`; do not trust client-supplied scope IDs.
+- Changes to Cognito-backed membership or lifecycle state must keep Cognito custom attributes and MongoDB user data in sync.
+- Return API responses with `ResponseWrapper` and log unexpected handler errors with `logError`.
+- Read `CONTEXT.md` before changing workspace membership, platform operations, or billing behavior.
+- Production deployments run through GitHub Actions; do not use `sam deploy --guided`.
+- To test the backend locally we have written two commands which are npm run dev and npm run dev:infra. To sync the changes to dev environment in AWS and then we hit that environment endpoint on frontend locally and we use this same envirnment and api endpoint for the develop branch deployed version which is dev-app.uprevit.com and dev.uprevit.com

--- a/src/controllers/onboarding/onboardAndUpdateInvitedUser.ts
+++ b/src/controllers/onboarding/onboardAndUpdateInvitedUser.ts
@@ -6,9 +6,13 @@ import { logError } from '../../utils/logger';
 import { validateMissingFields } from "../../utils/validationUtils";
 import { updateAuditLog } from "../../utils/auditLog";
 import { AuditLogAction } from "../../models/auditLog";
+import type { User } from '../../models/user';
 import { normalizePersistedAssetReference } from '../../utils/s3-storage';
 import { assertSeatActivationAllowed, verifySeatLimitAfterActivation } from '../../utils/billing/enforcement';
 import { recordCommittedUploadIfNew } from '../../utils/billing/uploadCommit';
+import { AdminUpdateUserAttributesCommand, CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
+
+const cognito = new CognitoIdentityProviderClient();
 
 /**
  * @param {APIGatewayProxyEvent} event
@@ -32,17 +36,18 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
 		const db = await getDb();
 
-		const existingUser = await db.collection('users').findOne({
+		const existingUser = await db.collection<User>('users').findOne({
 			cognitoSub: context.cognitoSub,
 			workspaceId: context.workspaceId,
 		});
+		if (!existingUser) return ResponseWrapper.notFound("User not found or no changes were made.");
 
 		const normalizedAvatar = normalizePersistedAssetReference(
 			input.profileAvatar,
 			typeof existingUser?.profileAvatar === 'string' ? existingUser.profileAvatar : '',
 		);
 
-		const previousStatus = existingUser?.status ?? 'invited';
+		const previousStatus = existingUser.status;
 		const activatingUser = previousStatus !== 'active';
 
 		if (activatingUser) {
@@ -75,6 +80,20 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 					{ $set: { status: previousStatus } },
 				);
 				return ResponseWrapper.forbidden(postActivationCheck.reason);
+			}
+
+			try {
+				await cognito.send(new AdminUpdateUserAttributesCommand({
+					UserPoolId: process.env.USER_POOL_ID!,
+					Username: existingUser.email,
+					UserAttributes: [{ Name: 'custom:status', Value: 'active' }],
+				}));
+			} catch (error) {
+				await db.collection('users').updateOne(
+					{ cognitoSub: context.cognitoSub, workspaceId: context.workspaceId },
+					{ $set: { status: previousStatus } },
+				);
+				throw error;
 			}
 		}
         

--- a/template.yaml
+++ b/template.yaml
@@ -332,6 +332,12 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: controllers/onboarding/onboardAndUpdateInvitedUser.handler
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - cognito-idp:AdminUpdateUserAttributes
+              Resource: !Sub "arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${UserPoolId}"
       Events:
         OnboardAndUpdateInvitedUser:
           Type: Api


### PR DESCRIPTION
* Update Cognito custom status when an invited user completes onboarding.
* Restore MongoDB status if the Cognito update fails.
* Add the required Lambda permission and backend agent instructions.
* Closes SAT-Software/uprevit-backend#165.